### PR TITLE
Make the action working for monorepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,19 +16,23 @@ Total Coverage: <b>99.39%</b>
 ## Inputs
 
 ##### `github-token` (**Required**)
+
 Github token used for posting the comment. To use the key provided by the GitHub
 action runner, use `${{ secrets.GITHUB_TOKEN }}`.
 
 ##### `lcov-file` (**Optional**)
+
 The location of the lcov file to read the coverage report from. Defaults to
 `./coverage/lcov.info`.
 
 ##### `lcov-base` (**Optional**)
+
 The location of the lcov file resulting from running the tests in the base
 branch. When this is set a diff of the coverage percentages is shown.
 
 ##### `monorepo-base` (**Optional**)
-The location of the monrepo `packages/` path
+
+The location of the monrepo `packages` path
 
 ## Example usage
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ The location of the lcov file to read the coverage report from. Defaults to
 The location of the lcov file resulting from running the tests in the base
 branch. When this is set a diff of the coverage percentages is shown.
 
+##### `monorepo-base` (**Optional**)
+The location of the monrepo `packages/` path
+
 ## Example usage
 
 ```yml

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 name: Code Coverage Report
-description: Comments a pull request with the code coverage
-author: Romeo Van Snick
+description: Comments a pull request with the code coverage for mono repo and single repo
+author: 'Eesh Tyagi, Marina, John Hannagan'
 branding:
   icon: check-square
   color: green
@@ -8,11 +8,14 @@ inputs:
   github-token:
     description: Github token
     required: true
+  monorepo-base-path:
+    description: Location of your monorepo `packages` parent folder. If this is specified then we don't need `lcov-file` and `lcov-base` params
+    required: false
   lcov-file:
-    description: The location of the lcov.info file
+    description: The location of the lcov.info file. Applicable for single repo setup.
     required: false
   lcov-base:
-    description: The location of the lcov file for the base branch
+    description: The location of the lcov file for the base branch. Applicable for single repo setup.
     required: false
 runs:
   using: node12

--- a/dist/main.js
+++ b/dist/main.js
@@ -5922,12 +5922,16 @@ function commentForMonorepo(
 		const plus = pdiff > 0 ? "+" : "";
 		const arrow = pdiff === 0 ? "" : pdiff < 0 ? "▾" : "▴";
 
+		const pdiffHtml = baseLcov
+			? th(arrow, " ", plus, pdiff.toFixed(2), "%")
+			: "";
+
 		return `${table(
 			tbody(
 				tr(
 					th(lcovObj.packageName),
 					th(percentage(lcovObj.lcov).toFixed(2), "%"),
-					th(arrow, " ", plus, pdiff.toFixed(2), "%"),
+					pdiffHtml,
 				),
 			),
 		)} \n\n ${details(

--- a/dist/main.js
+++ b/dist/main.js
@@ -6151,8 +6151,10 @@ async function main() {
 		console.log(`No coverage report found at '${baseFile}', ignoring...`);
 	}
 
-	let lcovArray = getLcovFiles(monorepoBasePath);
-	let lcovBaseArray = getLcovBaseFiles(monorepoBasePath);
+	let lcovArray = monorepoBasePath ? getLcovFiles(monorepoBasePath) : [];
+	let lcovBaseArray = monorepoBasePath
+		? getLcovBaseFiles(monorepoBasePath)
+		: [];
 
 	const lcovArrayForMonorepo = [];
 	const lcovBaseArrayForMonorepo = [];

--- a/dist/main.js
+++ b/dist/main.js
@@ -22741,11 +22741,11 @@ function parse$2(data) {
 		lib$1(data, function(err, res) {
 			if (err) {
 				reject(err);
-				return
+				return;
 			}
 			resolve(res);
 		});
-	})
+	});
 }
 
 // Get the total coverage percentage from the lcov data.
@@ -22757,7 +22757,7 @@ function percentage(lcov) {
 		found += entry.lines.found;
 	}
 
-	return (hit / found) * 100
+	return (hit / found) * 100;
 }
 
 function tag(name) {
@@ -22771,8 +22771,8 @@ function tag(name) {
 
 		const c = typeof children[0] === "string" ? children : children.slice(1);
 
-		return `<${name}${props}>${c.join("")}</${name}>`
-	}
+		return `<${name}${props}>${c.join("")}</${name}>`;
+	};
 }
 
 const details = tag("details");
@@ -22786,7 +22786,7 @@ const tbody = tag("tbody");
 const a = tag("a");
 
 const fragment = function(...children) {
-	return children.join("")
+	return children.join("");
 };
 
 // Tabulate the lcov data in a HTML table.
@@ -22818,15 +22818,15 @@ function tabulate(lcov, options) {
 			[],
 		);
 
-	return table(tbody(head, ...rows))
+	return table(tbody(head, ...rows));
 }
 
 function toFolder(path) {
 	if (path === "") {
-		return ""
+		return "";
 	}
 
-	return tr(td({ colspan: 5 }, b(path)))
+	return tr(td({ colspan: 5 }, b(path)));
 }
 
 function toRow(file, indent, options) {
@@ -22836,7 +22836,7 @@ function toRow(file, indent, options) {
 		td(percentage$1(file.functions)),
 		td(percentage$1(file.lines)),
 		td(uncovered(file, options)),
-	)
+	);
 }
 
 function filename(file, indent, options) {
@@ -22845,12 +22845,12 @@ function filename(file, indent, options) {
 	const parts = relative.split("/");
 	const last = parts[parts.length - 1];
 	const space = indent ? "&nbsp; &nbsp;" : "";
-	return fragment(space, a({ href }, last))
+	return fragment(space, a({ href }, last));
 }
 
 function percentage$1(item) {
 	if (!item) {
-		return "N/A"
+		return "N/A";
 	}
 
 	const value = item.found === 0 ? 100 : (item.hit / item.found) * 100;
@@ -22858,7 +22858,7 @@ function percentage$1(item) {
 
 	const tag = value === 100 ? fragment : b;
 
-	return tag(`${rounded}%`)
+	return tag(`${rounded}%`);
 }
 
 function uncovered(file, options) {
@@ -22876,45 +22876,44 @@ function uncovered(file, options) {
 		.map(function(line) {
 			const relative = file.file.replace(options.prefix, "");
 			const href = `https://github.com/${options.repository}/blob/${options.commit}/${relative}#L${line}`;
-			return a({ href }, line)
+			return a({ href }, line);
 		})
-		.join(", ")
+		.join(", ");
 }
 
-function comment (lcov, options) {
+function comment(lcov, options) {
 	return fragment(
 		`Coverage after merging ${b(options.head)} into ${b(options.base)}`,
 		table(tbody(tr(th(percentage(lcov).toFixed(2), "%")))),
 		"\n\n",
 		details(summary("Coverage Report"), tabulate(lcov, options)),
-	)
+	);
 }
 
 function diff(lcov, before, options) {
 	if (!before) {
-		return comment(lcov, options)
+		return comment(lcov, options);
 	}
 
 	const pbefore = percentage(before);
 	const pafter = percentage(lcov);
 	const pdiff = pafter - pbefore;
 	const plus = pdiff > 0 ? "+" : "";
-	const arrow =
-		pdiff === 0
-			? ""
-			: pdiff < 0
-				? "▾"
-				: "▴";
+	const arrow = pdiff === 0 ? "" : pdiff < 0 ? "▾" : "▴";
 
 	return fragment(
 		`Coverage after merging ${b(options.head)} into ${b(options.base)}`,
-		table(tbody(tr(
-			th(pafter.toFixed(2), "%"),
-			th(arrow, " ", plus, pdiff.toFixed(2), "%"),
-		))),
+		table(
+			tbody(
+				tr(
+					th(pafter.toFixed(2), "%"),
+					th(arrow, " ", plus, pdiff.toFixed(2), "%"),
+				),
+			),
+		),
 		"\n\n",
 		details(summary("Coverage Report"), tabulate(lcov, options)),
-	)
+	);
 }
 
 async function main$1() {
@@ -22925,7 +22924,8 @@ async function main$1() {
 	// Add base path for monorepo
 	const monorepoBasePath = core$1.getInput("monorepo-base-path") || "./packages";
 
-	for await (const dirent of monorepoBasePath) {
+	const dir = await fs.promises.promises.opendir(monorepoBasePath);
+	for await (const dirent of dir) {
     console.log(dirent.name);
   }
 
@@ -22933,10 +22933,11 @@ async function main$1() {
 	const raw = await fs.promises.readFile(lcovFile, "utf-8").catch(err => null);
 	if (!raw) {
 		console.log(`No coverage report found at '${lcovFile}', exiting...`);
-		return
+		return;
 	}
 
-	const baseRaw = baseFile && await fs.promises.readFile(baseFile, "utf-8").catch(err => null);
+	const baseRaw =
+		baseFile && (await fs.promises.readFile(baseFile, "utf-8").catch(err => null));
 	if (baseFile && !baseRaw) {
 		console.log(`No coverage report found at '${baseFile}', ignoring...`);
 	}
@@ -22950,7 +22951,7 @@ async function main$1() {
 	};
 
 	const lcov = await parse$2(raw);
-	const baselcov = baseRaw && await parse$2(baseRaw);
+	const baselcov = baseRaw && (await parse$2(baseRaw));
 	const body = diff(lcov, baselcov, options);
 
 	await new github_2(token).issues.createComment({

--- a/dist/main.js
+++ b/dist/main.js
@@ -5763,43 +5763,43 @@ lib$1.source = source;
 
 // Parse lcov string into lcov data
 function parse$1(data) {
-	return new Promise(function(resolve, reject) {
-		lib$1(data, function(err, res) {
-			if (err) {
-				reject(err);
-				return;
-			}
-			resolve(res);
-		});
-	});
+    return new Promise(function(resolve, reject) {
+        lib$1(data, function(err, res) {
+            if (err) {
+                reject(err);
+                return;
+            }
+            resolve(res);
+        });
+    });
 }
 
 // Get the total coverage percentage from the lcov data.
 function percentage(lcov) {
-	let hit = 0;
-	let found = 0;
-	for (const entry of lcov) {
-		hit += entry.lines.hit;
-		found += entry.lines.found;
-	}
+    let hit = 0;
+    let found = 0;
+    for (const entry of lcov) {
+        hit += entry.lines.hit;
+        found += entry.lines.found;
+    }
 
-	return (hit / found) * 100;
+    return (hit / found) * 100;
 }
 
 function tag(name) {
-	return function(...children) {
-		const props =
-			typeof children[0] === "object"
-				? Object.keys(children[0])
-						.map(key => ` ${key}='${children[0][key]}'`)
-						.join("")
-				: "";
+    return function(...children) {
+        const props =
+            typeof children[0] === "object"
+                ? Object.keys(children[0])
+                      .map(key => ` ${key}='${children[0][key]}'`)
+                      .join("")
+                : "";
 
-		const c =
-			typeof children[0] === "string" ? children : children.slice(1);
+        const c =
+            typeof children[0] === "string" ? children : children.slice(1);
 
-		return `<${name}${props}>${c.join("")}</${name}>`;
-	};
+        return `<${name}${props}>${c.join("")}</${name}>`;
+    };
 }
 
 const details = tag("details");
@@ -5813,99 +5813,99 @@ const tbody = tag("tbody");
 const a = tag("a");
 
 const fragment = function(...children) {
-	return children.join("");
+    return children.join("");
 };
 
 // Tabulate the lcov data in a HTML table.
 function tabulate(lcov, options) {
-	const head = tr(
-		th("File"),
-		th("Branches"),
-		th("Funcs"),
-		th("Lines"),
-		th("Uncovered Lines"),
-	);
+    const head = tr(
+        th("File"),
+        th("Branches"),
+        th("Funcs"),
+        th("Lines"),
+        th("Uncovered Lines"),
+    );
 
-	const folders = {};
-	for (const file of lcov) {
-		const parts = file.file.replace(options.prefix, "").split("/");
-		const folder = parts.slice(0, -1).join("/");
-		folders[folder] = folders[folder] || [];
-		folders[folder].push(file);
-	}
+    const folders = {};
+    for (const file of lcov) {
+        const parts = file.file.replace(options.prefix, "").split("/");
+        const folder = parts.slice(0, -1).join("/");
+        folders[folder] = folders[folder] || [];
+        folders[folder].push(file);
+    }
 
-	const rows = Object.keys(folders)
-		.sort()
-		.reduce(
-			(acc, key) => [
-				...acc,
-				toFolder(key),
-				...folders[key].map(file => toRow(file, key !== "", options)),
-			],
-			[],
-		);
+    const rows = Object.keys(folders)
+        .sort()
+        .reduce(
+            (acc, key) => [
+                ...acc,
+                toFolder(key),
+                ...folders[key].map(file => toRow(file, key !== "", options)),
+            ],
+            [],
+        );
 
-	return table(tbody(head, ...rows));
+    return table(tbody(head, ...rows));
 }
 
 function toFolder(path) {
-	if (path === "") {
-		return "";
-	}
+    if (path === "") {
+        return "";
+    }
 
-	return tr(td({ colspan: 5 }, b(path)));
+    return tr(td({ colspan: 5 }, b(path)));
 }
 
 function toRow(file, indent, options) {
-	return tr(
-		td(filename(file, indent, options)),
-		td(percentage$1(file.branches)),
-		td(percentage$1(file.functions)),
-		td(percentage$1(file.lines)),
-		td(uncovered(file, options)),
-	);
+    return tr(
+        td(filename(file, indent, options)),
+        td(percentage$1(file.branches)),
+        td(percentage$1(file.functions)),
+        td(percentage$1(file.lines)),
+        td(uncovered(file, options)),
+    );
 }
 
 function filename(file, indent, options) {
-	const relative = file.file.replace(options.prefix, "");
-	const href = `https://github.com/${options.repository}/blob/${options.commit}/${relative}`;
-	const parts = relative.split("/");
-	const last = parts[parts.length - 1];
-	const space = indent ? "&nbsp; &nbsp;" : "";
-	return fragment(space, a({ href }, last));
+    const relative = file.file.replace(options.prefix, "");
+    const href = `https://github.com/${options.repository}/blob/${options.commit}/${relative}`;
+    const parts = relative.split("/");
+    const last = parts[parts.length - 1];
+    const space = indent ? "&nbsp; &nbsp;" : "";
+    return fragment(space, a({ href }, last));
 }
 
 function percentage$1(item) {
-	if (!item) {
-		return "N/A";
-	}
+    if (!item) {
+        return "N/A";
+    }
 
-	const value = item.found === 0 ? 100 : (item.hit / item.found) * 100;
-	const rounded = value.toFixed(2).replace(/\.0*$/, "");
+    const value = item.found === 0 ? 100 : (item.hit / item.found) * 100;
+    const rounded = value.toFixed(2).replace(/\.0*$/, "");
 
-	const tag = value === 100 ? fragment : b;
+    const tag = value === 100 ? fragment : b;
 
-	return tag(`${rounded}%`);
+    return tag(`${rounded}%`);
 }
 
 function uncovered(file, options) {
-	const branches = (file.branches ? file.branches.details : [])
-		.filter(branch => branch.taken === 0)
-		.map(branch => branch.line);
+    const branches = (file.branches ? file.branches.details : [])
+        .filter(branch => branch.taken === 0)
+        .map(branch => branch.line);
 
-	const lines = (file.lines ? file.lines.details : [])
-		.filter(line => line.hit === 0)
-		.map(line => line.line);
+    const lines = (file.lines ? file.lines.details : [])
+        .filter(line => line.hit === 0)
+        .map(line => line.line);
 
-	const all = [...branches, ...lines].sort();
+    const all = [...branches, ...lines].sort();
 
-	return all
-		.map(function(line) {
-			const relative = file.file.replace(options.prefix, "");
-			const href = `https://github.com/${options.repository}/blob/${options.commit}/${relative}#L${line}`;
-			return a({ href }, line);
-		})
-		.join(", ");
+    return all
+        .map(function(line) {
+            const relative = file.file.replace(options.prefix, "");
+            const href = `https://github.com/${options.repository}/blob/${options.commit}/${relative}#L${line}`;
+            return a({ href }, line);
+        })
+        .join(", ");
 }
 
 /**
@@ -5915,42 +5915,42 @@ function uncovered(file, options) {
  * @param {*} options
  */
 function commentForMonorepo(
-	lcovArrayForMonorepo,
-	lcovBaseArrayForMonorepo,
-	options,
+    lcovArrayForMonorepo,
+    lcovBaseArrayForMonorepo,
+    options,
 ) {
-	const html = lcovArrayForMonorepo.map(lcovObj => {
-		const baseLcov = lcovBaseArrayForMonorepo.find(
-			el => el.packageName === lcovObj.packageName,
-		);
-		const pbefore = baseLcov ? percentage(baseLcov) : 0;
-		const pafter = baseLcov ? percentage(lcovObj.lcov) : 0;
-		const pdiff = pafter - pbefore;
-		const plus = pdiff > 0 ? "+" : "";
-		const arrow = pdiff === 0 ? "" : pdiff < 0 ? "▾" : "▴";
+    const html = lcovArrayForMonorepo.map(lcovObj => {
+        const baseLcov = lcovBaseArrayForMonorepo.find(
+            el => el.packageName === lcovObj.packageName,
+        );
+        const pbefore = baseLcov ? percentage(baseLcov) : 0;
+        const pafter = baseLcov ? percentage(lcovObj.lcov) : 0;
+        const pdiff = pafter - pbefore;
+        const plus = pdiff > 0 ? "+" : "";
+        const arrow = pdiff === 0 ? "" : pdiff < 0 ? "▾" : "▴";
 
-		const pdiffHtml = baseLcov
-			? th(arrow, " ", plus, pdiff.toFixed(2), "%")
-			: "";
+        const pdiffHtml = baseLcov
+            ? th(arrow, " ", plus, pdiff.toFixed(2), "%")
+            : "";
 
-		return `${table(
-			tbody(
-				tr(
-					th(lcovObj.packageName),
-					th(percentage(lcovObj.lcov).toFixed(2), "%"),
-					pdiffHtml,
-				),
-			),
-		)} \n\n ${details(
-			summary("Coverage Report"),
-			tabulate(lcovObj.lcov, options),
-		)} <br/>`;
-	});
+        return `${table(
+            tbody(
+                tr(
+                    th(lcovObj.packageName),
+                    th(percentage(lcovObj.lcov).toFixed(2), "%"),
+                    pdiffHtml,
+                ),
+            ),
+        )} \n\n ${details(
+            summary("Coverage Report"),
+            tabulate(lcovObj.lcov, options),
+        )} <br/>`;
+    });
 
-	return fragment(
-		`Coverage after merging into ${b(options.base)} <p></p>`,
-		html.join(""),
-	);
+    return fragment(
+        `Coverage after merging into ${b(options.base)} <p></p>`,
+        html.join(""),
+    );
 }
 
 /**
@@ -5959,22 +5959,22 @@ function commentForMonorepo(
  * @param {*} options
  */
 function comment(lcov, before, options) {
-	const pbefore = before ? percentage(before) : 0;
-	const pafter = before ? percentage(lcov) : 0;
-	const pdiff = pafter - pbefore;
-	const plus = pdiff > 0 ? "+" : "";
-	const arrow = pdiff === 0 ? "" : pdiff < 0 ? "▾" : "▴";
+    const pbefore = before ? percentage(before) : 0;
+    const pafter = before ? percentage(lcov) : 0;
+    const pdiff = pafter - pbefore;
+    const plus = pdiff > 0 ? "+" : "";
+    const arrow = pdiff === 0 ? "" : pdiff < 0 ? "▾" : "▴";
 
-	const pdiffHtml = before ? th(arrow, " ", plus, pdiff.toFixed(2), "%") : "";
+    const pdiffHtml = before ? th(arrow, " ", plus, pdiff.toFixed(2), "%") : "";
 
-	return fragment(
-		`Coverage after merging ${b(options.head)} into ${b(
-			options.base,
-		)} <p></p>`,
-		table(tbody(tr(th(percentage(lcov).toFixed(2), "%"), pdiffHtml))),
-		"\n\n",
-		details(summary("Coverage Report"), tabulate(lcov, options)),
-	);
+    return fragment(
+        `Coverage after merging ${b(options.head)} into ${b(
+            options.base,
+        )} <p></p>`,
+        table(tbody(tr(th(percentage(lcov).toFixed(2), "%"), pdiffHtml))),
+        "\n\n",
+        details(summary("Coverage Report"), tabulate(lcov, options)),
+    );
 }
 
 /**
@@ -5984,7 +5984,7 @@ function comment(lcov, before, options) {
  * @param {*} options
  */
 function diff(lcov, before, options) {
-	return comment(lcov, before, options);
+    return comment(lcov, before, options);
 }
 
 /**
@@ -5994,15 +5994,15 @@ function diff(lcov, before, options) {
  * @param {*} options
  */
 function diffForMonorepo(
-	lcovArrayForMonorepo,
-	lcovBaseArrayForMonorepo,
-	options,
+    lcovArrayForMonorepo,
+    lcovBaseArrayForMonorepo,
+    options,
 ) {
-	return commentForMonorepo(
-		lcovArrayForMonorepo,
-		lcovBaseArrayForMonorepo,
-		options,
-	);
+    return commentForMonorepo(
+        lcovArrayForMonorepo,
+        lcovBaseArrayForMonorepo,
+        options,
+    );
 }
 
 // Modified from: https://github.com/slavcodev/coverage-monitor-action
@@ -6023,69 +6023,69 @@ const hiddenHeader = `<!-- monorepo-jest-reporter-action -->`;
 const appendHiddenHeaderToComment = body => hiddenHeader + body;
 
 const listComments = async ({ client, context, prNumber, commentHeader }) => {
-	const { data: existingComments } = await client.issues.listComments({
-		...context.repo,
-		issue_number: prNumber,
-	});
+    const { data: existingComments } = await client.issues.listComments({
+        ...context.repo,
+        issue_number: prNumber,
+    });
 
-	return existingComments.filter(({ body }) => body.startsWith(hiddenHeader));
+    return existingComments.filter(({ body }) => body.startsWith(hiddenHeader));
 };
 
 const insertComment = async ({ client, context, prNumber, body }) =>
-	client.issues.createComment({
-		...context.repo,
-		issue_number: prNumber,
-		body: appendHiddenHeaderToComment(body),
-	});
+    client.issues.createComment({
+        ...context.repo,
+        issue_number: prNumber,
+        body: appendHiddenHeaderToComment(body),
+    });
 
 const updateComment = async ({ client, context, body, commentId }) =>
-	client.issues.updateComment({
-		...context.repo,
-		comment_id: commentId,
-		body: appendHiddenHeaderToComment(body),
-	});
+    client.issues.updateComment({
+        ...context.repo,
+        comment_id: commentId,
+        body: appendHiddenHeaderToComment(body),
+    });
 
 const deleteComments = async ({ client, context, comments }) =>
-	Promise.all(
-		comments.map(({ id }) =>
-			client.issues.deleteComment({
-				...context.repo,
-				comment_id: id,
-			}),
-		),
-	);
+    Promise.all(
+        comments.map(({ id }) =>
+            client.issues.deleteComment({
+                ...context.repo,
+                comment_id: id,
+            }),
+        ),
+    );
 
 const upsertComment = async ({ client, context, prNumber, body }) => {
-	const existingComments = await listComments({
-		client,
-		context,
-		prNumber,
-	});
-	const last = existingComments.pop();
+    const existingComments = await listComments({
+        client,
+        context,
+        prNumber,
+    });
+    const last = existingComments.pop();
 
-	await deleteComments({
-		client,
-		context,
-		comments: existingComments,
-	});
+    await deleteComments({
+        client,
+        context,
+        comments: existingComments,
+    });
 
-	return last
-		? updateComment({
-				client,
-				context,
-				body,
-				commentId: last.id,
-		  })
-		: insertComment({
-				client,
-				context,
-				prNumber,
-				body,
-		  });
+    return last
+        ? updateComment({
+              client,
+              context,
+              body,
+              commentId: last.id,
+          })
+        : insertComment({
+              client,
+              context,
+              prNumber,
+              body,
+          });
 };
 
 var github$2 = {
-	upsertComment,
+    upsertComment,
 };
 var github_1$1 = github$2.upsertComment;
 
@@ -6096,19 +6096,19 @@ var github_1$1 = github$2.upsertComment;
  * @return {string[{<package_name>: <path_to_lcov_file>}]} Array with lcove file names with package names as key.
  */
 const getLcovFiles = (dir, filelist = []) => {
-	fs__default.readdirSync(dir).forEach(file => {
-		filelist = fs__default.statSync(path.join(dir, file)).isDirectory()
-			? getLcovFiles(path.join(dir, file), filelist)
-			: filelist
-					.filter(file => {
-						return file.path.includes("lcov.info");
-					})
-					.concat({
-						name: dir.split("/")[1],
-						path: path.join(dir, file),
-					});
-	});
-	return filelist;
+    fs__default.readdirSync(dir).forEach(file => {
+        filelist = fs__default.statSync(path.join(dir, file)).isDirectory()
+            ? getLcovFiles(path.join(dir, file), filelist)
+            : filelist
+                  .filter(file => {
+                      return file.path.includes("lcov.info");
+                  })
+                  .concat({
+                      name: dir.split("/")[1],
+                      path: path.join(dir, file),
+                  });
+    });
+    return filelist;
 };
 
 /**
@@ -6118,102 +6118,102 @@ const getLcovFiles = (dir, filelist = []) => {
  * @return {string[{<package_name>: <path_to_lcov_file>}]} Array with lcove file names with package names as key.
  */
 const getLcovBaseFiles = (dir, filelist = []) => {
-	fs__default.readdirSync(dir).forEach(file => {
-		filelist = fs__default.statSync(path.join(dir, file)).isDirectory()
-			? getLcovBaseFiles(path.join(dir, file), filelist)
-			: filelist
-					.filter(file => {
-						return file.path.includes("lcov-base.info");
-					})
-					.concat({
-						name: dir.split("/")[1],
-						path: path.join(dir, file),
-					});
-	});
-	return filelist;
+    fs__default.readdirSync(dir).forEach(file => {
+        filelist = fs__default.statSync(path.join(dir, file)).isDirectory()
+            ? getLcovBaseFiles(path.join(dir, file), filelist)
+            : filelist
+                  .filter(file => {
+                      return file.path.includes("lcov-base.info");
+                  })
+                  .concat({
+                      name: dir.split("/")[1],
+                      path: path.join(dir, file),
+                  });
+    });
+    return filelist;
 };
 
 async function main() {
-	const { context = {} } = github$1 || {};
+    const { context = {} } = github$1 || {};
 
-	const token = core$1.getInput("github-token");
-	const lcovFile = core$1.getInput("lcov-file") || "./coverage/lcov.info";
-	const baseFile = core$1.getInput("lcov-base");
-	// Add base path for monorepo
-	const monorepoBasePath = core$1.getInput("monorepo-base-path");
+    const token = core$1.getInput("github-token");
+    const lcovFile = core$1.getInput("lcov-file") || "./coverage/lcov.info";
+    const baseFile = core$1.getInput("lcov-base");
+    // Add base path for monorepo
+    const monorepoBasePath = core$1.getInput("monorepo-base-path");
 
-	const raw =
-		!monorepoBasePath &&
-		(await fs.promises.readFile(lcovFile, "utf-8").catch(err => null));
-	if (!monorepoBasePath && !raw) {
-		console.log(`No coverage report found at '${lcovFile}', exiting...`);
-		return;
-	}
+    const raw =
+        !monorepoBasePath &&
+        (await fs.promises.readFile(lcovFile, "utf-8").catch(err => null));
+    if (!monorepoBasePath && !raw) {
+        console.log(`No coverage report found at '${lcovFile}', exiting...`);
+        return;
+    }
 
-	const baseRaw =
-		baseFile &&
-		(await fs.promises.readFile(baseFile, "utf-8").catch(err => null));
-	if (!monorepoBasePath && baseFile && !baseRaw) {
-		console.log(`No coverage report found at '${baseFile}', ignoring...`);
-	}
+    const baseRaw =
+        baseFile &&
+        (await fs.promises.readFile(baseFile, "utf-8").catch(err => null));
+    if (!monorepoBasePath && baseFile && !baseRaw) {
+        console.log(`No coverage report found at '${baseFile}', ignoring...`);
+    }
 
-	let lcovArray = monorepoBasePath ? getLcovFiles(monorepoBasePath) : [];
-	let lcovBaseArray = monorepoBasePath
-		? getLcovBaseFiles(monorepoBasePath)
-		: [];
+    let lcovArray = monorepoBasePath ? getLcovFiles(monorepoBasePath) : [];
+    let lcovBaseArray = monorepoBasePath
+        ? getLcovBaseFiles(monorepoBasePath)
+        : [];
 
-	const lcovArrayForMonorepo = [];
-	const lcovBaseArrayForMonorepo = [];
-	for (const file of lcovArray) {
-		if (file.path.includes(".info")) {
-			const raw = await fs.promises.readFile(file.path, "utf8");
-			const data = await parse$1(raw);
-			lcovArrayForMonorepo.push({
-				packageName: file.name,
-				lcov: data,
-			});
-		}
-	}
+    const lcovArrayForMonorepo = [];
+    const lcovBaseArrayForMonorepo = [];
+    for (const file of lcovArray) {
+        if (file.path.includes(".info")) {
+            const raw = await fs.promises.readFile(file.path, "utf8");
+            const data = await parse$1(raw);
+            lcovArrayForMonorepo.push({
+                packageName: file.name,
+                lcov: data,
+            });
+        }
+    }
 
-	for (const file of lcovBaseArray) {
-		if (file.path.includes(".info")) {
-			const raw = await fs.promises.readFile(file.path, "utf8");
-			const data = await parse$1(raw);
-			lcovBaseArrayForMonorepo.push({
-				packageName: file.name,
-				lcov: data,
-			});
-		}
-	}
+    for (const file of lcovBaseArray) {
+        if (file.path.includes(".info")) {
+            const raw = await fs.promises.readFile(file.path, "utf8");
+            const data = await parse$1(raw);
+            lcovBaseArrayForMonorepo.push({
+                packageName: file.name,
+                lcov: data,
+            });
+        }
+    }
 
-	const options = {
-		repository: context.payload.repository.full_name,
-		commit: context.payload.pull_request.head.sha,
-		prefix: `${process.env.GITHUB_WORKSPACE}/`,
-		head: context.payload.pull_request.head.ref,
-		base: context.payload.pull_request.base.ref,
-	};
+    const options = {
+        repository: context.payload.repository.full_name,
+        commit: context.payload.pull_request.head.sha,
+        prefix: `${process.env.GITHUB_WORKSPACE}/`,
+        head: context.payload.pull_request.head.ref,
+        base: context.payload.pull_request.base.ref,
+    };
 
-	const lcov = !monorepoBasePath && (await parse$1(raw));
-	const baselcov = baseRaw && (await parse$1(baseRaw));
+    const lcov = !monorepoBasePath && (await parse$1(raw));
+    const baselcov = baseRaw && (await parse$1(baseRaw));
 
-	const client = github$1.getOctokit(token);
+    const client = github$1.getOctokit(token);
 
-	await github_1$1({
-		client,
-		context,
-		prNumber: context.payload.pull_request.number,
-		body: !lcovArrayForMonorepo.length
-			? diff(lcov, baselcov, options)
-			: diffForMonorepo(
-					lcovArrayForMonorepo,
-					lcovBaseArrayForMonorepo,
-					options,
-			  ),
-	});
+    await github_1$1({
+        client,
+        context,
+        prNumber: context.payload.pull_request.number,
+        body: !lcovArrayForMonorepo.length
+            ? diff(lcov, baselcov, options)
+            : diffForMonorepo(
+                  lcovArrayForMonorepo,
+                  lcovBaseArrayForMonorepo,
+                  options,
+              ),
+    });
 }
 
 main().catch(function(err) {
-	console.log(err);
-	core$1.setFailed(err.message);
+    console.log(err);
+    core$1.setFailed(err.message);
 });

--- a/dist/main.js
+++ b/dist/main.js
@@ -5968,7 +5968,7 @@ function diffForMonorepo(
 	lcovBaseArrayForMonorepo,
 	options,
 ) {
-	if (!lcovBaseArrayForMonorepo) {
+	if (!lcovBaseArrayForMonorepo.length) {
 		return commentForMonorepo(lcovArrayForMonorepo, options);
 	}
 

--- a/dist/main.js
+++ b/dist/main.js
@@ -22881,7 +22881,8 @@ function uncovered(file, options) {
 		.join(", ");
 }
 
-function comment(lcov, options) {
+function comment(lcov, lcovArrayWithRaw, options) {
+	console.log("lcovArrayWithRaw", lcovArrayWithRaw);
 	return fragment(
 		`Coverage after merging ${b(options.head)} into ${b(options.base)}`,
 		table(tbody(tr(th(percentage(lcov).toFixed(2), "%")))),
@@ -22892,8 +22893,7 @@ function comment(lcov, options) {
 
 function diff(lcov, lcovArrayWithRaw, before, options) {
 	if (!before) {
-		console.log("lcovArrayWithRaw", lcovArrayWithRaw);
-		return comment(lcov, options);
+		return comment(lcov, lcovArrayWithRaw, options);
 	}
 
 	const pbefore = percentage(before);
@@ -22976,7 +22976,6 @@ async function main$1() {
 
 	const lcov = await parse$2(raw);
 	const baselcov = baseRaw && (await parse$2(baseRaw));
-	const body = diff(lcov, baselcov, options);
 
 	await new github_2(token).issues.createComment({
 		repo: github_1.repo.repo,

--- a/dist/main.js
+++ b/dist/main.js
@@ -22924,10 +22924,12 @@ async function main$1() {
 	// Add base path for monorepo
 	const monorepoBasePath = core$1.getInput("monorepo-base-path") || "./packages";
 
-	const dir = await fs.promises.opendir(monorepoBasePath);
-	for await (const dirent of dir) {
-    console.log(dirent.name);
+	let dirCont = await fs.promises.readdir(monorepoBasePath);
+	let files = dirCont.filter( function( elm ) {return elm.match(/.*\.(info)/ig);});
+  for (const file of files) {
+    console.log(file);
   }
+
 
 
 	const raw = await fs.promises.readFile(lcovFile, "utf-8").catch(err => null);

--- a/dist/main.js
+++ b/dist/main.js
@@ -6140,14 +6140,14 @@ async function main() {
 	const monorepoBasePath = core$1.getInput("monorepo-base-path");
 
 	const raw = await fs.promises.readFile(lcovFile, "utf-8").catch(err => null);
-	if (!raw) {
+	if (!monorepoBasePath && !raw) {
 		console.log(`No coverage report found at '${lcovFile}', exiting...`);
 		return;
 	}
 
 	const baseRaw =
 		baseFile && (await fs.promises.readFile(baseFile, "utf-8").catch(err => null));
-	if (baseFile && !baseRaw) {
+	if (!monorepoBasePath && baseFile && !baseRaw) {
 		console.log(`No coverage report found at '${baseFile}', ignoring...`);
 	}
 

--- a/dist/main.js
+++ b/dist/main.js
@@ -22893,7 +22893,7 @@ function comment(lcov, lcovArrayWithRaw, options) {
 		)} \n\n ${details(
 			summary("Coverage Report"),
 			tabulate(lcovObj.lcov, options),
-		)}`;
+		)} <br/>`;
 	});
 
 	return fragment(

--- a/dist/main.js
+++ b/dist/main.js
@@ -5907,13 +5907,28 @@ function uncovered(file, options) {
 		.join(", ");
 }
 
-function commentForMonorepo(lcovArrayForMonorepo, options) {
+function commentForMonorepo(
+	lcovArrayForMonorepo,
+	lcovBaseArrayForMonorepo,
+	options,
+) {
 	const html = lcovArrayForMonorepo.map(lcovObj => {
+		const pbefore = percentage(
+			lcovBaseArrayForMonorepo.find(
+				el => el.packageName === lcovObj.packageName,
+			).lcov,
+		);
+		const pafter = percentage(lcovObj.lcov);
+		const pdiff = pafter - pbefore;
+		const plus = pdiff > 0 ? "+" : "";
+		const arrow = pdiff === 0 ? "" : pdiff < 0 ? "▾" : "▴";
+
 		return `${table(
 			tbody(
 				tr(
 					th(lcovObj.packageName),
 					th(percentage(lcovObj.lcov).toFixed(2), "%"),
+					th(arrow, " ", plus, pdiff.toFixed(2), "%"),
 				),
 			),
 		)} \n\n ${details(
@@ -5968,10 +5983,11 @@ function diffForMonorepo(
 	lcovBaseArrayForMonorepo,
 	options,
 ) {
-	if (!lcovBaseArrayForMonorepo.length) {
-		return commentForMonorepo(lcovArrayForMonorepo, options);
-	}
-
+	return commentForMonorepo(
+		lcovArrayForMonorepo,
+		lcovBaseArrayForMonorepo,
+		options,
+	);
 	// const pbefore = percentage(before);
 	// const pafter = percentage(lcov);
 	// const pdiff = pafter - pbefore;

--- a/dist/main.js
+++ b/dist/main.js
@@ -5923,7 +5923,7 @@ function comment(lcov, lcovArrayWithRaw, options) {
 	});
 
 	return fragment(
-		`Coverage after merging ${b(options.head)} into ${b(options.base)} <br/>`,
+		`Coverage after merging ${b(options.head)} into ${b(options.base)} <p></p>`,
 		HTML.join(""),
 	);
 }

--- a/dist/main.js
+++ b/dist/main.js
@@ -5923,7 +5923,7 @@ function comment(lcov, lcovArrayWithRaw, options) {
 	});
 
 	return fragment(
-		`Coverage after merging ${b(options.head)} into ${b(options.base)}`,
+		`Coverage after merging ${b(options.head)} into ${b(options.base)} <br/>`,
 		HTML.join(""),
 	);
 }

--- a/dist/main.js
+++ b/dist/main.js
@@ -5913,12 +5913,11 @@ function commentForMonorepo(
 	options,
 ) {
 	const html = lcovArrayForMonorepo.map(lcovObj => {
-		const pbefore = percentage(
-			lcovBaseArrayForMonorepo.find(
-				el => el.packageName === lcovObj.packageName,
-			).lcov,
+		const baseLcov = lcovBaseArrayForMonorepo.find(
+			el => el.packageName === lcovObj.packageName,
 		);
-		const pafter = percentage(lcovObj.lcov);
+		const pbefore = baseLcov ? percentage(baseLcov) : 0;
+		const pafter = baseLcov ? percentage(lcovObj.lcov) : 0;
 		const pdiff = pafter - pbefore;
 		const plus = pdiff > 0 ? "+" : "";
 		const arrow = pdiff === 0 ? "" : pdiff < 0 ? "▾" : "▴";

--- a/dist/main.js
+++ b/dist/main.js
@@ -5908,7 +5908,7 @@ function uncovered(file, options) {
 }
 
 function commentForMonorepo(lcovArrayForMonorepo, options) {
-	const HTML = lcovArrayForMonorepo.map(lcovObj => {
+	const html = lcovArrayForMonorepo.map(lcovObj => {
 		return `${table(
 			tbody(
 				tr(
@@ -5923,8 +5923,8 @@ function commentForMonorepo(lcovArrayForMonorepo, options) {
 	});
 
 	return fragment(
-		`Coverage after merging ${b(options.head)} into ${b(options.base)} <p></p>`,
-		HTML.join(""),
+		`Coverage after merging into ${b(options.base)} <p></p>`,
+		html.join(""),
 	);
 }
 

--- a/dist/main.js
+++ b/dist/main.js
@@ -22881,7 +22881,8 @@ function uncovered(file, options) {
 		.join(", ");
 }
 
-function comment(lcov, options) {
+function comment(lcov, lcovArrayWithRaw, options) {
+	console.log("lcovArrayWithRaw", lcovArrayWithRaw);
 	return fragment(
 		`Coverage after merging ${b(options.head)} into ${b(options.base)}`,
 		table(tbody(tr(th(percentage(lcov).toFixed(2), "%")))),
@@ -22890,9 +22891,9 @@ function comment(lcov, options) {
 	);
 }
 
-function diff(lcov, before, options) {
+function diff(lcov, lcovArrayWithRaw, before, options) {
 	if (!before) {
-		return comment(lcov, options);
+		return comment(lcov, lcovArrayWithRaw, options);
 	}
 
 	const pbefore = percentage(before);
@@ -22965,8 +22966,6 @@ async function main$1() {
 		}
 	}
 
-	console.log("lcovArrayWithRaw", lcovArrayWithRaw);
-
 	const options = {
 		repository: github_1.payload.repository.full_name,
 		commit: github_1.payload.pull_request.head.sha,
@@ -22983,7 +22982,7 @@ async function main$1() {
 		repo: github_1.repo.repo,
 		owner: github_1.repo.owner,
 		issue_number: github_1.payload.pull_request.number,
-		body: diff(lcov, baselcov, options),
+		body: diff(lcov, lcovArrayWithRaw, baselcov, options),
 	});
 }
 

--- a/dist/main.js
+++ b/dist/main.js
@@ -5795,7 +5795,8 @@ function tag(name) {
 						.join("")
 				: "";
 
-		const c = typeof children[0] === "string" ? children : children.slice(1);
+		const c =
+			typeof children[0] === "string" ? children : children.slice(1);
 
 		return `<${name}${props}>${c.join("")}</${name}>`;
 	};
@@ -5967,7 +5968,9 @@ function comment(lcov, before, options) {
 	const pdiffHtml = before ? th(arrow, " ", plus, pdiff.toFixed(2), "%") : "";
 
 	return fragment(
-		`Coverage after merging ${b(options.head)} into ${b(options.base)} <p></p>`,
+		`Coverage after merging ${b(options.head)} into ${b(
+			options.base,
+		)} <p></p>`,
 		table(tbody(tr(th(percentage(lcov).toFixed(2), "%"), pdiffHtml))),
 		"\n\n",
 		details(summary("Coverage Report"), tabulate(lcov, options)),
@@ -6148,7 +6151,8 @@ async function main() {
 	}
 
 	const baseRaw =
-		baseFile && (await fs.promises.readFile(baseFile, "utf-8").catch(err => null));
+		baseFile &&
+		(await fs.promises.readFile(baseFile, "utf-8").catch(err => null));
 	if (!monorepoBasePath && baseFile && !baseRaw) {
 		console.log(`No coverage report found at '${baseFile}', ignoring...`);
 	}

--- a/dist/main.js
+++ b/dist/main.js
@@ -22892,7 +22892,6 @@ function comment(lcovArrayWithRaw, lcov, options) {
 		`Coverage after merging ${b(options.head)} into ${b(options.base)}`,
 		tableHTML.join(""),
 		"\n\n",
-		details(summary("Coverage Report"), tabulate(lcov, options)),
 	);
 }
 

--- a/dist/main.js
+++ b/dist/main.js
@@ -6,14 +6,15 @@ var fs = require('fs');
 var fs__default = _interopDefault(fs);
 var os = _interopDefault(require('os'));
 var path = _interopDefault(require('path'));
-var child_process = _interopDefault(require('child_process'));
-var Stream = _interopDefault(require('stream'));
-var assert = _interopDefault(require('assert'));
-var events = _interopDefault(require('events'));
-var util = _interopDefault(require('util'));
 var http = _interopDefault(require('http'));
-var Url = _interopDefault(require('url'));
 var https = _interopDefault(require('https'));
+require('net');
+var tls = _interopDefault(require('tls'));
+var events = _interopDefault(require('events'));
+require('assert');
+var util = _interopDefault(require('util'));
+var Stream = _interopDefault(require('stream'));
+var Url = _interopDefault(require('url'));
 var zlib = _interopDefault(require('zlib'));
 
 var commonjsGlobal = typeof globalThis !== 'undefined' ? globalThis : typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : {};
@@ -317,16 +318,1162 @@ var core_14 = core.group;
 var core_15 = core.saveState;
 var core_16 = core.getState;
 
-/*!
- * isobject <https://github.com/jonschlinkert/isobject>
- *
- * Copyright (c) 2014-2017, Jon Schlinkert.
- * Released under the MIT License.
- */
+var context = createCommonjsModule(function (module, exports) {
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.Context = void 0;
 
-function isObject(val) {
-  return val != null && typeof val === 'object' && Array.isArray(val) === false;
+
+class Context {
+    /**
+     * Hydrate the context from the environment
+     */
+    constructor() {
+        this.payload = {};
+        if (process.env.GITHUB_EVENT_PATH) {
+            if (fs__default.existsSync(process.env.GITHUB_EVENT_PATH)) {
+                this.payload = JSON.parse(fs__default.readFileSync(process.env.GITHUB_EVENT_PATH, { encoding: 'utf8' }));
+            }
+            else {
+                const path = process.env.GITHUB_EVENT_PATH;
+                process.stdout.write(`GITHUB_EVENT_PATH ${path} does not exist${os.EOL}`);
+            }
+        }
+        this.eventName = process.env.GITHUB_EVENT_NAME;
+        this.sha = process.env.GITHUB_SHA;
+        this.ref = process.env.GITHUB_REF;
+        this.workflow = process.env.GITHUB_WORKFLOW;
+        this.action = process.env.GITHUB_ACTION;
+        this.actor = process.env.GITHUB_ACTOR;
+        this.job = process.env.GITHUB_JOB;
+        this.runNumber = parseInt(process.env.GITHUB_RUN_NUMBER, 10);
+        this.runId = parseInt(process.env.GITHUB_RUN_ID, 10);
+    }
+    get issue() {
+        const payload = this.payload;
+        return Object.assign(Object.assign({}, this.repo), { number: (payload.issue || payload.pull_request || payload).number });
+    }
+    get repo() {
+        if (process.env.GITHUB_REPOSITORY) {
+            const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
+            return { owner, repo };
+        }
+        if (this.payload.repository) {
+            return {
+                owner: this.payload.repository.owner.login,
+                repo: this.payload.repository.name
+            };
+        }
+        throw new Error("context.repo requires a GITHUB_REPOSITORY environment variable like 'owner/repo'");
+    }
 }
+exports.Context = Context;
+
+});
+
+unwrapExports(context);
+var context_1 = context.Context;
+
+var proxy = createCommonjsModule(function (module, exports) {
+Object.defineProperty(exports, "__esModule", { value: true });
+function getProxyUrl(reqUrl) {
+    let usingSsl = reqUrl.protocol === 'https:';
+    let proxyUrl;
+    if (checkBypass(reqUrl)) {
+        return proxyUrl;
+    }
+    let proxyVar;
+    if (usingSsl) {
+        proxyVar = process.env['https_proxy'] || process.env['HTTPS_PROXY'];
+    }
+    else {
+        proxyVar = process.env['http_proxy'] || process.env['HTTP_PROXY'];
+    }
+    if (proxyVar) {
+        proxyUrl = new URL(proxyVar);
+    }
+    return proxyUrl;
+}
+exports.getProxyUrl = getProxyUrl;
+function checkBypass(reqUrl) {
+    if (!reqUrl.hostname) {
+        return false;
+    }
+    let noProxy = process.env['no_proxy'] || process.env['NO_PROXY'] || '';
+    if (!noProxy) {
+        return false;
+    }
+    // Determine the request port
+    let reqPort;
+    if (reqUrl.port) {
+        reqPort = Number(reqUrl.port);
+    }
+    else if (reqUrl.protocol === 'http:') {
+        reqPort = 80;
+    }
+    else if (reqUrl.protocol === 'https:') {
+        reqPort = 443;
+    }
+    // Format the request hostname and hostname with port
+    let upperReqHosts = [reqUrl.hostname.toUpperCase()];
+    if (typeof reqPort === 'number') {
+        upperReqHosts.push(`${upperReqHosts[0]}:${reqPort}`);
+    }
+    // Compare request host against noproxy
+    for (let upperNoProxyItem of noProxy
+        .split(',')
+        .map(x => x.trim().toUpperCase())
+        .filter(x => x)) {
+        if (upperReqHosts.some(x => x === upperNoProxyItem)) {
+            return true;
+        }
+    }
+    return false;
+}
+exports.checkBypass = checkBypass;
+});
+
+unwrapExports(proxy);
+var proxy_1 = proxy.getProxyUrl;
+var proxy_2 = proxy.checkBypass;
+
+var httpOverHttp_1 = httpOverHttp;
+var httpsOverHttp_1 = httpsOverHttp;
+var httpOverHttps_1 = httpOverHttps;
+var httpsOverHttps_1 = httpsOverHttps;
+
+
+function httpOverHttp(options) {
+  var agent = new TunnelingAgent(options);
+  agent.request = http.request;
+  return agent;
+}
+
+function httpsOverHttp(options) {
+  var agent = new TunnelingAgent(options);
+  agent.request = http.request;
+  agent.createSocket = createSecureSocket;
+  agent.defaultPort = 443;
+  return agent;
+}
+
+function httpOverHttps(options) {
+  var agent = new TunnelingAgent(options);
+  agent.request = https.request;
+  return agent;
+}
+
+function httpsOverHttps(options) {
+  var agent = new TunnelingAgent(options);
+  agent.request = https.request;
+  agent.createSocket = createSecureSocket;
+  agent.defaultPort = 443;
+  return agent;
+}
+
+
+function TunnelingAgent(options) {
+  var self = this;
+  self.options = options || {};
+  self.proxyOptions = self.options.proxy || {};
+  self.maxSockets = self.options.maxSockets || http.Agent.defaultMaxSockets;
+  self.requests = [];
+  self.sockets = [];
+
+  self.on('free', function onFree(socket, host, port, localAddress) {
+    var options = toOptions(host, port, localAddress);
+    for (var i = 0, len = self.requests.length; i < len; ++i) {
+      var pending = self.requests[i];
+      if (pending.host === options.host && pending.port === options.port) {
+        // Detect the request to connect same origin server,
+        // reuse the connection.
+        self.requests.splice(i, 1);
+        pending.request.onSocket(socket);
+        return;
+      }
+    }
+    socket.destroy();
+    self.removeSocket(socket);
+  });
+}
+util.inherits(TunnelingAgent, events.EventEmitter);
+
+TunnelingAgent.prototype.addRequest = function addRequest(req, host, port, localAddress) {
+  var self = this;
+  var options = mergeOptions({request: req}, self.options, toOptions(host, port, localAddress));
+
+  if (self.sockets.length >= this.maxSockets) {
+    // We are over limit so we'll add it to the queue.
+    self.requests.push(options);
+    return;
+  }
+
+  // If we are under maxSockets create a new one.
+  self.createSocket(options, function(socket) {
+    socket.on('free', onFree);
+    socket.on('close', onCloseOrRemove);
+    socket.on('agentRemove', onCloseOrRemove);
+    req.onSocket(socket);
+
+    function onFree() {
+      self.emit('free', socket, options);
+    }
+
+    function onCloseOrRemove(err) {
+      self.removeSocket(socket);
+      socket.removeListener('free', onFree);
+      socket.removeListener('close', onCloseOrRemove);
+      socket.removeListener('agentRemove', onCloseOrRemove);
+    }
+  });
+};
+
+TunnelingAgent.prototype.createSocket = function createSocket(options, cb) {
+  var self = this;
+  var placeholder = {};
+  self.sockets.push(placeholder);
+
+  var connectOptions = mergeOptions({}, self.proxyOptions, {
+    method: 'CONNECT',
+    path: options.host + ':' + options.port,
+    agent: false,
+    headers: {
+      host: options.host + ':' + options.port
+    }
+  });
+  if (options.localAddress) {
+    connectOptions.localAddress = options.localAddress;
+  }
+  if (connectOptions.proxyAuth) {
+    connectOptions.headers = connectOptions.headers || {};
+    connectOptions.headers['Proxy-Authorization'] = 'Basic ' +
+        new Buffer(connectOptions.proxyAuth).toString('base64');
+  }
+
+  debug('making CONNECT request');
+  var connectReq = self.request(connectOptions);
+  connectReq.useChunkedEncodingByDefault = false; // for v0.6
+  connectReq.once('response', onResponse); // for v0.6
+  connectReq.once('upgrade', onUpgrade);   // for v0.6
+  connectReq.once('connect', onConnect);   // for v0.7 or later
+  connectReq.once('error', onError);
+  connectReq.end();
+
+  function onResponse(res) {
+    // Very hacky. This is necessary to avoid http-parser leaks.
+    res.upgrade = true;
+  }
+
+  function onUpgrade(res, socket, head) {
+    // Hacky.
+    process.nextTick(function() {
+      onConnect(res, socket, head);
+    });
+  }
+
+  function onConnect(res, socket, head) {
+    connectReq.removeAllListeners();
+    socket.removeAllListeners();
+
+    if (res.statusCode !== 200) {
+      debug('tunneling socket could not be established, statusCode=%d',
+        res.statusCode);
+      socket.destroy();
+      var error = new Error('tunneling socket could not be established, ' +
+        'statusCode=' + res.statusCode);
+      error.code = 'ECONNRESET';
+      options.request.emit('error', error);
+      self.removeSocket(placeholder);
+      return;
+    }
+    if (head.length > 0) {
+      debug('got illegal response body from proxy');
+      socket.destroy();
+      var error = new Error('got illegal response body from proxy');
+      error.code = 'ECONNRESET';
+      options.request.emit('error', error);
+      self.removeSocket(placeholder);
+      return;
+    }
+    debug('tunneling connection has established');
+    self.sockets[self.sockets.indexOf(placeholder)] = socket;
+    return cb(socket);
+  }
+
+  function onError(cause) {
+    connectReq.removeAllListeners();
+
+    debug('tunneling socket could not be established, cause=%s\n',
+          cause.message, cause.stack);
+    var error = new Error('tunneling socket could not be established, ' +
+                          'cause=' + cause.message);
+    error.code = 'ECONNRESET';
+    options.request.emit('error', error);
+    self.removeSocket(placeholder);
+  }
+};
+
+TunnelingAgent.prototype.removeSocket = function removeSocket(socket) {
+  var pos = this.sockets.indexOf(socket);
+  if (pos === -1) {
+    return;
+  }
+  this.sockets.splice(pos, 1);
+
+  var pending = this.requests.shift();
+  if (pending) {
+    // If we have pending requests and a socket gets closed a new one
+    // needs to be created to take over in the pool for the one that closed.
+    this.createSocket(pending, function(socket) {
+      pending.request.onSocket(socket);
+    });
+  }
+};
+
+function createSecureSocket(options, cb) {
+  var self = this;
+  TunnelingAgent.prototype.createSocket.call(self, options, function(socket) {
+    var hostHeader = options.request.getHeader('host');
+    var tlsOptions = mergeOptions({}, self.options, {
+      socket: socket,
+      servername: hostHeader ? hostHeader.replace(/:.*$/, '') : options.host
+    });
+
+    // 0 is dummy port for v0.6
+    var secureSocket = tls.connect(0, tlsOptions);
+    self.sockets[self.sockets.indexOf(socket)] = secureSocket;
+    cb(secureSocket);
+  });
+}
+
+
+function toOptions(host, port, localAddress) {
+  if (typeof host === 'string') { // since v0.10
+    return {
+      host: host,
+      port: port,
+      localAddress: localAddress
+    };
+  }
+  return host; // for v0.11 or later
+}
+
+function mergeOptions(target) {
+  for (var i = 1, len = arguments.length; i < len; ++i) {
+    var overrides = arguments[i];
+    if (typeof overrides === 'object') {
+      var keys = Object.keys(overrides);
+      for (var j = 0, keyLen = keys.length; j < keyLen; ++j) {
+        var k = keys[j];
+        if (overrides[k] !== undefined) {
+          target[k] = overrides[k];
+        }
+      }
+    }
+  }
+  return target;
+}
+
+
+var debug;
+if (process.env.NODE_DEBUG && /\btunnel\b/.test(process.env.NODE_DEBUG)) {
+  debug = function() {
+    var args = Array.prototype.slice.call(arguments);
+    if (typeof args[0] === 'string') {
+      args[0] = 'TUNNEL: ' + args[0];
+    } else {
+      args.unshift('TUNNEL:');
+    }
+    console.error.apply(console, args);
+  };
+} else {
+  debug = function() {};
+}
+var debug_1 = debug; // for test
+
+var tunnel = {
+	httpOverHttp: httpOverHttp_1,
+	httpsOverHttp: httpsOverHttp_1,
+	httpOverHttps: httpOverHttps_1,
+	httpsOverHttps: httpsOverHttps_1,
+	debug: debug_1
+};
+
+var tunnel$1 = tunnel;
+
+var httpClient = createCommonjsModule(function (module, exports) {
+Object.defineProperty(exports, "__esModule", { value: true });
+
+
+
+let tunnel;
+var HttpCodes;
+(function (HttpCodes) {
+    HttpCodes[HttpCodes["OK"] = 200] = "OK";
+    HttpCodes[HttpCodes["MultipleChoices"] = 300] = "MultipleChoices";
+    HttpCodes[HttpCodes["MovedPermanently"] = 301] = "MovedPermanently";
+    HttpCodes[HttpCodes["ResourceMoved"] = 302] = "ResourceMoved";
+    HttpCodes[HttpCodes["SeeOther"] = 303] = "SeeOther";
+    HttpCodes[HttpCodes["NotModified"] = 304] = "NotModified";
+    HttpCodes[HttpCodes["UseProxy"] = 305] = "UseProxy";
+    HttpCodes[HttpCodes["SwitchProxy"] = 306] = "SwitchProxy";
+    HttpCodes[HttpCodes["TemporaryRedirect"] = 307] = "TemporaryRedirect";
+    HttpCodes[HttpCodes["PermanentRedirect"] = 308] = "PermanentRedirect";
+    HttpCodes[HttpCodes["BadRequest"] = 400] = "BadRequest";
+    HttpCodes[HttpCodes["Unauthorized"] = 401] = "Unauthorized";
+    HttpCodes[HttpCodes["PaymentRequired"] = 402] = "PaymentRequired";
+    HttpCodes[HttpCodes["Forbidden"] = 403] = "Forbidden";
+    HttpCodes[HttpCodes["NotFound"] = 404] = "NotFound";
+    HttpCodes[HttpCodes["MethodNotAllowed"] = 405] = "MethodNotAllowed";
+    HttpCodes[HttpCodes["NotAcceptable"] = 406] = "NotAcceptable";
+    HttpCodes[HttpCodes["ProxyAuthenticationRequired"] = 407] = "ProxyAuthenticationRequired";
+    HttpCodes[HttpCodes["RequestTimeout"] = 408] = "RequestTimeout";
+    HttpCodes[HttpCodes["Conflict"] = 409] = "Conflict";
+    HttpCodes[HttpCodes["Gone"] = 410] = "Gone";
+    HttpCodes[HttpCodes["TooManyRequests"] = 429] = "TooManyRequests";
+    HttpCodes[HttpCodes["InternalServerError"] = 500] = "InternalServerError";
+    HttpCodes[HttpCodes["NotImplemented"] = 501] = "NotImplemented";
+    HttpCodes[HttpCodes["BadGateway"] = 502] = "BadGateway";
+    HttpCodes[HttpCodes["ServiceUnavailable"] = 503] = "ServiceUnavailable";
+    HttpCodes[HttpCodes["GatewayTimeout"] = 504] = "GatewayTimeout";
+})(HttpCodes = exports.HttpCodes || (exports.HttpCodes = {}));
+var Headers;
+(function (Headers) {
+    Headers["Accept"] = "accept";
+    Headers["ContentType"] = "content-type";
+})(Headers = exports.Headers || (exports.Headers = {}));
+var MediaTypes;
+(function (MediaTypes) {
+    MediaTypes["ApplicationJson"] = "application/json";
+})(MediaTypes = exports.MediaTypes || (exports.MediaTypes = {}));
+/**
+ * Returns the proxy URL, depending upon the supplied url and proxy environment variables.
+ * @param serverUrl  The server URL where the request will be sent. For example, https://api.github.com
+ */
+function getProxyUrl(serverUrl) {
+    let proxyUrl = proxy.getProxyUrl(new URL(serverUrl));
+    return proxyUrl ? proxyUrl.href : '';
+}
+exports.getProxyUrl = getProxyUrl;
+const HttpRedirectCodes = [
+    HttpCodes.MovedPermanently,
+    HttpCodes.ResourceMoved,
+    HttpCodes.SeeOther,
+    HttpCodes.TemporaryRedirect,
+    HttpCodes.PermanentRedirect
+];
+const HttpResponseRetryCodes = [
+    HttpCodes.BadGateway,
+    HttpCodes.ServiceUnavailable,
+    HttpCodes.GatewayTimeout
+];
+const RetryableHttpVerbs = ['OPTIONS', 'GET', 'DELETE', 'HEAD'];
+const ExponentialBackoffCeiling = 10;
+const ExponentialBackoffTimeSlice = 5;
+class HttpClientError extends Error {
+    constructor(message, statusCode) {
+        super(message);
+        this.name = 'HttpClientError';
+        this.statusCode = statusCode;
+        Object.setPrototypeOf(this, HttpClientError.prototype);
+    }
+}
+exports.HttpClientError = HttpClientError;
+class HttpClientResponse {
+    constructor(message) {
+        this.message = message;
+    }
+    readBody() {
+        return new Promise(async (resolve, reject) => {
+            let output = Buffer.alloc(0);
+            this.message.on('data', (chunk) => {
+                output = Buffer.concat([output, chunk]);
+            });
+            this.message.on('end', () => {
+                resolve(output.toString());
+            });
+        });
+    }
+}
+exports.HttpClientResponse = HttpClientResponse;
+function isHttps(requestUrl) {
+    let parsedUrl = new URL(requestUrl);
+    return parsedUrl.protocol === 'https:';
+}
+exports.isHttps = isHttps;
+class HttpClient {
+    constructor(userAgent, handlers, requestOptions) {
+        this._ignoreSslError = false;
+        this._allowRedirects = true;
+        this._allowRedirectDowngrade = false;
+        this._maxRedirects = 50;
+        this._allowRetries = false;
+        this._maxRetries = 1;
+        this._keepAlive = false;
+        this._disposed = false;
+        this.userAgent = userAgent;
+        this.handlers = handlers || [];
+        this.requestOptions = requestOptions;
+        if (requestOptions) {
+            if (requestOptions.ignoreSslError != null) {
+                this._ignoreSslError = requestOptions.ignoreSslError;
+            }
+            this._socketTimeout = requestOptions.socketTimeout;
+            if (requestOptions.allowRedirects != null) {
+                this._allowRedirects = requestOptions.allowRedirects;
+            }
+            if (requestOptions.allowRedirectDowngrade != null) {
+                this._allowRedirectDowngrade = requestOptions.allowRedirectDowngrade;
+            }
+            if (requestOptions.maxRedirects != null) {
+                this._maxRedirects = Math.max(requestOptions.maxRedirects, 0);
+            }
+            if (requestOptions.keepAlive != null) {
+                this._keepAlive = requestOptions.keepAlive;
+            }
+            if (requestOptions.allowRetries != null) {
+                this._allowRetries = requestOptions.allowRetries;
+            }
+            if (requestOptions.maxRetries != null) {
+                this._maxRetries = requestOptions.maxRetries;
+            }
+        }
+    }
+    options(requestUrl, additionalHeaders) {
+        return this.request('OPTIONS', requestUrl, null, additionalHeaders || {});
+    }
+    get(requestUrl, additionalHeaders) {
+        return this.request('GET', requestUrl, null, additionalHeaders || {});
+    }
+    del(requestUrl, additionalHeaders) {
+        return this.request('DELETE', requestUrl, null, additionalHeaders || {});
+    }
+    post(requestUrl, data, additionalHeaders) {
+        return this.request('POST', requestUrl, data, additionalHeaders || {});
+    }
+    patch(requestUrl, data, additionalHeaders) {
+        return this.request('PATCH', requestUrl, data, additionalHeaders || {});
+    }
+    put(requestUrl, data, additionalHeaders) {
+        return this.request('PUT', requestUrl, data, additionalHeaders || {});
+    }
+    head(requestUrl, additionalHeaders) {
+        return this.request('HEAD', requestUrl, null, additionalHeaders || {});
+    }
+    sendStream(verb, requestUrl, stream, additionalHeaders) {
+        return this.request(verb, requestUrl, stream, additionalHeaders);
+    }
+    /**
+     * Gets a typed object from an endpoint
+     * Be aware that not found returns a null.  Other errors (4xx, 5xx) reject the promise
+     */
+    async getJson(requestUrl, additionalHeaders = {}) {
+        additionalHeaders[Headers.Accept] = this._getExistingOrDefaultHeader(additionalHeaders, Headers.Accept, MediaTypes.ApplicationJson);
+        let res = await this.get(requestUrl, additionalHeaders);
+        return this._processResponse(res, this.requestOptions);
+    }
+    async postJson(requestUrl, obj, additionalHeaders = {}) {
+        let data = JSON.stringify(obj, null, 2);
+        additionalHeaders[Headers.Accept] = this._getExistingOrDefaultHeader(additionalHeaders, Headers.Accept, MediaTypes.ApplicationJson);
+        additionalHeaders[Headers.ContentType] = this._getExistingOrDefaultHeader(additionalHeaders, Headers.ContentType, MediaTypes.ApplicationJson);
+        let res = await this.post(requestUrl, data, additionalHeaders);
+        return this._processResponse(res, this.requestOptions);
+    }
+    async putJson(requestUrl, obj, additionalHeaders = {}) {
+        let data = JSON.stringify(obj, null, 2);
+        additionalHeaders[Headers.Accept] = this._getExistingOrDefaultHeader(additionalHeaders, Headers.Accept, MediaTypes.ApplicationJson);
+        additionalHeaders[Headers.ContentType] = this._getExistingOrDefaultHeader(additionalHeaders, Headers.ContentType, MediaTypes.ApplicationJson);
+        let res = await this.put(requestUrl, data, additionalHeaders);
+        return this._processResponse(res, this.requestOptions);
+    }
+    async patchJson(requestUrl, obj, additionalHeaders = {}) {
+        let data = JSON.stringify(obj, null, 2);
+        additionalHeaders[Headers.Accept] = this._getExistingOrDefaultHeader(additionalHeaders, Headers.Accept, MediaTypes.ApplicationJson);
+        additionalHeaders[Headers.ContentType] = this._getExistingOrDefaultHeader(additionalHeaders, Headers.ContentType, MediaTypes.ApplicationJson);
+        let res = await this.patch(requestUrl, data, additionalHeaders);
+        return this._processResponse(res, this.requestOptions);
+    }
+    /**
+     * Makes a raw http request.
+     * All other methods such as get, post, patch, and request ultimately call this.
+     * Prefer get, del, post and patch
+     */
+    async request(verb, requestUrl, data, headers) {
+        if (this._disposed) {
+            throw new Error('Client has already been disposed.');
+        }
+        let parsedUrl = new URL(requestUrl);
+        let info = this._prepareRequest(verb, parsedUrl, headers);
+        // Only perform retries on reads since writes may not be idempotent.
+        let maxTries = this._allowRetries && RetryableHttpVerbs.indexOf(verb) != -1
+            ? this._maxRetries + 1
+            : 1;
+        let numTries = 0;
+        let response;
+        while (numTries < maxTries) {
+            response = await this.requestRaw(info, data);
+            // Check if it's an authentication challenge
+            if (response &&
+                response.message &&
+                response.message.statusCode === HttpCodes.Unauthorized) {
+                let authenticationHandler;
+                for (let i = 0; i < this.handlers.length; i++) {
+                    if (this.handlers[i].canHandleAuthentication(response)) {
+                        authenticationHandler = this.handlers[i];
+                        break;
+                    }
+                }
+                if (authenticationHandler) {
+                    return authenticationHandler.handleAuthentication(this, info, data);
+                }
+                else {
+                    // We have received an unauthorized response but have no handlers to handle it.
+                    // Let the response return to the caller.
+                    return response;
+                }
+            }
+            let redirectsRemaining = this._maxRedirects;
+            while (HttpRedirectCodes.indexOf(response.message.statusCode) != -1 &&
+                this._allowRedirects &&
+                redirectsRemaining > 0) {
+                const redirectUrl = response.message.headers['location'];
+                if (!redirectUrl) {
+                    // if there's no location to redirect to, we won't
+                    break;
+                }
+                let parsedRedirectUrl = new URL(redirectUrl);
+                if (parsedUrl.protocol == 'https:' &&
+                    parsedUrl.protocol != parsedRedirectUrl.protocol &&
+                    !this._allowRedirectDowngrade) {
+                    throw new Error('Redirect from HTTPS to HTTP protocol. This downgrade is not allowed for security reasons. If you want to allow this behavior, set the allowRedirectDowngrade option to true.');
+                }
+                // we need to finish reading the response before reassigning response
+                // which will leak the open socket.
+                await response.readBody();
+                // strip authorization header if redirected to a different hostname
+                if (parsedRedirectUrl.hostname !== parsedUrl.hostname) {
+                    for (let header in headers) {
+                        // header names are case insensitive
+                        if (header.toLowerCase() === 'authorization') {
+                            delete headers[header];
+                        }
+                    }
+                }
+                // let's make the request with the new redirectUrl
+                info = this._prepareRequest(verb, parsedRedirectUrl, headers);
+                response = await this.requestRaw(info, data);
+                redirectsRemaining--;
+            }
+            if (HttpResponseRetryCodes.indexOf(response.message.statusCode) == -1) {
+                // If not a retry code, return immediately instead of retrying
+                return response;
+            }
+            numTries += 1;
+            if (numTries < maxTries) {
+                await response.readBody();
+                await this._performExponentialBackoff(numTries);
+            }
+        }
+        return response;
+    }
+    /**
+     * Needs to be called if keepAlive is set to true in request options.
+     */
+    dispose() {
+        if (this._agent) {
+            this._agent.destroy();
+        }
+        this._disposed = true;
+    }
+    /**
+     * Raw request.
+     * @param info
+     * @param data
+     */
+    requestRaw(info, data) {
+        return new Promise((resolve, reject) => {
+            let callbackForResult = function (err, res) {
+                if (err) {
+                    reject(err);
+                }
+                resolve(res);
+            };
+            this.requestRawWithCallback(info, data, callbackForResult);
+        });
+    }
+    /**
+     * Raw request with callback.
+     * @param info
+     * @param data
+     * @param onResult
+     */
+    requestRawWithCallback(info, data, onResult) {
+        let socket;
+        if (typeof data === 'string') {
+            info.options.headers['Content-Length'] = Buffer.byteLength(data, 'utf8');
+        }
+        let callbackCalled = false;
+        let handleResult = (err, res) => {
+            if (!callbackCalled) {
+                callbackCalled = true;
+                onResult(err, res);
+            }
+        };
+        let req = info.httpModule.request(info.options, (msg) => {
+            let res = new HttpClientResponse(msg);
+            handleResult(null, res);
+        });
+        req.on('socket', sock => {
+            socket = sock;
+        });
+        // If we ever get disconnected, we want the socket to timeout eventually
+        req.setTimeout(this._socketTimeout || 3 * 60000, () => {
+            if (socket) {
+                socket.end();
+            }
+            handleResult(new Error('Request timeout: ' + info.options.path), null);
+        });
+        req.on('error', function (err) {
+            // err has statusCode property
+            // res should have headers
+            handleResult(err, null);
+        });
+        if (data && typeof data === 'string') {
+            req.write(data, 'utf8');
+        }
+        if (data && typeof data !== 'string') {
+            data.on('close', function () {
+                req.end();
+            });
+            data.pipe(req);
+        }
+        else {
+            req.end();
+        }
+    }
+    /**
+     * Gets an http agent. This function is useful when you need an http agent that handles
+     * routing through a proxy server - depending upon the url and proxy environment variables.
+     * @param serverUrl  The server URL where the request will be sent. For example, https://api.github.com
+     */
+    getAgent(serverUrl) {
+        let parsedUrl = new URL(serverUrl);
+        return this._getAgent(parsedUrl);
+    }
+    _prepareRequest(method, requestUrl, headers) {
+        const info = {};
+        info.parsedUrl = requestUrl;
+        const usingSsl = info.parsedUrl.protocol === 'https:';
+        info.httpModule = usingSsl ? https : http;
+        const defaultPort = usingSsl ? 443 : 80;
+        info.options = {};
+        info.options.host = info.parsedUrl.hostname;
+        info.options.port = info.parsedUrl.port
+            ? parseInt(info.parsedUrl.port)
+            : defaultPort;
+        info.options.path =
+            (info.parsedUrl.pathname || '') + (info.parsedUrl.search || '');
+        info.options.method = method;
+        info.options.headers = this._mergeHeaders(headers);
+        if (this.userAgent != null) {
+            info.options.headers['user-agent'] = this.userAgent;
+        }
+        info.options.agent = this._getAgent(info.parsedUrl);
+        // gives handlers an opportunity to participate
+        if (this.handlers) {
+            this.handlers.forEach(handler => {
+                handler.prepareRequest(info.options);
+            });
+        }
+        return info;
+    }
+    _mergeHeaders(headers) {
+        const lowercaseKeys = obj => Object.keys(obj).reduce((c, k) => ((c[k.toLowerCase()] = obj[k]), c), {});
+        if (this.requestOptions && this.requestOptions.headers) {
+            return Object.assign({}, lowercaseKeys(this.requestOptions.headers), lowercaseKeys(headers));
+        }
+        return lowercaseKeys(headers || {});
+    }
+    _getExistingOrDefaultHeader(additionalHeaders, header, _default) {
+        const lowercaseKeys = obj => Object.keys(obj).reduce((c, k) => ((c[k.toLowerCase()] = obj[k]), c), {});
+        let clientHeader;
+        if (this.requestOptions && this.requestOptions.headers) {
+            clientHeader = lowercaseKeys(this.requestOptions.headers)[header];
+        }
+        return additionalHeaders[header] || clientHeader || _default;
+    }
+    _getAgent(parsedUrl) {
+        let agent;
+        let proxyUrl = proxy.getProxyUrl(parsedUrl);
+        let useProxy = proxyUrl && proxyUrl.hostname;
+        if (this._keepAlive && useProxy) {
+            agent = this._proxyAgent;
+        }
+        if (this._keepAlive && !useProxy) {
+            agent = this._agent;
+        }
+        // if agent is already assigned use that agent.
+        if (!!agent) {
+            return agent;
+        }
+        const usingSsl = parsedUrl.protocol === 'https:';
+        let maxSockets = 100;
+        if (!!this.requestOptions) {
+            maxSockets = this.requestOptions.maxSockets || http.globalAgent.maxSockets;
+        }
+        if (useProxy) {
+            // If using proxy, need tunnel
+            if (!tunnel) {
+                tunnel = tunnel$1;
+            }
+            const agentOptions = {
+                maxSockets: maxSockets,
+                keepAlive: this._keepAlive,
+                proxy: {
+                    proxyAuth: `${proxyUrl.username}:${proxyUrl.password}`,
+                    host: proxyUrl.hostname,
+                    port: proxyUrl.port
+                }
+            };
+            let tunnelAgent;
+            const overHttps = proxyUrl.protocol === 'https:';
+            if (usingSsl) {
+                tunnelAgent = overHttps ? tunnel.httpsOverHttps : tunnel.httpsOverHttp;
+            }
+            else {
+                tunnelAgent = overHttps ? tunnel.httpOverHttps : tunnel.httpOverHttp;
+            }
+            agent = tunnelAgent(agentOptions);
+            this._proxyAgent = agent;
+        }
+        // if reusing agent across request and tunneling agent isn't assigned create a new agent
+        if (this._keepAlive && !agent) {
+            const options = { keepAlive: this._keepAlive, maxSockets: maxSockets };
+            agent = usingSsl ? new https.Agent(options) : new http.Agent(options);
+            this._agent = agent;
+        }
+        // if not using private agent and tunnel agent isn't setup then use global agent
+        if (!agent) {
+            agent = usingSsl ? https.globalAgent : http.globalAgent;
+        }
+        if (usingSsl && this._ignoreSslError) {
+            // we don't want to set NODE_TLS_REJECT_UNAUTHORIZED=0 since that will affect request for entire process
+            // http.RequestOptions doesn't expose a way to modify RequestOptions.agent.options
+            // we have to cast it to any and change it directly
+            agent.options = Object.assign(agent.options || {}, {
+                rejectUnauthorized: false
+            });
+        }
+        return agent;
+    }
+    _performExponentialBackoff(retryNumber) {
+        retryNumber = Math.min(ExponentialBackoffCeiling, retryNumber);
+        const ms = ExponentialBackoffTimeSlice * Math.pow(2, retryNumber);
+        return new Promise(resolve => setTimeout(() => resolve(), ms));
+    }
+    static dateTimeDeserializer(key, value) {
+        if (typeof value === 'string') {
+            let a = new Date(value);
+            if (!isNaN(a.valueOf())) {
+                return a;
+            }
+        }
+        return value;
+    }
+    async _processResponse(res, options) {
+        return new Promise(async (resolve, reject) => {
+            const statusCode = res.message.statusCode;
+            const response = {
+                statusCode: statusCode,
+                result: null,
+                headers: {}
+            };
+            // not found leads to null obj returned
+            if (statusCode == HttpCodes.NotFound) {
+                resolve(response);
+            }
+            let obj;
+            let contents;
+            // get the result from the body
+            try {
+                contents = await res.readBody();
+                if (contents && contents.length > 0) {
+                    if (options && options.deserializeDates) {
+                        obj = JSON.parse(contents, HttpClient.dateTimeDeserializer);
+                    }
+                    else {
+                        obj = JSON.parse(contents);
+                    }
+                    response.result = obj;
+                }
+                response.headers = res.message.headers;
+            }
+            catch (err) {
+                // Invalid resource (contents not json);  leaving result obj null
+            }
+            // note that 3xx redirects are handled by the http layer.
+            if (statusCode > 299) {
+                let msg;
+                // if exception/error in body, attempt to get better error
+                if (obj && obj.message) {
+                    msg = obj.message;
+                }
+                else if (contents && contents.length > 0) {
+                    // it may be the case that the exception is in the body message as string
+                    msg = contents;
+                }
+                else {
+                    msg = 'Failed request: (' + statusCode + ')';
+                }
+                let err = new HttpClientError(msg, statusCode);
+                err.result = response.result;
+                reject(err);
+            }
+            else {
+                resolve(response);
+            }
+        });
+    }
+}
+exports.HttpClient = HttpClient;
+});
+
+unwrapExports(httpClient);
+var httpClient_1 = httpClient.HttpCodes;
+var httpClient_2 = httpClient.Headers;
+var httpClient_3 = httpClient.MediaTypes;
+var httpClient_4 = httpClient.getProxyUrl;
+var httpClient_5 = httpClient.HttpClientError;
+var httpClient_6 = httpClient.HttpClientResponse;
+var httpClient_7 = httpClient.isHttps;
+var httpClient_8 = httpClient.HttpClient;
+
+var utils = createCommonjsModule(function (module, exports) {
+var __createBinding = (commonjsGlobal && commonjsGlobal.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (commonjsGlobal && commonjsGlobal.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (commonjsGlobal && commonjsGlobal.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getApiBaseUrl = exports.getProxyAgent = exports.getAuthString = void 0;
+const httpClient$1 = __importStar(httpClient);
+function getAuthString(token, options) {
+    if (!token && !options.auth) {
+        throw new Error('Parameter token or opts.auth is required');
+    }
+    else if (token && options.auth) {
+        throw new Error('Parameters token and opts.auth may not both be specified');
+    }
+    return typeof options.auth === 'string' ? options.auth : `token ${token}`;
+}
+exports.getAuthString = getAuthString;
+function getProxyAgent(destinationUrl) {
+    const hc = new httpClient$1.HttpClient();
+    return hc.getAgent(destinationUrl);
+}
+exports.getProxyAgent = getProxyAgent;
+function getApiBaseUrl() {
+    return process.env['GITHUB_API_URL'] || 'https://api.github.com';
+}
+exports.getApiBaseUrl = getApiBaseUrl;
+
+});
+
+unwrapExports(utils);
+var utils_1 = utils.getApiBaseUrl;
+var utils_2 = utils.getProxyAgent;
+var utils_3 = utils.getAuthString;
+
+var distNode = createCommonjsModule(function (module, exports) {
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+function getUserAgent() {
+  if (typeof navigator === "object" && "userAgent" in navigator) {
+    return navigator.userAgent;
+  }
+
+  if (typeof process === "object" && "version" in process) {
+    return `Node.js/${process.version.substr(1)} (${process.platform}; ${process.arch})`;
+  }
+
+  return "<environment undetectable>";
+}
+
+exports.getUserAgent = getUserAgent;
+
+});
+
+unwrapExports(distNode);
+var distNode_1 = distNode.getUserAgent;
+
+var register_1 = register;
+
+function register (state, name, method, options) {
+  if (typeof method !== 'function') {
+    throw new Error('method for before hook must be a function')
+  }
+
+  if (!options) {
+    options = {};
+  }
+
+  if (Array.isArray(name)) {
+    return name.reverse().reduce(function (callback, name) {
+      return register.bind(null, state, name, callback, options)
+    }, method)()
+  }
+
+  return Promise.resolve()
+    .then(function () {
+      if (!state.registry[name]) {
+        return method(options)
+      }
+
+      return (state.registry[name]).reduce(function (method, registered) {
+        return registered.hook.bind(null, method, options)
+      }, method)()
+    })
+}
+
+var add = addHook;
+
+function addHook (state, kind, name, hook) {
+  var orig = hook;
+  if (!state.registry[name]) {
+    state.registry[name] = [];
+  }
+
+  if (kind === 'before') {
+    hook = function (method, options) {
+      return Promise.resolve()
+        .then(orig.bind(null, options))
+        .then(method.bind(null, options))
+    };
+  }
+
+  if (kind === 'after') {
+    hook = function (method, options) {
+      var result;
+      return Promise.resolve()
+        .then(method.bind(null, options))
+        .then(function (result_) {
+          result = result_;
+          return orig(result, options)
+        })
+        .then(function () {
+          return result
+        })
+    };
+  }
+
+  if (kind === 'error') {
+    hook = function (method, options) {
+      return Promise.resolve()
+        .then(method.bind(null, options))
+        .catch(function (error) {
+          return orig(error, options)
+        })
+    };
+  }
+
+  state.registry[name].push({
+    hook: hook,
+    orig: orig
+  });
+}
+
+var remove = removeHook;
+
+function removeHook (state, name, method) {
+  if (!state.registry[name]) {
+    return
+  }
+
+  var index = state.registry[name]
+    .map(function (registered) { return registered.orig })
+    .indexOf(method);
+
+  if (index === -1) {
+    return
+  }
+
+  state.registry[name].splice(index, 1);
+}
+
+// bind with array of arguments: https://stackoverflow.com/a/21792913
+var bind = Function.bind;
+var bindable = bind.bind(bind);
+
+function bindApi (hook, state, name) {
+  var removeHookRef = bindable(remove, null).apply(null, name ? [state, name] : [state]);
+  hook.api = { remove: removeHookRef };
+  hook.remove = removeHookRef
+
+  ;['before', 'error', 'after', 'wrap'].forEach(function (kind) {
+    var args = name ? [state, kind, name] : [state, kind];
+    hook[kind] = hook.api[kind] = bindable(add, null).apply(null, args);
+  });
+}
+
+function HookSingular () {
+  var singularHookName = 'h';
+  var singularHookState = {
+    registry: {}
+  };
+  var singularHook = register_1.bind(null, singularHookState, singularHookName);
+  bindApi(singularHook, singularHookState, singularHookName);
+  return singularHook
+}
+
+function HookCollection () {
+  var state = {
+    registry: {}
+  };
+
+  var hook = register_1.bind(null, state);
+  bindApi(hook, state);
+
+  return hook
+}
+
+var collectionHookDeprecationMessageDisplayed = false;
+function Hook () {
+  if (!collectionHookDeprecationMessageDisplayed) {
+    console.warn('[before-after-hook]: "Hook()" repurposing warning, use "Hook.Collection()". Read more: https://git.io/upgrade-before-after-hook-to-1.4');
+    collectionHookDeprecationMessageDisplayed = true;
+  }
+  return HookCollection()
+}
+
+Hook.Singular = HookSingular.bind();
+Hook.Collection = HookCollection.bind();
+
+var beforeAfterHook = Hook;
+// expose constructors as a named property for TypeScript
+var Hook_1 = Hook;
+var Singular = Hook.Singular;
+var Collection = Hook.Collection;
+beforeAfterHook.Hook = Hook_1;
+beforeAfterHook.Singular = Singular;
+beforeAfterHook.Collection = Collection;
+
+var isPlainObject_1 = createCommonjsModule(function (module, exports) {
+
+Object.defineProperty(exports, '__esModule', { value: true });
 
 /*!
  * is-plain-object <https://github.com/jonschlinkert/is-plain-object>
@@ -335,23 +1482,22 @@ function isObject(val) {
  * Released under the MIT License.
  */
 
-function isObjectObject(o) {
-  return isObject(o) === true
-    && Object.prototype.toString.call(o) === '[object Object]';
+function isObject(o) {
+  return Object.prototype.toString.call(o) === '[object Object]';
 }
 
 function isPlainObject(o) {
   var ctor,prot;
 
-  if (isObjectObject(o) === false) return false;
+  if (isObject(o) === false) return false;
 
   // If has modified constructor
   ctor = o.constructor;
-  if (typeof ctor !== 'function') return false;
+  if (ctor === undefined) return true;
 
   // If has modified prototype
   prot = ctor.prototype;
-  if (isObjectObject(prot) === false) return false;
+  if (isObject(prot) === false) return false;
 
   // If constructor does not have an Object-specific method
   if (prot.hasOwnProperty('isPrototypeOf') === false) {
@@ -362,3451 +1508,17 @@ function isPlainObject(o) {
   return true;
 }
 
-var index_cjs = isPlainObject;
-
-const nameMap = new Map([
-	[19, 'Catalina'],
-	[18, 'Mojave'],
-	[17, 'High Sierra'],
-	[16, 'Sierra'],
-	[15, 'El Capitan'],
-	[14, 'Yosemite'],
-	[13, 'Mavericks'],
-	[12, 'Mountain Lion'],
-	[11, 'Lion'],
-	[10, 'Snow Leopard'],
-	[9, 'Leopard'],
-	[8, 'Tiger'],
-	[7, 'Panther'],
-	[6, 'Jaguar'],
-	[5, 'Puma']
-]);
-
-const macosRelease = release => {
-	release = Number((release || os.release()).split('.')[0]);
-	return {
-		name: nameMap.get(release),
-		version: '10.' + (release - 4)
-	};
-};
-
-var macosRelease_1 = macosRelease;
-// TODO: remove this in the next major version
-var default_1 = macosRelease;
-macosRelease_1.default = default_1;
-
-/**
- * Tries to execute a function and discards any error that occurs.
- * @param {Function} fn - Function that might or might not throw an error.
- * @returns {?*} Return-value of the function when no error occurred.
- */
-var src = function(fn) {
-
-	try { return fn() } catch (e) {}
-
-};
-
-var windows = isexe;
-isexe.sync = sync;
-
-
-
-function checkPathExt (path, options) {
-  var pathext = options.pathExt !== undefined ?
-    options.pathExt : process.env.PATHEXT;
-
-  if (!pathext) {
-    return true
-  }
-
-  pathext = pathext.split(';');
-  if (pathext.indexOf('') !== -1) {
-    return true
-  }
-  for (var i = 0; i < pathext.length; i++) {
-    var p = pathext[i].toLowerCase();
-    if (p && path.substr(-p.length).toLowerCase() === p) {
-      return true
-    }
-  }
-  return false
-}
-
-function checkStat (stat, path, options) {
-  if (!stat.isSymbolicLink() && !stat.isFile()) {
-    return false
-  }
-  return checkPathExt(path, options)
-}
-
-function isexe (path, options, cb) {
-  fs__default.stat(path, function (er, stat) {
-    cb(er, er ? false : checkStat(stat, path, options));
-  });
-}
-
-function sync (path, options) {
-  return checkStat(fs__default.statSync(path), path, options)
-}
-
-var mode = isexe$1;
-isexe$1.sync = sync$1;
-
-
-
-function isexe$1 (path, options, cb) {
-  fs__default.stat(path, function (er, stat) {
-    cb(er, er ? false : checkStat$1(stat, options));
-  });
-}
-
-function sync$1 (path, options) {
-  return checkStat$1(fs__default.statSync(path), options)
-}
-
-function checkStat$1 (stat, options) {
-  return stat.isFile() && checkMode(stat, options)
-}
-
-function checkMode (stat, options) {
-  var mod = stat.mode;
-  var uid = stat.uid;
-  var gid = stat.gid;
-
-  var myUid = options.uid !== undefined ?
-    options.uid : process.getuid && process.getuid();
-  var myGid = options.gid !== undefined ?
-    options.gid : process.getgid && process.getgid();
-
-  var u = parseInt('100', 8);
-  var g = parseInt('010', 8);
-  var o = parseInt('001', 8);
-  var ug = u | g;
-
-  var ret = (mod & o) ||
-    (mod & g) && gid === myGid ||
-    (mod & u) && uid === myUid ||
-    (mod & ug) && myUid === 0;
-
-  return ret
-}
-
-var core$2;
-if (process.platform === 'win32' || commonjsGlobal.TESTING_WINDOWS) {
-  core$2 = windows;
-} else {
-  core$2 = mode;
-}
-
-var isexe_1 = isexe$2;
-isexe$2.sync = sync$2;
-
-function isexe$2 (path, options, cb) {
-  if (typeof options === 'function') {
-    cb = options;
-    options = {};
-  }
-
-  if (!cb) {
-    if (typeof Promise !== 'function') {
-      throw new TypeError('callback not provided')
-    }
-
-    return new Promise(function (resolve, reject) {
-      isexe$2(path, options || {}, function (er, is) {
-        if (er) {
-          reject(er);
-        } else {
-          resolve(is);
-        }
-      });
-    })
-  }
-
-  core$2(path, options || {}, function (er, is) {
-    // ignore EACCES because that just means we aren't allowed to run it
-    if (er) {
-      if (er.code === 'EACCES' || options && options.ignoreErrors) {
-        er = null;
-        is = false;
-      }
-    }
-    cb(er, is);
-  });
-}
-
-function sync$2 (path, options) {
-  // my kingdom for a filtered catch
-  try {
-    return core$2.sync(path, options || {})
-  } catch (er) {
-    if (options && options.ignoreErrors || er.code === 'EACCES') {
-      return false
-    } else {
-      throw er
-    }
-  }
-}
-
-var which_1 = which;
-which.sync = whichSync;
-
-var isWindows = process.platform === 'win32' ||
-    process.env.OSTYPE === 'cygwin' ||
-    process.env.OSTYPE === 'msys';
-
-
-var COLON = isWindows ? ';' : ':';
-
-
-function getNotFoundError (cmd) {
-  var er = new Error('not found: ' + cmd);
-  er.code = 'ENOENT';
-
-  return er
-}
-
-function getPathInfo (cmd, opt) {
-  var colon = opt.colon || COLON;
-  var pathEnv = opt.path || process.env.PATH || '';
-  var pathExt = [''];
-
-  pathEnv = pathEnv.split(colon);
-
-  var pathExtExe = '';
-  if (isWindows) {
-    pathEnv.unshift(process.cwd());
-    pathExtExe = (opt.pathExt || process.env.PATHEXT || '.EXE;.CMD;.BAT;.COM');
-    pathExt = pathExtExe.split(colon);
-
-
-    // Always test the cmd itself first.  isexe will check to make sure
-    // it's found in the pathExt set.
-    if (cmd.indexOf('.') !== -1 && pathExt[0] !== '')
-      pathExt.unshift('');
-  }
-
-  // If it has a slash, then we don't bother searching the pathenv.
-  // just check the file itself, and that's it.
-  if (cmd.match(/\//) || isWindows && cmd.match(/\\/))
-    pathEnv = [''];
-
-  return {
-    env: pathEnv,
-    ext: pathExt,
-    extExe: pathExtExe
-  }
-}
-
-function which (cmd, opt, cb) {
-  if (typeof opt === 'function') {
-    cb = opt;
-    opt = {};
-  }
-
-  var info = getPathInfo(cmd, opt);
-  var pathEnv = info.env;
-  var pathExt = info.ext;
-  var pathExtExe = info.extExe;
-  var found = []
-
-  ;(function F (i, l) {
-    if (i === l) {
-      if (opt.all && found.length)
-        return cb(null, found)
-      else
-        return cb(getNotFoundError(cmd))
-    }
-
-    var pathPart = pathEnv[i];
-    if (pathPart.charAt(0) === '"' && pathPart.slice(-1) === '"')
-      pathPart = pathPart.slice(1, -1);
-
-    var p = path.join(pathPart, cmd);
-    if (!pathPart && (/^\.[\\\/]/).test(cmd)) {
-      p = cmd.slice(0, 2) + p;
-    }
-(function E (ii, ll) {
-      if (ii === ll) return F(i + 1, l)
-      var ext = pathExt[ii];
-      isexe_1(p + ext, { pathExt: pathExtExe }, function (er, is) {
-        if (!er && is) {
-          if (opt.all)
-            found.push(p + ext);
-          else
-            return cb(null, p + ext)
-        }
-        return E(ii + 1, ll)
-      });
-    })(0, pathExt.length);
-  })(0, pathEnv.length);
-}
-
-function whichSync (cmd, opt) {
-  opt = opt || {};
-
-  var info = getPathInfo(cmd, opt);
-  var pathEnv = info.env;
-  var pathExt = info.ext;
-  var pathExtExe = info.extExe;
-  var found = [];
-
-  for (var i = 0, l = pathEnv.length; i < l; i ++) {
-    var pathPart = pathEnv[i];
-    if (pathPart.charAt(0) === '"' && pathPart.slice(-1) === '"')
-      pathPart = pathPart.slice(1, -1);
-
-    var p = path.join(pathPart, cmd);
-    if (!pathPart && /^\.[\\\/]/.test(cmd)) {
-      p = cmd.slice(0, 2) + p;
-    }
-    for (var j = 0, ll = pathExt.length; j < ll; j ++) {
-      var cur = p + pathExt[j];
-      var is;
-      try {
-        is = isexe_1.sync(cur, { pathExt: pathExtExe });
-        if (is) {
-          if (opt.all)
-            found.push(cur);
-          else
-            return cur
-        }
-      } catch (ex) {}
-    }
-  }
-
-  if (opt.all && found.length)
-    return found
-
-  if (opt.nothrow)
-    return null
-
-  throw getNotFoundError(cmd)
-}
-
-var pathKey = opts => {
-	opts = opts || {};
-
-	const env = opts.env || process.env;
-	const platform = opts.platform || process.platform;
-
-	if (platform !== 'win32') {
-		return 'PATH';
-	}
-
-	return Object.keys(env).find(x => x.toUpperCase() === 'PATH') || 'Path';
-};
-
-const pathKey$1 = pathKey();
-
-function resolveCommandAttempt(parsed, withoutPathExt) {
-    const cwd = process.cwd();
-    const hasCustomCwd = parsed.options.cwd != null;
-
-    // If a custom `cwd` was specified, we need to change the process cwd
-    // because `which` will do stat calls but does not support a custom cwd
-    if (hasCustomCwd) {
-        try {
-            process.chdir(parsed.options.cwd);
-        } catch (err) {
-            /* Empty */
-        }
-    }
-
-    let resolved;
-
-    try {
-        resolved = which_1.sync(parsed.command, {
-            path: (parsed.options.env || process.env)[pathKey$1],
-            pathExt: withoutPathExt ? path.delimiter : undefined,
-        });
-    } catch (e) {
-        /* Empty */
-    } finally {
-        process.chdir(cwd);
-    }
-
-    // If we successfully resolved, ensure that an absolute path is returned
-    // Note that when a custom `cwd` was used, we need to resolve to an absolute path based on it
-    if (resolved) {
-        resolved = path.resolve(hasCustomCwd ? parsed.options.cwd : '', resolved);
-    }
-
-    return resolved;
-}
-
-function resolveCommand(parsed) {
-    return resolveCommandAttempt(parsed) || resolveCommandAttempt(parsed, true);
-}
-
-var resolveCommand_1 = resolveCommand;
-
-// See http://www.robvanderwoude.com/escapechars.php
-const metaCharsRegExp = /([()\][%!^"`<>&|;, *?])/g;
-
-function escapeCommand(arg) {
-    // Escape meta chars
-    arg = arg.replace(metaCharsRegExp, '^$1');
-
-    return arg;
-}
-
-function escapeArgument(arg, doubleEscapeMetaChars) {
-    // Convert to string
-    arg = `${arg}`;
-
-    // Algorithm below is based on https://qntm.org/cmd
-
-    // Sequence of backslashes followed by a double quote:
-    // double up all the backslashes and escape the double quote
-    arg = arg.replace(/(\\*)"/g, '$1$1\\"');
-
-    // Sequence of backslashes followed by the end of the string
-    // (which will become a double quote later):
-    // double up all the backslashes
-    arg = arg.replace(/(\\*)$/, '$1$1');
-
-    // All other backslashes occur literally
-
-    // Quote the whole thing:
-    arg = `"${arg}"`;
-
-    // Escape meta chars
-    arg = arg.replace(metaCharsRegExp, '^$1');
-
-    // Double escape meta chars if necessary
-    if (doubleEscapeMetaChars) {
-        arg = arg.replace(metaCharsRegExp, '^$1');
-    }
-
-    return arg;
-}
-
-var command$1 = escapeCommand;
-var argument = escapeArgument;
-
-var _escape = {
-	command: command$1,
-	argument: argument
-};
-
-var shebangRegex = /^#!.*/;
-
-var shebangCommand = function (str) {
-	var match = str.match(shebangRegex);
-
-	if (!match) {
-		return null;
-	}
-
-	var arr = match[0].replace(/#! ?/, '').split(' ');
-	var bin = arr[0].split('/').pop();
-	var arg = arr[1];
-
-	return (bin === 'env' ?
-		arg :
-		bin + (arg ? ' ' + arg : '')
-	);
-};
-
-function readShebang(command) {
-    // Read the first 150 bytes from the file
-    const size = 150;
-    let buffer;
-
-    if (Buffer.alloc) {
-        // Node.js v4.5+ / v5.10+
-        buffer = Buffer.alloc(size);
-    } else {
-        // Old Node.js API
-        buffer = new Buffer(size);
-        buffer.fill(0); // zero-fill
-    }
-
-    let fd;
-
-    try {
-        fd = fs__default.openSync(command, 'r');
-        fs__default.readSync(fd, buffer, 0, size, 0);
-        fs__default.closeSync(fd);
-    } catch (e) { /* Empty */ }
-
-    // Attempt to extract shebang (null is returned if not a shebang)
-    return shebangCommand(buffer.toString());
-}
-
-var readShebang_1 = readShebang;
-
-var semver = createCommonjsModule(function (module, exports) {
-exports = module.exports = SemVer;
-
-var debug;
-/* istanbul ignore next */
-if (typeof process === 'object' &&
-    process.env &&
-    process.env.NODE_DEBUG &&
-    /\bsemver\b/i.test(process.env.NODE_DEBUG)) {
-  debug = function () {
-    var args = Array.prototype.slice.call(arguments, 0);
-    args.unshift('SEMVER');
-    console.log.apply(console, args);
-  };
-} else {
-  debug = function () {};
-}
-
-// Note: this is the semver.org version of the spec that it implements
-// Not necessarily the package version of this code.
-exports.SEMVER_SPEC_VERSION = '2.0.0';
-
-var MAX_LENGTH = 256;
-var MAX_SAFE_INTEGER = Number.MAX_SAFE_INTEGER ||
-  /* istanbul ignore next */ 9007199254740991;
-
-// Max safe segment length for coercion.
-var MAX_SAFE_COMPONENT_LENGTH = 16;
-
-// The actual regexps go on exports.re
-var re = exports.re = [];
-var src = exports.src = [];
-var R = 0;
-
-// The following Regular Expressions can be used for tokenizing,
-// validating, and parsing SemVer version strings.
-
-// ## Numeric Identifier
-// A single `0`, or a non-zero digit followed by zero or more digits.
-
-var NUMERICIDENTIFIER = R++;
-src[NUMERICIDENTIFIER] = '0|[1-9]\\d*';
-var NUMERICIDENTIFIERLOOSE = R++;
-src[NUMERICIDENTIFIERLOOSE] = '[0-9]+';
-
-// ## Non-numeric Identifier
-// Zero or more digits, followed by a letter or hyphen, and then zero or
-// more letters, digits, or hyphens.
-
-var NONNUMERICIDENTIFIER = R++;
-src[NONNUMERICIDENTIFIER] = '\\d*[a-zA-Z-][a-zA-Z0-9-]*';
-
-// ## Main Version
-// Three dot-separated numeric identifiers.
-
-var MAINVERSION = R++;
-src[MAINVERSION] = '(' + src[NUMERICIDENTIFIER] + ')\\.' +
-                   '(' + src[NUMERICIDENTIFIER] + ')\\.' +
-                   '(' + src[NUMERICIDENTIFIER] + ')';
-
-var MAINVERSIONLOOSE = R++;
-src[MAINVERSIONLOOSE] = '(' + src[NUMERICIDENTIFIERLOOSE] + ')\\.' +
-                        '(' + src[NUMERICIDENTIFIERLOOSE] + ')\\.' +
-                        '(' + src[NUMERICIDENTIFIERLOOSE] + ')';
-
-// ## Pre-release Version Identifier
-// A numeric identifier, or a non-numeric identifier.
-
-var PRERELEASEIDENTIFIER = R++;
-src[PRERELEASEIDENTIFIER] = '(?:' + src[NUMERICIDENTIFIER] +
-                            '|' + src[NONNUMERICIDENTIFIER] + ')';
-
-var PRERELEASEIDENTIFIERLOOSE = R++;
-src[PRERELEASEIDENTIFIERLOOSE] = '(?:' + src[NUMERICIDENTIFIERLOOSE] +
-                                 '|' + src[NONNUMERICIDENTIFIER] + ')';
-
-// ## Pre-release Version
-// Hyphen, followed by one or more dot-separated pre-release version
-// identifiers.
-
-var PRERELEASE = R++;
-src[PRERELEASE] = '(?:-(' + src[PRERELEASEIDENTIFIER] +
-                  '(?:\\.' + src[PRERELEASEIDENTIFIER] + ')*))';
-
-var PRERELEASELOOSE = R++;
-src[PRERELEASELOOSE] = '(?:-?(' + src[PRERELEASEIDENTIFIERLOOSE] +
-                       '(?:\\.' + src[PRERELEASEIDENTIFIERLOOSE] + ')*))';
-
-// ## Build Metadata Identifier
-// Any combination of digits, letters, or hyphens.
-
-var BUILDIDENTIFIER = R++;
-src[BUILDIDENTIFIER] = '[0-9A-Za-z-]+';
-
-// ## Build Metadata
-// Plus sign, followed by one or more period-separated build metadata
-// identifiers.
-
-var BUILD = R++;
-src[BUILD] = '(?:\\+(' + src[BUILDIDENTIFIER] +
-             '(?:\\.' + src[BUILDIDENTIFIER] + ')*))';
-
-// ## Full Version String
-// A main version, followed optionally by a pre-release version and
-// build metadata.
-
-// Note that the only major, minor, patch, and pre-release sections of
-// the version string are capturing groups.  The build metadata is not a
-// capturing group, because it should not ever be used in version
-// comparison.
-
-var FULL = R++;
-var FULLPLAIN = 'v?' + src[MAINVERSION] +
-                src[PRERELEASE] + '?' +
-                src[BUILD] + '?';
-
-src[FULL] = '^' + FULLPLAIN + '$';
-
-// like full, but allows v1.2.3 and =1.2.3, which people do sometimes.
-// also, 1.0.0alpha1 (prerelease without the hyphen) which is pretty
-// common in the npm registry.
-var LOOSEPLAIN = '[v=\\s]*' + src[MAINVERSIONLOOSE] +
-                 src[PRERELEASELOOSE] + '?' +
-                 src[BUILD] + '?';
-
-var LOOSE = R++;
-src[LOOSE] = '^' + LOOSEPLAIN + '$';
-
-var GTLT = R++;
-src[GTLT] = '((?:<|>)?=?)';
-
-// Something like "2.*" or "1.2.x".
-// Note that "x.x" is a valid xRange identifer, meaning "any version"
-// Only the first item is strictly required.
-var XRANGEIDENTIFIERLOOSE = R++;
-src[XRANGEIDENTIFIERLOOSE] = src[NUMERICIDENTIFIERLOOSE] + '|x|X|\\*';
-var XRANGEIDENTIFIER = R++;
-src[XRANGEIDENTIFIER] = src[NUMERICIDENTIFIER] + '|x|X|\\*';
-
-var XRANGEPLAIN = R++;
-src[XRANGEPLAIN] = '[v=\\s]*(' + src[XRANGEIDENTIFIER] + ')' +
-                   '(?:\\.(' + src[XRANGEIDENTIFIER] + ')' +
-                   '(?:\\.(' + src[XRANGEIDENTIFIER] + ')' +
-                   '(?:' + src[PRERELEASE] + ')?' +
-                   src[BUILD] + '?' +
-                   ')?)?';
-
-var XRANGEPLAINLOOSE = R++;
-src[XRANGEPLAINLOOSE] = '[v=\\s]*(' + src[XRANGEIDENTIFIERLOOSE] + ')' +
-                        '(?:\\.(' + src[XRANGEIDENTIFIERLOOSE] + ')' +
-                        '(?:\\.(' + src[XRANGEIDENTIFIERLOOSE] + ')' +
-                        '(?:' + src[PRERELEASELOOSE] + ')?' +
-                        src[BUILD] + '?' +
-                        ')?)?';
-
-var XRANGE = R++;
-src[XRANGE] = '^' + src[GTLT] + '\\s*' + src[XRANGEPLAIN] + '$';
-var XRANGELOOSE = R++;
-src[XRANGELOOSE] = '^' + src[GTLT] + '\\s*' + src[XRANGEPLAINLOOSE] + '$';
-
-// Coercion.
-// Extract anything that could conceivably be a part of a valid semver
-var COERCE = R++;
-src[COERCE] = '(?:^|[^\\d])' +
-              '(\\d{1,' + MAX_SAFE_COMPONENT_LENGTH + '})' +
-              '(?:\\.(\\d{1,' + MAX_SAFE_COMPONENT_LENGTH + '}))?' +
-              '(?:\\.(\\d{1,' + MAX_SAFE_COMPONENT_LENGTH + '}))?' +
-              '(?:$|[^\\d])';
-
-// Tilde ranges.
-// Meaning is "reasonably at or greater than"
-var LONETILDE = R++;
-src[LONETILDE] = '(?:~>?)';
-
-var TILDETRIM = R++;
-src[TILDETRIM] = '(\\s*)' + src[LONETILDE] + '\\s+';
-re[TILDETRIM] = new RegExp(src[TILDETRIM], 'g');
-var tildeTrimReplace = '$1~';
-
-var TILDE = R++;
-src[TILDE] = '^' + src[LONETILDE] + src[XRANGEPLAIN] + '$';
-var TILDELOOSE = R++;
-src[TILDELOOSE] = '^' + src[LONETILDE] + src[XRANGEPLAINLOOSE] + '$';
-
-// Caret ranges.
-// Meaning is "at least and backwards compatible with"
-var LONECARET = R++;
-src[LONECARET] = '(?:\\^)';
-
-var CARETTRIM = R++;
-src[CARETTRIM] = '(\\s*)' + src[LONECARET] + '\\s+';
-re[CARETTRIM] = new RegExp(src[CARETTRIM], 'g');
-var caretTrimReplace = '$1^';
-
-var CARET = R++;
-src[CARET] = '^' + src[LONECARET] + src[XRANGEPLAIN] + '$';
-var CARETLOOSE = R++;
-src[CARETLOOSE] = '^' + src[LONECARET] + src[XRANGEPLAINLOOSE] + '$';
-
-// A simple gt/lt/eq thing, or just "" to indicate "any version"
-var COMPARATORLOOSE = R++;
-src[COMPARATORLOOSE] = '^' + src[GTLT] + '\\s*(' + LOOSEPLAIN + ')$|^$';
-var COMPARATOR = R++;
-src[COMPARATOR] = '^' + src[GTLT] + '\\s*(' + FULLPLAIN + ')$|^$';
-
-// An expression to strip any whitespace between the gtlt and the thing
-// it modifies, so that `> 1.2.3` ==> `>1.2.3`
-var COMPARATORTRIM = R++;
-src[COMPARATORTRIM] = '(\\s*)' + src[GTLT] +
-                      '\\s*(' + LOOSEPLAIN + '|' + src[XRANGEPLAIN] + ')';
-
-// this one has to use the /g flag
-re[COMPARATORTRIM] = new RegExp(src[COMPARATORTRIM], 'g');
-var comparatorTrimReplace = '$1$2$3';
-
-// Something like `1.2.3 - 1.2.4`
-// Note that these all use the loose form, because they'll be
-// checked against either the strict or loose comparator form
-// later.
-var HYPHENRANGE = R++;
-src[HYPHENRANGE] = '^\\s*(' + src[XRANGEPLAIN] + ')' +
-                   '\\s+-\\s+' +
-                   '(' + src[XRANGEPLAIN] + ')' +
-                   '\\s*$';
-
-var HYPHENRANGELOOSE = R++;
-src[HYPHENRANGELOOSE] = '^\\s*(' + src[XRANGEPLAINLOOSE] + ')' +
-                        '\\s+-\\s+' +
-                        '(' + src[XRANGEPLAINLOOSE] + ')' +
-                        '\\s*$';
-
-// Star ranges basically just allow anything at all.
-var STAR = R++;
-src[STAR] = '(<|>)?=?\\s*\\*';
-
-// Compile to actual regexp objects.
-// All are flag-free, unless they were created above with a flag.
-for (var i = 0; i < R; i++) {
-  debug(i, src[i]);
-  if (!re[i]) {
-    re[i] = new RegExp(src[i]);
-  }
-}
-
-exports.parse = parse;
-function parse (version, options) {
-  if (!options || typeof options !== 'object') {
-    options = {
-      loose: !!options,
-      includePrerelease: false
-    };
-  }
-
-  if (version instanceof SemVer) {
-    return version
-  }
-
-  if (typeof version !== 'string') {
-    return null
-  }
-
-  if (version.length > MAX_LENGTH) {
-    return null
-  }
-
-  var r = options.loose ? re[LOOSE] : re[FULL];
-  if (!r.test(version)) {
-    return null
-  }
-
-  try {
-    return new SemVer(version, options)
-  } catch (er) {
-    return null
-  }
-}
-
-exports.valid = valid;
-function valid (version, options) {
-  var v = parse(version, options);
-  return v ? v.version : null
-}
-
-exports.clean = clean;
-function clean (version, options) {
-  var s = parse(version.trim().replace(/^[=v]+/, ''), options);
-  return s ? s.version : null
-}
-
-exports.SemVer = SemVer;
-
-function SemVer (version, options) {
-  if (!options || typeof options !== 'object') {
-    options = {
-      loose: !!options,
-      includePrerelease: false
-    };
-  }
-  if (version instanceof SemVer) {
-    if (version.loose === options.loose) {
-      return version
-    } else {
-      version = version.version;
-    }
-  } else if (typeof version !== 'string') {
-    throw new TypeError('Invalid Version: ' + version)
-  }
-
-  if (version.length > MAX_LENGTH) {
-    throw new TypeError('version is longer than ' + MAX_LENGTH + ' characters')
-  }
-
-  if (!(this instanceof SemVer)) {
-    return new SemVer(version, options)
-  }
-
-  debug('SemVer', version, options);
-  this.options = options;
-  this.loose = !!options.loose;
-
-  var m = version.trim().match(options.loose ? re[LOOSE] : re[FULL]);
-
-  if (!m) {
-    throw new TypeError('Invalid Version: ' + version)
-  }
-
-  this.raw = version;
-
-  // these are actually numbers
-  this.major = +m[1];
-  this.minor = +m[2];
-  this.patch = +m[3];
-
-  if (this.major > MAX_SAFE_INTEGER || this.major < 0) {
-    throw new TypeError('Invalid major version')
-  }
-
-  if (this.minor > MAX_SAFE_INTEGER || this.minor < 0) {
-    throw new TypeError('Invalid minor version')
-  }
-
-  if (this.patch > MAX_SAFE_INTEGER || this.patch < 0) {
-    throw new TypeError('Invalid patch version')
-  }
-
-  // numberify any prerelease numeric ids
-  if (!m[4]) {
-    this.prerelease = [];
-  } else {
-    this.prerelease = m[4].split('.').map(function (id) {
-      if (/^[0-9]+$/.test(id)) {
-        var num = +id;
-        if (num >= 0 && num < MAX_SAFE_INTEGER) {
-          return num
-        }
-      }
-      return id
-    });
-  }
-
-  this.build = m[5] ? m[5].split('.') : [];
-  this.format();
-}
-
-SemVer.prototype.format = function () {
-  this.version = this.major + '.' + this.minor + '.' + this.patch;
-  if (this.prerelease.length) {
-    this.version += '-' + this.prerelease.join('.');
-  }
-  return this.version
-};
-
-SemVer.prototype.toString = function () {
-  return this.version
-};
-
-SemVer.prototype.compare = function (other) {
-  debug('SemVer.compare', this.version, this.options, other);
-  if (!(other instanceof SemVer)) {
-    other = new SemVer(other, this.options);
-  }
-
-  return this.compareMain(other) || this.comparePre(other)
-};
-
-SemVer.prototype.compareMain = function (other) {
-  if (!(other instanceof SemVer)) {
-    other = new SemVer(other, this.options);
-  }
-
-  return compareIdentifiers(this.major, other.major) ||
-         compareIdentifiers(this.minor, other.minor) ||
-         compareIdentifiers(this.patch, other.patch)
-};
-
-SemVer.prototype.comparePre = function (other) {
-  if (!(other instanceof SemVer)) {
-    other = new SemVer(other, this.options);
-  }
-
-  // NOT having a prerelease is > having one
-  if (this.prerelease.length && !other.prerelease.length) {
-    return -1
-  } else if (!this.prerelease.length && other.prerelease.length) {
-    return 1
-  } else if (!this.prerelease.length && !other.prerelease.length) {
-    return 0
-  }
-
-  var i = 0;
-  do {
-    var a = this.prerelease[i];
-    var b = other.prerelease[i];
-    debug('prerelease compare', i, a, b);
-    if (a === undefined && b === undefined) {
-      return 0
-    } else if (b === undefined) {
-      return 1
-    } else if (a === undefined) {
-      return -1
-    } else if (a === b) {
-      continue
-    } else {
-      return compareIdentifiers(a, b)
-    }
-  } while (++i)
-};
-
-// preminor will bump the version up to the next minor release, and immediately
-// down to pre-release. premajor and prepatch work the same way.
-SemVer.prototype.inc = function (release, identifier) {
-  switch (release) {
-    case 'premajor':
-      this.prerelease.length = 0;
-      this.patch = 0;
-      this.minor = 0;
-      this.major++;
-      this.inc('pre', identifier);
-      break
-    case 'preminor':
-      this.prerelease.length = 0;
-      this.patch = 0;
-      this.minor++;
-      this.inc('pre', identifier);
-      break
-    case 'prepatch':
-      // If this is already a prerelease, it will bump to the next version
-      // drop any prereleases that might already exist, since they are not
-      // relevant at this point.
-      this.prerelease.length = 0;
-      this.inc('patch', identifier);
-      this.inc('pre', identifier);
-      break
-    // If the input is a non-prerelease version, this acts the same as
-    // prepatch.
-    case 'prerelease':
-      if (this.prerelease.length === 0) {
-        this.inc('patch', identifier);
-      }
-      this.inc('pre', identifier);
-      break
-
-    case 'major':
-      // If this is a pre-major version, bump up to the same major version.
-      // Otherwise increment major.
-      // 1.0.0-5 bumps to 1.0.0
-      // 1.1.0 bumps to 2.0.0
-      if (this.minor !== 0 ||
-          this.patch !== 0 ||
-          this.prerelease.length === 0) {
-        this.major++;
-      }
-      this.minor = 0;
-      this.patch = 0;
-      this.prerelease = [];
-      break
-    case 'minor':
-      // If this is a pre-minor version, bump up to the same minor version.
-      // Otherwise increment minor.
-      // 1.2.0-5 bumps to 1.2.0
-      // 1.2.1 bumps to 1.3.0
-      if (this.patch !== 0 || this.prerelease.length === 0) {
-        this.minor++;
-      }
-      this.patch = 0;
-      this.prerelease = [];
-      break
-    case 'patch':
-      // If this is not a pre-release version, it will increment the patch.
-      // If it is a pre-release it will bump up to the same patch version.
-      // 1.2.0-5 patches to 1.2.0
-      // 1.2.0 patches to 1.2.1
-      if (this.prerelease.length === 0) {
-        this.patch++;
-      }
-      this.prerelease = [];
-      break
-    // This probably shouldn't be used publicly.
-    // 1.0.0 "pre" would become 1.0.0-0 which is the wrong direction.
-    case 'pre':
-      if (this.prerelease.length === 0) {
-        this.prerelease = [0];
-      } else {
-        var i = this.prerelease.length;
-        while (--i >= 0) {
-          if (typeof this.prerelease[i] === 'number') {
-            this.prerelease[i]++;
-            i = -2;
-          }
-        }
-        if (i === -1) {
-          // didn't increment anything
-          this.prerelease.push(0);
-        }
-      }
-      if (identifier) {
-        // 1.2.0-beta.1 bumps to 1.2.0-beta.2,
-        // 1.2.0-beta.fooblz or 1.2.0-beta bumps to 1.2.0-beta.0
-        if (this.prerelease[0] === identifier) {
-          if (isNaN(this.prerelease[1])) {
-            this.prerelease = [identifier, 0];
-          }
-        } else {
-          this.prerelease = [identifier, 0];
-        }
-      }
-      break
-
-    default:
-      throw new Error('invalid increment argument: ' + release)
-  }
-  this.format();
-  this.raw = this.version;
-  return this
-};
-
-exports.inc = inc;
-function inc (version, release, loose, identifier) {
-  if (typeof (loose) === 'string') {
-    identifier = loose;
-    loose = undefined;
-  }
-
-  try {
-    return new SemVer(version, loose).inc(release, identifier).version
-  } catch (er) {
-    return null
-  }
-}
-
-exports.diff = diff;
-function diff (version1, version2) {
-  if (eq(version1, version2)) {
-    return null
-  } else {
-    var v1 = parse(version1);
-    var v2 = parse(version2);
-    var prefix = '';
-    if (v1.prerelease.length || v2.prerelease.length) {
-      prefix = 'pre';
-      var defaultResult = 'prerelease';
-    }
-    for (var key in v1) {
-      if (key === 'major' || key === 'minor' || key === 'patch') {
-        if (v1[key] !== v2[key]) {
-          return prefix + key
-        }
-      }
-    }
-    return defaultResult // may be undefined
-  }
-}
-
-exports.compareIdentifiers = compareIdentifiers;
-
-var numeric = /^[0-9]+$/;
-function compareIdentifiers (a, b) {
-  var anum = numeric.test(a);
-  var bnum = numeric.test(b);
-
-  if (anum && bnum) {
-    a = +a;
-    b = +b;
-  }
-
-  return a === b ? 0
-    : (anum && !bnum) ? -1
-    : (bnum && !anum) ? 1
-    : a < b ? -1
-    : 1
-}
-
-exports.rcompareIdentifiers = rcompareIdentifiers;
-function rcompareIdentifiers (a, b) {
-  return compareIdentifiers(b, a)
-}
-
-exports.major = major;
-function major (a, loose) {
-  return new SemVer(a, loose).major
-}
-
-exports.minor = minor;
-function minor (a, loose) {
-  return new SemVer(a, loose).minor
-}
-
-exports.patch = patch;
-function patch (a, loose) {
-  return new SemVer(a, loose).patch
-}
-
-exports.compare = compare;
-function compare (a, b, loose) {
-  return new SemVer(a, loose).compare(new SemVer(b, loose))
-}
-
-exports.compareLoose = compareLoose;
-function compareLoose (a, b) {
-  return compare(a, b, true)
-}
-
-exports.rcompare = rcompare;
-function rcompare (a, b, loose) {
-  return compare(b, a, loose)
-}
-
-exports.sort = sort;
-function sort (list, loose) {
-  return list.sort(function (a, b) {
-    return exports.compare(a, b, loose)
-  })
-}
-
-exports.rsort = rsort;
-function rsort (list, loose) {
-  return list.sort(function (a, b) {
-    return exports.rcompare(a, b, loose)
-  })
-}
-
-exports.gt = gt;
-function gt (a, b, loose) {
-  return compare(a, b, loose) > 0
-}
-
-exports.lt = lt;
-function lt (a, b, loose) {
-  return compare(a, b, loose) < 0
-}
-
-exports.eq = eq;
-function eq (a, b, loose) {
-  return compare(a, b, loose) === 0
-}
-
-exports.neq = neq;
-function neq (a, b, loose) {
-  return compare(a, b, loose) !== 0
-}
-
-exports.gte = gte;
-function gte (a, b, loose) {
-  return compare(a, b, loose) >= 0
-}
-
-exports.lte = lte;
-function lte (a, b, loose) {
-  return compare(a, b, loose) <= 0
-}
-
-exports.cmp = cmp;
-function cmp (a, op, b, loose) {
-  switch (op) {
-    case '===':
-      if (typeof a === 'object')
-        a = a.version;
-      if (typeof b === 'object')
-        b = b.version;
-      return a === b
-
-    case '!==':
-      if (typeof a === 'object')
-        a = a.version;
-      if (typeof b === 'object')
-        b = b.version;
-      return a !== b
-
-    case '':
-    case '=':
-    case '==':
-      return eq(a, b, loose)
-
-    case '!=':
-      return neq(a, b, loose)
-
-    case '>':
-      return gt(a, b, loose)
-
-    case '>=':
-      return gte(a, b, loose)
-
-    case '<':
-      return lt(a, b, loose)
-
-    case '<=':
-      return lte(a, b, loose)
-
-    default:
-      throw new TypeError('Invalid operator: ' + op)
-  }
-}
-
-exports.Comparator = Comparator;
-function Comparator (comp, options) {
-  if (!options || typeof options !== 'object') {
-    options = {
-      loose: !!options,
-      includePrerelease: false
-    };
-  }
-
-  if (comp instanceof Comparator) {
-    if (comp.loose === !!options.loose) {
-      return comp
-    } else {
-      comp = comp.value;
-    }
-  }
-
-  if (!(this instanceof Comparator)) {
-    return new Comparator(comp, options)
-  }
-
-  debug('comparator', comp, options);
-  this.options = options;
-  this.loose = !!options.loose;
-  this.parse(comp);
-
-  if (this.semver === ANY) {
-    this.value = '';
-  } else {
-    this.value = this.operator + this.semver.version;
-  }
-
-  debug('comp', this);
-}
-
-var ANY = {};
-Comparator.prototype.parse = function (comp) {
-  var r = this.options.loose ? re[COMPARATORLOOSE] : re[COMPARATOR];
-  var m = comp.match(r);
-
-  if (!m) {
-    throw new TypeError('Invalid comparator: ' + comp)
-  }
-
-  this.operator = m[1];
-  if (this.operator === '=') {
-    this.operator = '';
-  }
-
-  // if it literally is just '>' or '' then allow anything.
-  if (!m[2]) {
-    this.semver = ANY;
-  } else {
-    this.semver = new SemVer(m[2], this.options.loose);
-  }
-};
-
-Comparator.prototype.toString = function () {
-  return this.value
-};
-
-Comparator.prototype.test = function (version) {
-  debug('Comparator.test', version, this.options.loose);
-
-  if (this.semver === ANY) {
-    return true
-  }
-
-  if (typeof version === 'string') {
-    version = new SemVer(version, this.options);
-  }
-
-  return cmp(version, this.operator, this.semver, this.options)
-};
-
-Comparator.prototype.intersects = function (comp, options) {
-  if (!(comp instanceof Comparator)) {
-    throw new TypeError('a Comparator is required')
-  }
-
-  if (!options || typeof options !== 'object') {
-    options = {
-      loose: !!options,
-      includePrerelease: false
-    };
-  }
-
-  var rangeTmp;
-
-  if (this.operator === '') {
-    rangeTmp = new Range(comp.value, options);
-    return satisfies(this.value, rangeTmp, options)
-  } else if (comp.operator === '') {
-    rangeTmp = new Range(this.value, options);
-    return satisfies(comp.semver, rangeTmp, options)
-  }
-
-  var sameDirectionIncreasing =
-    (this.operator === '>=' || this.operator === '>') &&
-    (comp.operator === '>=' || comp.operator === '>');
-  var sameDirectionDecreasing =
-    (this.operator === '<=' || this.operator === '<') &&
-    (comp.operator === '<=' || comp.operator === '<');
-  var sameSemVer = this.semver.version === comp.semver.version;
-  var differentDirectionsInclusive =
-    (this.operator === '>=' || this.operator === '<=') &&
-    (comp.operator === '>=' || comp.operator === '<=');
-  var oppositeDirectionsLessThan =
-    cmp(this.semver, '<', comp.semver, options) &&
-    ((this.operator === '>=' || this.operator === '>') &&
-    (comp.operator === '<=' || comp.operator === '<'));
-  var oppositeDirectionsGreaterThan =
-    cmp(this.semver, '>', comp.semver, options) &&
-    ((this.operator === '<=' || this.operator === '<') &&
-    (comp.operator === '>=' || comp.operator === '>'));
-
-  return sameDirectionIncreasing || sameDirectionDecreasing ||
-    (sameSemVer && differentDirectionsInclusive) ||
-    oppositeDirectionsLessThan || oppositeDirectionsGreaterThan
-};
-
-exports.Range = Range;
-function Range (range, options) {
-  if (!options || typeof options !== 'object') {
-    options = {
-      loose: !!options,
-      includePrerelease: false
-    };
-  }
-
-  if (range instanceof Range) {
-    if (range.loose === !!options.loose &&
-        range.includePrerelease === !!options.includePrerelease) {
-      return range
-    } else {
-      return new Range(range.raw, options)
-    }
-  }
-
-  if (range instanceof Comparator) {
-    return new Range(range.value, options)
-  }
-
-  if (!(this instanceof Range)) {
-    return new Range(range, options)
-  }
-
-  this.options = options;
-  this.loose = !!options.loose;
-  this.includePrerelease = !!options.includePrerelease;
-
-  // First, split based on boolean or ||
-  this.raw = range;
-  this.set = range.split(/\s*\|\|\s*/).map(function (range) {
-    return this.parseRange(range.trim())
-  }, this).filter(function (c) {
-    // throw out any that are not relevant for whatever reason
-    return c.length
-  });
-
-  if (!this.set.length) {
-    throw new TypeError('Invalid SemVer Range: ' + range)
-  }
-
-  this.format();
-}
-
-Range.prototype.format = function () {
-  this.range = this.set.map(function (comps) {
-    return comps.join(' ').trim()
-  }).join('||').trim();
-  return this.range
-};
-
-Range.prototype.toString = function () {
-  return this.range
-};
-
-Range.prototype.parseRange = function (range) {
-  var loose = this.options.loose;
-  range = range.trim();
-  // `1.2.3 - 1.2.4` => `>=1.2.3 <=1.2.4`
-  var hr = loose ? re[HYPHENRANGELOOSE] : re[HYPHENRANGE];
-  range = range.replace(hr, hyphenReplace);
-  debug('hyphen replace', range);
-  // `> 1.2.3 < 1.2.5` => `>1.2.3 <1.2.5`
-  range = range.replace(re[COMPARATORTRIM], comparatorTrimReplace);
-  debug('comparator trim', range, re[COMPARATORTRIM]);
-
-  // `~ 1.2.3` => `~1.2.3`
-  range = range.replace(re[TILDETRIM], tildeTrimReplace);
-
-  // `^ 1.2.3` => `^1.2.3`
-  range = range.replace(re[CARETTRIM], caretTrimReplace);
-
-  // normalize spaces
-  range = range.split(/\s+/).join(' ');
-
-  // At this point, the range is completely trimmed and
-  // ready to be split into comparators.
-
-  var compRe = loose ? re[COMPARATORLOOSE] : re[COMPARATOR];
-  var set = range.split(' ').map(function (comp) {
-    return parseComparator(comp, this.options)
-  }, this).join(' ').split(/\s+/);
-  if (this.options.loose) {
-    // in loose mode, throw out any that are not valid comparators
-    set = set.filter(function (comp) {
-      return !!comp.match(compRe)
-    });
-  }
-  set = set.map(function (comp) {
-    return new Comparator(comp, this.options)
-  }, this);
-
-  return set
-};
-
-Range.prototype.intersects = function (range, options) {
-  if (!(range instanceof Range)) {
-    throw new TypeError('a Range is required')
-  }
-
-  return this.set.some(function (thisComparators) {
-    return thisComparators.every(function (thisComparator) {
-      return range.set.some(function (rangeComparators) {
-        return rangeComparators.every(function (rangeComparator) {
-          return thisComparator.intersects(rangeComparator, options)
-        })
-      })
-    })
-  })
-};
-
-// Mostly just for testing and legacy API reasons
-exports.toComparators = toComparators;
-function toComparators (range, options) {
-  return new Range(range, options).set.map(function (comp) {
-    return comp.map(function (c) {
-      return c.value
-    }).join(' ').trim().split(' ')
-  })
-}
-
-// comprised of xranges, tildes, stars, and gtlt's at this point.
-// already replaced the hyphen ranges
-// turn into a set of JUST comparators.
-function parseComparator (comp, options) {
-  debug('comp', comp, options);
-  comp = replaceCarets(comp, options);
-  debug('caret', comp);
-  comp = replaceTildes(comp, options);
-  debug('tildes', comp);
-  comp = replaceXRanges(comp, options);
-  debug('xrange', comp);
-  comp = replaceStars(comp, options);
-  debug('stars', comp);
-  return comp
-}
-
-function isX (id) {
-  return !id || id.toLowerCase() === 'x' || id === '*'
-}
-
-// ~, ~> --> * (any, kinda silly)
-// ~2, ~2.x, ~2.x.x, ~>2, ~>2.x ~>2.x.x --> >=2.0.0 <3.0.0
-// ~2.0, ~2.0.x, ~>2.0, ~>2.0.x --> >=2.0.0 <2.1.0
-// ~1.2, ~1.2.x, ~>1.2, ~>1.2.x --> >=1.2.0 <1.3.0
-// ~1.2.3, ~>1.2.3 --> >=1.2.3 <1.3.0
-// ~1.2.0, ~>1.2.0 --> >=1.2.0 <1.3.0
-function replaceTildes (comp, options) {
-  return comp.trim().split(/\s+/).map(function (comp) {
-    return replaceTilde(comp, options)
-  }).join(' ')
-}
-
-function replaceTilde (comp, options) {
-  var r = options.loose ? re[TILDELOOSE] : re[TILDE];
-  return comp.replace(r, function (_, M, m, p, pr) {
-    debug('tilde', comp, _, M, m, p, pr);
-    var ret;
-
-    if (isX(M)) {
-      ret = '';
-    } else if (isX(m)) {
-      ret = '>=' + M + '.0.0 <' + (+M + 1) + '.0.0';
-    } else if (isX(p)) {
-      // ~1.2 == >=1.2.0 <1.3.0
-      ret = '>=' + M + '.' + m + '.0 <' + M + '.' + (+m + 1) + '.0';
-    } else if (pr) {
-      debug('replaceTilde pr', pr);
-      ret = '>=' + M + '.' + m + '.' + p + '-' + pr +
-            ' <' + M + '.' + (+m + 1) + '.0';
-    } else {
-      // ~1.2.3 == >=1.2.3 <1.3.0
-      ret = '>=' + M + '.' + m + '.' + p +
-            ' <' + M + '.' + (+m + 1) + '.0';
-    }
-
-    debug('tilde return', ret);
-    return ret
-  })
-}
-
-// ^ --> * (any, kinda silly)
-// ^2, ^2.x, ^2.x.x --> >=2.0.0 <3.0.0
-// ^2.0, ^2.0.x --> >=2.0.0 <3.0.0
-// ^1.2, ^1.2.x --> >=1.2.0 <2.0.0
-// ^1.2.3 --> >=1.2.3 <2.0.0
-// ^1.2.0 --> >=1.2.0 <2.0.0
-function replaceCarets (comp, options) {
-  return comp.trim().split(/\s+/).map(function (comp) {
-    return replaceCaret(comp, options)
-  }).join(' ')
-}
-
-function replaceCaret (comp, options) {
-  debug('caret', comp, options);
-  var r = options.loose ? re[CARETLOOSE] : re[CARET];
-  return comp.replace(r, function (_, M, m, p, pr) {
-    debug('caret', comp, _, M, m, p, pr);
-    var ret;
-
-    if (isX(M)) {
-      ret = '';
-    } else if (isX(m)) {
-      ret = '>=' + M + '.0.0 <' + (+M + 1) + '.0.0';
-    } else if (isX(p)) {
-      if (M === '0') {
-        ret = '>=' + M + '.' + m + '.0 <' + M + '.' + (+m + 1) + '.0';
-      } else {
-        ret = '>=' + M + '.' + m + '.0 <' + (+M + 1) + '.0.0';
-      }
-    } else if (pr) {
-      debug('replaceCaret pr', pr);
-      if (M === '0') {
-        if (m === '0') {
-          ret = '>=' + M + '.' + m + '.' + p + '-' + pr +
-                ' <' + M + '.' + m + '.' + (+p + 1);
-        } else {
-          ret = '>=' + M + '.' + m + '.' + p + '-' + pr +
-                ' <' + M + '.' + (+m + 1) + '.0';
-        }
-      } else {
-        ret = '>=' + M + '.' + m + '.' + p + '-' + pr +
-              ' <' + (+M + 1) + '.0.0';
-      }
-    } else {
-      debug('no pr');
-      if (M === '0') {
-        if (m === '0') {
-          ret = '>=' + M + '.' + m + '.' + p +
-                ' <' + M + '.' + m + '.' + (+p + 1);
-        } else {
-          ret = '>=' + M + '.' + m + '.' + p +
-                ' <' + M + '.' + (+m + 1) + '.0';
-        }
-      } else {
-        ret = '>=' + M + '.' + m + '.' + p +
-              ' <' + (+M + 1) + '.0.0';
-      }
-    }
-
-    debug('caret return', ret);
-    return ret
-  })
-}
-
-function replaceXRanges (comp, options) {
-  debug('replaceXRanges', comp, options);
-  return comp.split(/\s+/).map(function (comp) {
-    return replaceXRange(comp, options)
-  }).join(' ')
-}
-
-function replaceXRange (comp, options) {
-  comp = comp.trim();
-  var r = options.loose ? re[XRANGELOOSE] : re[XRANGE];
-  return comp.replace(r, function (ret, gtlt, M, m, p, pr) {
-    debug('xRange', comp, ret, gtlt, M, m, p, pr);
-    var xM = isX(M);
-    var xm = xM || isX(m);
-    var xp = xm || isX(p);
-    var anyX = xp;
-
-    if (gtlt === '=' && anyX) {
-      gtlt = '';
-    }
-
-    if (xM) {
-      if (gtlt === '>' || gtlt === '<') {
-        // nothing is allowed
-        ret = '<0.0.0';
-      } else {
-        // nothing is forbidden
-        ret = '*';
-      }
-    } else if (gtlt && anyX) {
-      // we know patch is an x, because we have any x at all.
-      // replace X with 0
-      if (xm) {
-        m = 0;
-      }
-      p = 0;
-
-      if (gtlt === '>') {
-        // >1 => >=2.0.0
-        // >1.2 => >=1.3.0
-        // >1.2.3 => >= 1.2.4
-        gtlt = '>=';
-        if (xm) {
-          M = +M + 1;
-          m = 0;
-          p = 0;
-        } else {
-          m = +m + 1;
-          p = 0;
-        }
-      } else if (gtlt === '<=') {
-        // <=0.7.x is actually <0.8.0, since any 0.7.x should
-        // pass.  Similarly, <=7.x is actually <8.0.0, etc.
-        gtlt = '<';
-        if (xm) {
-          M = +M + 1;
-        } else {
-          m = +m + 1;
-        }
-      }
-
-      ret = gtlt + M + '.' + m + '.' + p;
-    } else if (xm) {
-      ret = '>=' + M + '.0.0 <' + (+M + 1) + '.0.0';
-    } else if (xp) {
-      ret = '>=' + M + '.' + m + '.0 <' + M + '.' + (+m + 1) + '.0';
-    }
-
-    debug('xRange return', ret);
-
-    return ret
-  })
-}
-
-// Because * is AND-ed with everything else in the comparator,
-// and '' means "any version", just remove the *s entirely.
-function replaceStars (comp, options) {
-  debug('replaceStars', comp, options);
-  // Looseness is ignored here.  star is always as loose as it gets!
-  return comp.trim().replace(re[STAR], '')
-}
-
-// This function is passed to string.replace(re[HYPHENRANGE])
-// M, m, patch, prerelease, build
-// 1.2 - 3.4.5 => >=1.2.0 <=3.4.5
-// 1.2.3 - 3.4 => >=1.2.0 <3.5.0 Any 3.4.x will do
-// 1.2 - 3.4 => >=1.2.0 <3.5.0
-function hyphenReplace ($0,
-  from, fM, fm, fp, fpr, fb,
-  to, tM, tm, tp, tpr, tb) {
-  if (isX(fM)) {
-    from = '';
-  } else if (isX(fm)) {
-    from = '>=' + fM + '.0.0';
-  } else if (isX(fp)) {
-    from = '>=' + fM + '.' + fm + '.0';
-  } else {
-    from = '>=' + from;
-  }
-
-  if (isX(tM)) {
-    to = '';
-  } else if (isX(tm)) {
-    to = '<' + (+tM + 1) + '.0.0';
-  } else if (isX(tp)) {
-    to = '<' + tM + '.' + (+tm + 1) + '.0';
-  } else if (tpr) {
-    to = '<=' + tM + '.' + tm + '.' + tp + '-' + tpr;
-  } else {
-    to = '<=' + to;
-  }
-
-  return (from + ' ' + to).trim()
-}
-
-// if ANY of the sets match ALL of its comparators, then pass
-Range.prototype.test = function (version) {
-  if (!version) {
-    return false
-  }
-
-  if (typeof version === 'string') {
-    version = new SemVer(version, this.options);
-  }
-
-  for (var i = 0; i < this.set.length; i++) {
-    if (testSet(this.set[i], version, this.options)) {
-      return true
-    }
-  }
-  return false
-};
-
-function testSet (set, version, options) {
-  for (var i = 0; i < set.length; i++) {
-    if (!set[i].test(version)) {
-      return false
-    }
-  }
-
-  if (version.prerelease.length && !options.includePrerelease) {
-    // Find the set of versions that are allowed to have prereleases
-    // For example, ^1.2.3-pr.1 desugars to >=1.2.3-pr.1 <2.0.0
-    // That should allow `1.2.3-pr.2` to pass.
-    // However, `1.2.4-alpha.notready` should NOT be allowed,
-    // even though it's within the range set by the comparators.
-    for (i = 0; i < set.length; i++) {
-      debug(set[i].semver);
-      if (set[i].semver === ANY) {
-        continue
-      }
-
-      if (set[i].semver.prerelease.length > 0) {
-        var allowed = set[i].semver;
-        if (allowed.major === version.major &&
-            allowed.minor === version.minor &&
-            allowed.patch === version.patch) {
-          return true
-        }
-      }
-    }
-
-    // Version has a -pre, but it's not one of the ones we like.
-    return false
-  }
-
-  return true
-}
-
-exports.satisfies = satisfies;
-function satisfies (version, range, options) {
-  try {
-    range = new Range(range, options);
-  } catch (er) {
-    return false
-  }
-  return range.test(version)
-}
-
-exports.maxSatisfying = maxSatisfying;
-function maxSatisfying (versions, range, options) {
-  var max = null;
-  var maxSV = null;
-  try {
-    var rangeObj = new Range(range, options);
-  } catch (er) {
-    return null
-  }
-  versions.forEach(function (v) {
-    if (rangeObj.test(v)) {
-      // satisfies(v, range, options)
-      if (!max || maxSV.compare(v) === -1) {
-        // compare(max, v, true)
-        max = v;
-        maxSV = new SemVer(max, options);
-      }
-    }
-  });
-  return max
-}
-
-exports.minSatisfying = minSatisfying;
-function minSatisfying (versions, range, options) {
-  var min = null;
-  var minSV = null;
-  try {
-    var rangeObj = new Range(range, options);
-  } catch (er) {
-    return null
-  }
-  versions.forEach(function (v) {
-    if (rangeObj.test(v)) {
-      // satisfies(v, range, options)
-      if (!min || minSV.compare(v) === 1) {
-        // compare(min, v, true)
-        min = v;
-        minSV = new SemVer(min, options);
-      }
-    }
-  });
-  return min
-}
-
-exports.minVersion = minVersion;
-function minVersion (range, loose) {
-  range = new Range(range, loose);
-
-  var minver = new SemVer('0.0.0');
-  if (range.test(minver)) {
-    return minver
-  }
-
-  minver = new SemVer('0.0.0-0');
-  if (range.test(minver)) {
-    return minver
-  }
-
-  minver = null;
-  for (var i = 0; i < range.set.length; ++i) {
-    var comparators = range.set[i];
-
-    comparators.forEach(function (comparator) {
-      // Clone to avoid manipulating the comparator's semver object.
-      var compver = new SemVer(comparator.semver.version);
-      switch (comparator.operator) {
-        case '>':
-          if (compver.prerelease.length === 0) {
-            compver.patch++;
-          } else {
-            compver.prerelease.push(0);
-          }
-          compver.raw = compver.format();
-          /* fallthrough */
-        case '':
-        case '>=':
-          if (!minver || gt(minver, compver)) {
-            minver = compver;
-          }
-          break
-        case '<':
-        case '<=':
-          /* Ignore maximum versions */
-          break
-        /* istanbul ignore next */
-        default:
-          throw new Error('Unexpected operation: ' + comparator.operator)
-      }
-    });
-  }
-
-  if (minver && range.test(minver)) {
-    return minver
-  }
-
-  return null
-}
-
-exports.validRange = validRange;
-function validRange (range, options) {
-  try {
-    // Return '*' instead of '' so that truthiness works.
-    // This will throw if it's invalid anyway
-    return new Range(range, options).range || '*'
-  } catch (er) {
-    return null
-  }
-}
-
-// Determine if version is less than all the versions possible in the range
-exports.ltr = ltr;
-function ltr (version, range, options) {
-  return outside(version, range, '<', options)
-}
-
-// Determine if version is greater than all the versions possible in the range.
-exports.gtr = gtr;
-function gtr (version, range, options) {
-  return outside(version, range, '>', options)
-}
-
-exports.outside = outside;
-function outside (version, range, hilo, options) {
-  version = new SemVer(version, options);
-  range = new Range(range, options);
-
-  var gtfn, ltefn, ltfn, comp, ecomp;
-  switch (hilo) {
-    case '>':
-      gtfn = gt;
-      ltefn = lte;
-      ltfn = lt;
-      comp = '>';
-      ecomp = '>=';
-      break
-    case '<':
-      gtfn = lt;
-      ltefn = gte;
-      ltfn = gt;
-      comp = '<';
-      ecomp = '<=';
-      break
-    default:
-      throw new TypeError('Must provide a hilo val of "<" or ">"')
-  }
-
-  // If it satisifes the range it is not outside
-  if (satisfies(version, range, options)) {
-    return false
-  }
-
-  // From now on, variable terms are as if we're in "gtr" mode.
-  // but note that everything is flipped for the "ltr" function.
-
-  for (var i = 0; i < range.set.length; ++i) {
-    var comparators = range.set[i];
-
-    var high = null;
-    var low = null;
-
-    comparators.forEach(function (comparator) {
-      if (comparator.semver === ANY) {
-        comparator = new Comparator('>=0.0.0');
-      }
-      high = high || comparator;
-      low = low || comparator;
-      if (gtfn(comparator.semver, high.semver, options)) {
-        high = comparator;
-      } else if (ltfn(comparator.semver, low.semver, options)) {
-        low = comparator;
-      }
-    });
-
-    // If the edge version comparator has a operator then our version
-    // isn't outside it
-    if (high.operator === comp || high.operator === ecomp) {
-      return false
-    }
-
-    // If the lowest version comparator has an operator and our version
-    // is less than it then it isn't higher than the range
-    if ((!low.operator || low.operator === comp) &&
-        ltefn(version, low.semver)) {
-      return false
-    } else if (low.operator === ecomp && ltfn(version, low.semver)) {
-      return false
-    }
-  }
-  return true
-}
-
-exports.prerelease = prerelease;
-function prerelease (version, options) {
-  var parsed = parse(version, options);
-  return (parsed && parsed.prerelease.length) ? parsed.prerelease : null
-}
-
-exports.intersects = intersects;
-function intersects (r1, r2, options) {
-  r1 = new Range(r1, options);
-  r2 = new Range(r2, options);
-  return r1.intersects(r2)
-}
-
-exports.coerce = coerce;
-function coerce (version) {
-  if (version instanceof SemVer) {
-    return version
-  }
-
-  if (typeof version !== 'string') {
-    return null
-  }
-
-  var match = version.match(re[COERCE]);
-
-  if (match == null) {
-    return null
-  }
-
-  return parse(match[1] +
-    '.' + (match[2] || '0') +
-    '.' + (match[3] || '0'))
-}
-});
-var semver_1 = semver.SEMVER_SPEC_VERSION;
-var semver_2 = semver.re;
-var semver_3 = semver.src;
-var semver_4 = semver.parse;
-var semver_5 = semver.valid;
-var semver_6 = semver.clean;
-var semver_7 = semver.SemVer;
-var semver_8 = semver.inc;
-var semver_9 = semver.diff;
-var semver_10 = semver.compareIdentifiers;
-var semver_11 = semver.rcompareIdentifiers;
-var semver_12 = semver.major;
-var semver_13 = semver.minor;
-var semver_14 = semver.patch;
-var semver_15 = semver.compare;
-var semver_16 = semver.compareLoose;
-var semver_17 = semver.rcompare;
-var semver_18 = semver.sort;
-var semver_19 = semver.rsort;
-var semver_20 = semver.gt;
-var semver_21 = semver.lt;
-var semver_22 = semver.eq;
-var semver_23 = semver.neq;
-var semver_24 = semver.gte;
-var semver_25 = semver.lte;
-var semver_26 = semver.cmp;
-var semver_27 = semver.Comparator;
-var semver_28 = semver.Range;
-var semver_29 = semver.toComparators;
-var semver_30 = semver.satisfies;
-var semver_31 = semver.maxSatisfying;
-var semver_32 = semver.minSatisfying;
-var semver_33 = semver.minVersion;
-var semver_34 = semver.validRange;
-var semver_35 = semver.ltr;
-var semver_36 = semver.gtr;
-var semver_37 = semver.outside;
-var semver_38 = semver.prerelease;
-var semver_39 = semver.intersects;
-var semver_40 = semver.coerce;
-
-const isWin = process.platform === 'win32';
-const isExecutableRegExp = /\.(?:com|exe)$/i;
-const isCmdShimRegExp = /node_modules[\\/].bin[\\/][^\\/]+\.cmd$/i;
-
-// `options.shell` is supported in Node ^4.8.0, ^5.7.0 and >= 6.0.0
-const supportsShellOption = src(() => semver.satisfies(process.version, '^4.8.0 || ^5.7.0 || >= 6.0.0', true)) || false;
-
-function detectShebang(parsed) {
-    parsed.file = resolveCommand_1(parsed);
-
-    const shebang = parsed.file && readShebang_1(parsed.file);
-
-    if (shebang) {
-        parsed.args.unshift(parsed.file);
-        parsed.command = shebang;
-
-        return resolveCommand_1(parsed);
-    }
-
-    return parsed.file;
-}
-
-function parseNonShell(parsed) {
-    if (!isWin) {
-        return parsed;
-    }
-
-    // Detect & add support for shebangs
-    const commandFile = detectShebang(parsed);
-
-    // We don't need a shell if the command filename is an executable
-    const needsShell = !isExecutableRegExp.test(commandFile);
-
-    // If a shell is required, use cmd.exe and take care of escaping everything correctly
-    // Note that `forceShell` is an hidden option used only in tests
-    if (parsed.options.forceShell || needsShell) {
-        // Need to double escape meta chars if the command is a cmd-shim located in `node_modules/.bin/`
-        // The cmd-shim simply calls execute the package bin file with NodeJS, proxying any argument
-        // Because the escape of metachars with ^ gets interpreted when the cmd.exe is first called,
-        // we need to double escape them
-        const needsDoubleEscapeMetaChars = isCmdShimRegExp.test(commandFile);
-
-        // Normalize posix paths into OS compatible paths (e.g.: foo/bar -> foo\bar)
-        // This is necessary otherwise it will always fail with ENOENT in those cases
-        parsed.command = path.normalize(parsed.command);
-
-        // Escape command & arguments
-        parsed.command = _escape.command(parsed.command);
-        parsed.args = parsed.args.map((arg) => _escape.argument(arg, needsDoubleEscapeMetaChars));
-
-        const shellCommand = [parsed.command].concat(parsed.args).join(' ');
-
-        parsed.args = ['/d', '/s', '/c', `"${shellCommand}"`];
-        parsed.command = process.env.comspec || 'cmd.exe';
-        parsed.options.windowsVerbatimArguments = true; // Tell node's spawn that the arguments are already escaped
-    }
-
-    return parsed;
-}
-
-function parseShell(parsed) {
-    // If node supports the shell option, there's no need to mimic its behavior
-    if (supportsShellOption) {
-        return parsed;
-    }
-
-    // Mimic node shell option
-    // See https://github.com/nodejs/node/blob/b9f6a2dc059a1062776133f3d4fd848c4da7d150/lib/child_process.js#L335
-    const shellCommand = [parsed.command].concat(parsed.args).join(' ');
-
-    if (isWin) {
-        parsed.command = typeof parsed.options.shell === 'string' ? parsed.options.shell : process.env.comspec || 'cmd.exe';
-        parsed.args = ['/d', '/s', '/c', `"${shellCommand}"`];
-        parsed.options.windowsVerbatimArguments = true; // Tell node's spawn that the arguments are already escaped
-    } else {
-        if (typeof parsed.options.shell === 'string') {
-            parsed.command = parsed.options.shell;
-        } else if (process.platform === 'android') {
-            parsed.command = '/system/bin/sh';
-        } else {
-            parsed.command = '/bin/sh';
-        }
-
-        parsed.args = ['-c', shellCommand];
-    }
-
-    return parsed;
-}
-
-function parse(command, args, options) {
-    // Normalize arguments, similar to nodejs
-    if (args && !Array.isArray(args)) {
-        options = args;
-        args = null;
-    }
-
-    args = args ? args.slice(0) : []; // Clone array to avoid changing the original
-    options = Object.assign({}, options); // Clone object to avoid changing the original
-
-    // Build our parsed object
-    const parsed = {
-        command,
-        args,
-        options,
-        file: undefined,
-        original: {
-            command,
-            args,
-        },
-    };
-
-    // Delegate further parsing to shell or non-shell
-    return options.shell ? parseShell(parsed) : parseNonShell(parsed);
-}
-
-var parse_1 = parse;
-
-const isWin$1 = process.platform === 'win32';
-
-function notFoundError(original, syscall) {
-    return Object.assign(new Error(`${syscall} ${original.command} ENOENT`), {
-        code: 'ENOENT',
-        errno: 'ENOENT',
-        syscall: `${syscall} ${original.command}`,
-        path: original.command,
-        spawnargs: original.args,
-    });
-}
-
-function hookChildProcess(cp, parsed) {
-    if (!isWin$1) {
-        return;
-    }
-
-    const originalEmit = cp.emit;
-
-    cp.emit = function (name, arg1) {
-        // If emitting "exit" event and exit code is 1, we need to check if
-        // the command exists and emit an "error" instead
-        // See https://github.com/IndigoUnited/node-cross-spawn/issues/16
-        if (name === 'exit') {
-            const err = verifyENOENT(arg1, parsed);
-
-            if (err) {
-                return originalEmit.call(cp, 'error', err);
-            }
-        }
-
-        return originalEmit.apply(cp, arguments); // eslint-disable-line prefer-rest-params
-    };
-}
-
-function verifyENOENT(status, parsed) {
-    if (isWin$1 && status === 1 && !parsed.file) {
-        return notFoundError(parsed.original, 'spawn');
-    }
-
-    return null;
-}
-
-function verifyENOENTSync(status, parsed) {
-    if (isWin$1 && status === 1 && !parsed.file) {
-        return notFoundError(parsed.original, 'spawnSync');
-    }
-
-    return null;
-}
-
-var enoent = {
-    hookChildProcess,
-    verifyENOENT,
-    verifyENOENTSync,
-    notFoundError,
-};
-
-function spawn(command, args, options) {
-    // Parse the arguments
-    const parsed = parse_1(command, args, options);
-
-    // Spawn the child process
-    const spawned = child_process.spawn(parsed.command, parsed.args, parsed.options);
-
-    // Hook into child process "exit" event to emit an error if the command
-    // does not exists, see: https://github.com/IndigoUnited/node-cross-spawn/issues/16
-    enoent.hookChildProcess(spawned, parsed);
-
-    return spawned;
-}
-
-function spawnSync(command, args, options) {
-    // Parse the arguments
-    const parsed = parse_1(command, args, options);
-
-    // Spawn the child process
-    const result = child_process.spawnSync(parsed.command, parsed.args, parsed.options);
-
-    // Analyze if the command does not exist, see: https://github.com/IndigoUnited/node-cross-spawn/issues/16
-    result.error = result.error || enoent.verifyENOENTSync(result.status, parsed);
-
-    return result;
-}
-
-var crossSpawn = spawn;
-var spawn_1 = spawn;
-var sync$3 = spawnSync;
-
-var _parse = parse_1;
-var _enoent = enoent;
-crossSpawn.spawn = spawn_1;
-crossSpawn.sync = sync$3;
-crossSpawn._parse = _parse;
-crossSpawn._enoent = _enoent;
-
-var stripEof = function (x) {
-	var lf = typeof x === 'string' ? '\n' : '\n'.charCodeAt();
-	var cr = typeof x === 'string' ? '\r' : '\r'.charCodeAt();
-
-	if (x[x.length - 1] === lf) {
-		x = x.slice(0, x.length - 1);
-	}
-
-	if (x[x.length - 1] === cr) {
-		x = x.slice(0, x.length - 1);
-	}
-
-	return x;
-};
-
-var npmRunPath = createCommonjsModule(function (module) {
-
-
-
-module.exports = opts => {
-	opts = Object.assign({
-		cwd: process.cwd(),
-		path: process.env[pathKey()]
-	}, opts);
-
-	let prev;
-	let pth = path.resolve(opts.cwd);
-	const ret = [];
-
-	while (prev !== pth) {
-		ret.push(path.join(pth, 'node_modules/.bin'));
-		prev = pth;
-		pth = path.resolve(pth, '..');
-	}
-
-	// ensure the running `node` binary is used
-	ret.push(path.dirname(process.execPath));
-
-	return ret.concat(opts.path).join(path.delimiter);
-};
-
-module.exports.env = opts => {
-	opts = Object.assign({
-		env: process.env
-	}, opts);
-
-	const env = Object.assign({}, opts.env);
-	const path = pathKey({env});
-
-	opts.path = env[path];
-	env[path] = module.exports(opts);
-
-	return env;
-};
-});
-var npmRunPath_1 = npmRunPath.env;
-
-var isStream_1 = createCommonjsModule(function (module) {
-
-var isStream = module.exports = function (stream) {
-	return stream !== null && typeof stream === 'object' && typeof stream.pipe === 'function';
-};
-
-isStream.writable = function (stream) {
-	return isStream(stream) && stream.writable !== false && typeof stream._write === 'function' && typeof stream._writableState === 'object';
-};
-
-isStream.readable = function (stream) {
-	return isStream(stream) && stream.readable !== false && typeof stream._read === 'function' && typeof stream._readableState === 'object';
-};
-
-isStream.duplex = function (stream) {
-	return isStream.writable(stream) && isStream.readable(stream);
-};
-
-isStream.transform = function (stream) {
-	return isStream.duplex(stream) && typeof stream._transform === 'function' && typeof stream._transformState === 'object';
-};
+exports.isPlainObject = isPlainObject;
 });
 
-// Returns a wrapper function that returns a wrapped callback
-// The wrapper function should do some stuff, and return a
-// presumably different callback function.
-// This makes sure that own properties are retained, so that
-// decorations and such are not lost along the way.
-var wrappy_1 = wrappy;
-function wrappy (fn, cb) {
-  if (fn && cb) return wrappy(fn)(cb)
-
-  if (typeof fn !== 'function')
-    throw new TypeError('need wrapper function')
-
-  Object.keys(fn).forEach(function (k) {
-    wrapper[k] = fn[k];
-  });
-
-  return wrapper
-
-  function wrapper() {
-    var args = new Array(arguments.length);
-    for (var i = 0; i < args.length; i++) {
-      args[i] = arguments[i];
-    }
-    var ret = fn.apply(this, args);
-    var cb = args[args.length-1];
-    if (typeof ret === 'function' && ret !== cb) {
-      Object.keys(cb).forEach(function (k) {
-        ret[k] = cb[k];
-      });
-    }
-    return ret
-  }
-}
-
-var once_1 = wrappy_1(once);
-var strict = wrappy_1(onceStrict);
-
-once.proto = once(function () {
-  Object.defineProperty(Function.prototype, 'once', {
-    value: function () {
-      return once(this)
-    },
-    configurable: true
-  });
-
-  Object.defineProperty(Function.prototype, 'onceStrict', {
-    value: function () {
-      return onceStrict(this)
-    },
-    configurable: true
-  });
-});
-
-function once (fn) {
-  var f = function () {
-    if (f.called) return f.value
-    f.called = true;
-    return f.value = fn.apply(this, arguments)
-  };
-  f.called = false;
-  return f
-}
-
-function onceStrict (fn) {
-  var f = function () {
-    if (f.called)
-      throw new Error(f.onceError)
-    f.called = true;
-    return f.value = fn.apply(this, arguments)
-  };
-  var name = fn.name || 'Function wrapped with `once`';
-  f.onceError = name + " shouldn't be called more than once";
-  f.called = false;
-  return f
-}
-once_1.strict = strict;
-
-var noop = function() {};
-
-var isRequest = function(stream) {
-	return stream.setHeader && typeof stream.abort === 'function';
-};
-
-var isChildProcess = function(stream) {
-	return stream.stdio && Array.isArray(stream.stdio) && stream.stdio.length === 3
-};
-
-var eos = function(stream, opts, callback) {
-	if (typeof opts === 'function') return eos(stream, null, opts);
-	if (!opts) opts = {};
-
-	callback = once_1(callback || noop);
-
-	var ws = stream._writableState;
-	var rs = stream._readableState;
-	var readable = opts.readable || (opts.readable !== false && stream.readable);
-	var writable = opts.writable || (opts.writable !== false && stream.writable);
-	var cancelled = false;
-
-	var onlegacyfinish = function() {
-		if (!stream.writable) onfinish();
-	};
-
-	var onfinish = function() {
-		writable = false;
-		if (!readable) callback.call(stream);
-	};
-
-	var onend = function() {
-		readable = false;
-		if (!writable) callback.call(stream);
-	};
-
-	var onexit = function(exitCode) {
-		callback.call(stream, exitCode ? new Error('exited with error code: ' + exitCode) : null);
-	};
-
-	var onerror = function(err) {
-		callback.call(stream, err);
-	};
-
-	var onclose = function() {
-		process.nextTick(onclosenexttick);
-	};
-
-	var onclosenexttick = function() {
-		if (cancelled) return;
-		if (readable && !(rs && (rs.ended && !rs.destroyed))) return callback.call(stream, new Error('premature close'));
-		if (writable && !(ws && (ws.ended && !ws.destroyed))) return callback.call(stream, new Error('premature close'));
-	};
-
-	var onrequest = function() {
-		stream.req.on('finish', onfinish);
-	};
-
-	if (isRequest(stream)) {
-		stream.on('complete', onfinish);
-		stream.on('abort', onclose);
-		if (stream.req) onrequest();
-		else stream.on('request', onrequest);
-	} else if (writable && !ws) { // legacy streams
-		stream.on('end', onlegacyfinish);
-		stream.on('close', onlegacyfinish);
-	}
-
-	if (isChildProcess(stream)) stream.on('exit', onexit);
-
-	stream.on('end', onend);
-	stream.on('finish', onfinish);
-	if (opts.error !== false) stream.on('error', onerror);
-	stream.on('close', onclose);
-
-	return function() {
-		cancelled = true;
-		stream.removeListener('complete', onfinish);
-		stream.removeListener('abort', onclose);
-		stream.removeListener('request', onrequest);
-		if (stream.req) stream.req.removeListener('finish', onfinish);
-		stream.removeListener('end', onlegacyfinish);
-		stream.removeListener('close', onlegacyfinish);
-		stream.removeListener('finish', onfinish);
-		stream.removeListener('exit', onexit);
-		stream.removeListener('end', onend);
-		stream.removeListener('error', onerror);
-		stream.removeListener('close', onclose);
-	};
-};
-
-var endOfStream = eos;
-
-// we only need fs to get the ReadStream and WriteStream prototypes
-
-var noop$1 = function () {};
-var ancient = /^v?\.0/.test(process.version);
-
-var isFn = function (fn) {
-  return typeof fn === 'function'
-};
-
-var isFS = function (stream) {
-  if (!ancient) return false // newer node version do not need to care about fs is a special way
-  if (!fs__default) return false // browser
-  return (stream instanceof (fs__default.ReadStream || noop$1) || stream instanceof (fs__default.WriteStream || noop$1)) && isFn(stream.close)
-};
-
-var isRequest$1 = function (stream) {
-  return stream.setHeader && isFn(stream.abort)
-};
-
-var destroyer = function (stream, reading, writing, callback) {
-  callback = once_1(callback);
-
-  var closed = false;
-  stream.on('close', function () {
-    closed = true;
-  });
-
-  endOfStream(stream, {readable: reading, writable: writing}, function (err) {
-    if (err) return callback(err)
-    closed = true;
-    callback();
-  });
-
-  var destroyed = false;
-  return function (err) {
-    if (closed) return
-    if (destroyed) return
-    destroyed = true;
-
-    if (isFS(stream)) return stream.close(noop$1) // use close for fs streams to avoid fd leaks
-    if (isRequest$1(stream)) return stream.abort() // request.destroy just do .end - .abort is what we want
-
-    if (isFn(stream.destroy)) return stream.destroy()
-
-    callback(err || new Error('stream was destroyed'));
-  }
-};
-
-var call = function (fn) {
-  fn();
-};
-
-var pipe = function (from, to) {
-  return from.pipe(to)
-};
-
-var pump = function () {
-  var streams = Array.prototype.slice.call(arguments);
-  var callback = isFn(streams[streams.length - 1] || noop$1) && streams.pop() || noop$1;
-
-  if (Array.isArray(streams[0])) streams = streams[0];
-  if (streams.length < 2) throw new Error('pump requires two streams per minimum')
-
-  var error;
-  var destroys = streams.map(function (stream, i) {
-    var reading = i < streams.length - 1;
-    var writing = i > 0;
-    return destroyer(stream, reading, writing, function (err) {
-      if (!error) error = err;
-      if (err) destroys.forEach(call);
-      if (reading) return
-      destroys.forEach(call);
-      callback(error);
-    })
-  });
-
-  return streams.reduce(pipe)
-};
-
-var pump_1 = pump;
-
-const {PassThrough} = Stream;
-
-var bufferStream = options => {
-	options = Object.assign({}, options);
-
-	const {array} = options;
-	let {encoding} = options;
-	const buffer = encoding === 'buffer';
-	let objectMode = false;
-
-	if (array) {
-		objectMode = !(encoding || buffer);
-	} else {
-		encoding = encoding || 'utf8';
-	}
-
-	if (buffer) {
-		encoding = null;
-	}
-
-	let len = 0;
-	const ret = [];
-	const stream = new PassThrough({objectMode});
-
-	if (encoding) {
-		stream.setEncoding(encoding);
-	}
-
-	stream.on('data', chunk => {
-		ret.push(chunk);
-
-		if (objectMode) {
-			len = ret.length;
-		} else {
-			len += chunk.length;
-		}
-	});
-
-	stream.getBufferedValue = () => {
-		if (array) {
-			return ret;
-		}
-
-		return buffer ? Buffer.concat(ret, len) : ret.join('');
-	};
-
-	stream.getBufferedLength = () => len;
-
-	return stream;
-};
-
-class MaxBufferError extends Error {
-	constructor() {
-		super('maxBuffer exceeded');
-		this.name = 'MaxBufferError';
-	}
-}
-
-function getStream(inputStream, options) {
-	if (!inputStream) {
-		return Promise.reject(new Error('Expected a stream'));
-	}
-
-	options = Object.assign({maxBuffer: Infinity}, options);
-
-	const {maxBuffer} = options;
-
-	let stream;
-	return new Promise((resolve, reject) => {
-		const rejectPromise = error => {
-			if (error) { // A null check
-				error.bufferedData = stream.getBufferedValue();
-			}
-			reject(error);
-		};
-
-		stream = pump_1(inputStream, bufferStream(options), error => {
-			if (error) {
-				rejectPromise(error);
-				return;
-			}
-
-			resolve();
-		});
-
-		stream.on('data', () => {
-			if (stream.getBufferedLength() > maxBuffer) {
-				rejectPromise(new MaxBufferError());
-			}
-		});
-	}).then(() => stream.getBufferedValue());
-}
-
-var getStream_1 = getStream;
-var buffer = (stream, options) => getStream(stream, Object.assign({}, options, {encoding: 'buffer'}));
-var array = (stream, options) => getStream(stream, Object.assign({}, options, {array: true}));
-var MaxBufferError_1 = MaxBufferError;
-getStream_1.buffer = buffer;
-getStream_1.array = array;
-getStream_1.MaxBufferError = MaxBufferError_1;
-
-var pFinally = (promise, onFinally) => {
-	onFinally = onFinally || (() => {});
-
-	return promise.then(
-		val => new Promise(resolve => {
-			resolve(onFinally());
-		}).then(() => val),
-		err => new Promise(resolve => {
-			resolve(onFinally());
-		}).then(() => {
-			throw err;
-		})
-	);
-};
-
-var signals = createCommonjsModule(function (module) {
-// This is not the set of all possible signals.
-//
-// It IS, however, the set of all signals that trigger
-// an exit on either Linux or BSD systems.  Linux is a
-// superset of the signal names supported on BSD, and
-// the unknown signals just fail to register, so we can
-// catch that easily enough.
-//
-// Don't bother with SIGKILL.  It's uncatchable, which
-// means that we can't fire any callbacks anyway.
-//
-// If a user does happen to register a handler on a non-
-// fatal signal like SIGWINCH or something, and then
-// exit, it'll end up firing `process.emit('exit')`, so
-// the handler will be fired anyway.
-//
-// SIGBUS, SIGFPE, SIGSEGV and SIGILL, when not raised
-// artificially, inherently leave the process in a
-// state from which it is not safe to try and enter JS
-// listeners.
-module.exports = [
-  'SIGABRT',
-  'SIGALRM',
-  'SIGHUP',
-  'SIGINT',
-  'SIGTERM'
-];
-
-if (process.platform !== 'win32') {
-  module.exports.push(
-    'SIGVTALRM',
-    'SIGXCPU',
-    'SIGXFSZ',
-    'SIGUSR2',
-    'SIGTRAP',
-    'SIGSYS',
-    'SIGQUIT',
-    'SIGIOT'
-    // should detect profiler and enable/disable accordingly.
-    // see #21
-    // 'SIGPROF'
-  );
-}
-
-if (process.platform === 'linux') {
-  module.exports.push(
-    'SIGIO',
-    'SIGPOLL',
-    'SIGPWR',
-    'SIGSTKFLT',
-    'SIGUNUSED'
-  );
-}
-});
-
-// Note: since nyc uses this module to output coverage, any lines
-// that are in the direct sync flow of nyc's outputCoverage are
-// ignored, since we can never get coverage for them.
-
-var signals$1 = signals;
-
-var EE = events;
-/* istanbul ignore if */
-if (typeof EE !== 'function') {
-  EE = EE.EventEmitter;
-}
-
-var emitter;
-if (process.__signal_exit_emitter__) {
-  emitter = process.__signal_exit_emitter__;
-} else {
-  emitter = process.__signal_exit_emitter__ = new EE();
-  emitter.count = 0;
-  emitter.emitted = {};
-}
-
-// Because this emitter is a global, we have to check to see if a
-// previous version of this library failed to enable infinite listeners.
-// I know what you're about to say.  But literally everything about
-// signal-exit is a compromise with evil.  Get used to it.
-if (!emitter.infinite) {
-  emitter.setMaxListeners(Infinity);
-  emitter.infinite = true;
-}
-
-var signalExit = function (cb, opts) {
-  assert.equal(typeof cb, 'function', 'a callback must be provided for exit handler');
-
-  if (loaded === false) {
-    load();
-  }
-
-  var ev = 'exit';
-  if (opts && opts.alwaysLast) {
-    ev = 'afterexit';
-  }
-
-  var remove = function () {
-    emitter.removeListener(ev, cb);
-    if (emitter.listeners('exit').length === 0 &&
-        emitter.listeners('afterexit').length === 0) {
-      unload();
-    }
-  };
-  emitter.on(ev, cb);
-
-  return remove
-};
-
-var unload_1 = unload;
-function unload () {
-  if (!loaded) {
-    return
-  }
-  loaded = false;
-
-  signals$1.forEach(function (sig) {
-    try {
-      process.removeListener(sig, sigListeners[sig]);
-    } catch (er) {}
-  });
-  process.emit = originalProcessEmit;
-  process.reallyExit = originalProcessReallyExit;
-  emitter.count -= 1;
-}
-
-function emit (event, code, signal) {
-  if (emitter.emitted[event]) {
-    return
-  }
-  emitter.emitted[event] = true;
-  emitter.emit(event, code, signal);
-}
-
-// { <signal>: <listener fn>, ... }
-var sigListeners = {};
-signals$1.forEach(function (sig) {
-  sigListeners[sig] = function listener () {
-    // If there are no other listeners, an exit is coming!
-    // Simplest way: remove us and then re-send the signal.
-    // We know that this will kill the process, so we can
-    // safely emit now.
-    var listeners = process.listeners(sig);
-    if (listeners.length === emitter.count) {
-      unload();
-      emit('exit', null, sig);
-      /* istanbul ignore next */
-      emit('afterexit', null, sig);
-      /* istanbul ignore next */
-      process.kill(process.pid, sig);
-    }
-  };
-});
-
-var signals_1 = function () {
-  return signals$1
-};
-
-var load_1 = load;
-
-var loaded = false;
-
-function load () {
-  if (loaded) {
-    return
-  }
-  loaded = true;
-
-  // This is the number of onSignalExit's that are in play.
-  // It's important so that we can count the correct number of
-  // listeners on signals, and don't wait for the other one to
-  // handle it instead of us.
-  emitter.count += 1;
-
-  signals$1 = signals$1.filter(function (sig) {
-    try {
-      process.on(sig, sigListeners[sig]);
-      return true
-    } catch (er) {
-      return false
-    }
-  });
-
-  process.emit = processEmit;
-  process.reallyExit = processReallyExit;
-}
-
-var originalProcessReallyExit = process.reallyExit;
-function processReallyExit (code) {
-  process.exitCode = code || 0;
-  emit('exit', process.exitCode, null);
-  /* istanbul ignore next */
-  emit('afterexit', process.exitCode, null);
-  /* istanbul ignore next */
-  originalProcessReallyExit.call(process, process.exitCode);
-}
-
-var originalProcessEmit = process.emit;
-function processEmit (ev, arg) {
-  if (ev === 'exit') {
-    if (arg !== undefined) {
-      process.exitCode = arg;
-    }
-    var ret = originalProcessEmit.apply(this, arguments);
-    emit('exit', process.exitCode, null);
-    /* istanbul ignore next */
-    emit('afterexit', process.exitCode, null);
-    return ret
-  } else {
-    return originalProcessEmit.apply(this, arguments)
-  }
-}
-signalExit.unload = unload_1;
-signalExit.signals = signals_1;
-signalExit.load = load_1;
-
-var errname_1 = createCommonjsModule(function (module) {
-// Older verions of Node.js might not have `util.getSystemErrorName()`.
-// In that case, fall back to a deprecated internal.
-
-
-let uv;
-
-if (typeof util.getSystemErrorName === 'function') {
-	module.exports = util.getSystemErrorName;
-} else {
-	try {
-		uv = process.binding('uv');
-
-		if (typeof uv.errname !== 'function') {
-			throw new TypeError('uv.errname is not a function');
-		}
-	} catch (err) {
-		console.error('execa/lib/errname: unable to establish process.binding(\'uv\')', err);
-		uv = null;
-	}
-
-	module.exports = code => errname(uv, code);
-}
-
-// Used for testing the fallback behavior
-module.exports.__test__ = errname;
-
-function errname(uv, code) {
-	if (uv) {
-		return uv.errname(code);
-	}
-
-	if (!(code < 0)) {
-		throw new Error('err >= 0');
-	}
-
-	return `Unknown system error ${code}`;
-}
-});
-var errname_2 = errname_1.__test__;
-
-const alias = ['stdin', 'stdout', 'stderr'];
-
-const hasAlias = opts => alias.some(x => Boolean(opts[x]));
-
-var stdio = opts => {
-	if (!opts) {
-		return null;
-	}
-
-	if (opts.stdio && hasAlias(opts)) {
-		throw new Error(`It's not possible to provide \`stdio\` in combination with one of ${alias.map(x => `\`${x}\``).join(', ')}`);
-	}
-
-	if (typeof opts.stdio === 'string') {
-		return opts.stdio;
-	}
-
-	const stdio = opts.stdio || [];
-
-	if (!Array.isArray(stdio)) {
-		throw new TypeError(`Expected \`stdio\` to be of type \`string\` or \`Array\`, got \`${typeof stdio}\``);
-	}
-
-	const result = [];
-	const len = Math.max(stdio.length, alias.length);
-
-	for (let i = 0; i < len; i++) {
-		let value = null;
-
-		if (stdio[i] !== undefined) {
-			value = stdio[i];
-		} else if (opts[alias[i]] !== undefined) {
-			value = opts[alias[i]];
-		}
-
-		result[i] = value;
-	}
-
-	return result;
-};
-
-var execa = createCommonjsModule(function (module) {
-
-
-
-
-
-
-
-
-
-
-
-
-const TEN_MEGABYTES = 1000 * 1000 * 10;
-
-function handleArgs(cmd, args, opts) {
-	let parsed;
-
-	opts = Object.assign({
-		extendEnv: true,
-		env: {}
-	}, opts);
-
-	if (opts.extendEnv) {
-		opts.env = Object.assign({}, process.env, opts.env);
-	}
-
-	if (opts.__winShell === true) {
-		delete opts.__winShell;
-		parsed = {
-			command: cmd,
-			args,
-			options: opts,
-			file: cmd,
-			original: {
-				cmd,
-				args
-			}
-		};
-	} else {
-		parsed = crossSpawn._parse(cmd, args, opts);
-	}
-
-	opts = Object.assign({
-		maxBuffer: TEN_MEGABYTES,
-		buffer: true,
-		stripEof: true,
-		preferLocal: true,
-		localDir: parsed.options.cwd || process.cwd(),
-		encoding: 'utf8',
-		reject: true,
-		cleanup: true
-	}, parsed.options);
-
-	opts.stdio = stdio(opts);
-
-	if (opts.preferLocal) {
-		opts.env = npmRunPath.env(Object.assign({}, opts, {cwd: opts.localDir}));
-	}
-
-	if (opts.detached) {
-		// #115
-		opts.cleanup = false;
-	}
-
-	if (process.platform === 'win32' && path.basename(parsed.command) === 'cmd.exe') {
-		// #116
-		parsed.args.unshift('/q');
-	}
-
-	return {
-		cmd: parsed.command,
-		args: parsed.args,
-		opts,
-		parsed
-	};
-}
-
-function handleInput(spawned, input) {
-	if (input === null || input === undefined) {
-		return;
-	}
-
-	if (isStream_1(input)) {
-		input.pipe(spawned.stdin);
-	} else {
-		spawned.stdin.end(input);
-	}
-}
-
-function handleOutput(opts, val) {
-	if (val && opts.stripEof) {
-		val = stripEof(val);
-	}
-
-	return val;
-}
-
-function handleShell(fn, cmd, opts) {
-	let file = '/bin/sh';
-	let args = ['-c', cmd];
-
-	opts = Object.assign({}, opts);
-
-	if (process.platform === 'win32') {
-		opts.__winShell = true;
-		file = process.env.comspec || 'cmd.exe';
-		args = ['/s', '/c', `"${cmd}"`];
-		opts.windowsVerbatimArguments = true;
-	}
-
-	if (opts.shell) {
-		file = opts.shell;
-		delete opts.shell;
-	}
-
-	return fn(file, args, opts);
-}
-
-function getStream(process, stream, {encoding, buffer, maxBuffer}) {
-	if (!process[stream]) {
-		return null;
-	}
-
-	let ret;
-
-	if (!buffer) {
-		// TODO: Use `ret = util.promisify(stream.finished)(process[stream]);` when targeting Node.js 10
-		ret = new Promise((resolve, reject) => {
-			process[stream]
-				.once('end', resolve)
-				.once('error', reject);
-		});
-	} else if (encoding) {
-		ret = getStream_1(process[stream], {
-			encoding,
-			maxBuffer
-		});
-	} else {
-		ret = getStream_1.buffer(process[stream], {maxBuffer});
-	}
-
-	return ret.catch(err => {
-		err.stream = stream;
-		err.message = `${stream} ${err.message}`;
-		throw err;
-	});
-}
-
-function makeError(result, options) {
-	const {stdout, stderr} = result;
-
-	let err = result.error;
-	const {code, signal} = result;
-
-	const {parsed, joinedCmd} = options;
-	const timedOut = options.timedOut || false;
-
-	if (!err) {
-		let output = '';
-
-		if (Array.isArray(parsed.opts.stdio)) {
-			if (parsed.opts.stdio[2] !== 'inherit') {
-				output += output.length > 0 ? stderr : `\n${stderr}`;
-			}
-
-			if (parsed.opts.stdio[1] !== 'inherit') {
-				output += `\n${stdout}`;
-			}
-		} else if (parsed.opts.stdio !== 'inherit') {
-			output = `\n${stderr}${stdout}`;
-		}
-
-		err = new Error(`Command failed: ${joinedCmd}${output}`);
-		err.code = code < 0 ? errname_1(code) : code;
-	}
-
-	err.stdout = stdout;
-	err.stderr = stderr;
-	err.failed = true;
-	err.signal = signal || null;
-	err.cmd = joinedCmd;
-	err.timedOut = timedOut;
-
-	return err;
-}
-
-function joinCmd(cmd, args) {
-	let joinedCmd = cmd;
-
-	if (Array.isArray(args) && args.length > 0) {
-		joinedCmd += ' ' + args.join(' ');
-	}
-
-	return joinedCmd;
-}
-
-module.exports = (cmd, args, opts) => {
-	const parsed = handleArgs(cmd, args, opts);
-	const {encoding, buffer, maxBuffer} = parsed.opts;
-	const joinedCmd = joinCmd(cmd, args);
-
-	let spawned;
-	try {
-		spawned = child_process.spawn(parsed.cmd, parsed.args, parsed.opts);
-	} catch (err) {
-		return Promise.reject(err);
-	}
-
-	let removeExitHandler;
-	if (parsed.opts.cleanup) {
-		removeExitHandler = signalExit(() => {
-			spawned.kill();
-		});
-	}
-
-	let timeoutId = null;
-	let timedOut = false;
-
-	const cleanup = () => {
-		if (timeoutId) {
-			clearTimeout(timeoutId);
-			timeoutId = null;
-		}
-
-		if (removeExitHandler) {
-			removeExitHandler();
-		}
-	};
-
-	if (parsed.opts.timeout > 0) {
-		timeoutId = setTimeout(() => {
-			timeoutId = null;
-			timedOut = true;
-			spawned.kill(parsed.opts.killSignal);
-		}, parsed.opts.timeout);
-	}
-
-	const processDone = new Promise(resolve => {
-		spawned.on('exit', (code, signal) => {
-			cleanup();
-			resolve({code, signal});
-		});
-
-		spawned.on('error', err => {
-			cleanup();
-			resolve({error: err});
-		});
-
-		if (spawned.stdin) {
-			spawned.stdin.on('error', err => {
-				cleanup();
-				resolve({error: err});
-			});
-		}
-	});
-
-	function destroy() {
-		if (spawned.stdout) {
-			spawned.stdout.destroy();
-		}
-
-		if (spawned.stderr) {
-			spawned.stderr.destroy();
-		}
-	}
-
-	const handlePromise = () => pFinally(Promise.all([
-		processDone,
-		getStream(spawned, 'stdout', {encoding, buffer, maxBuffer}),
-		getStream(spawned, 'stderr', {encoding, buffer, maxBuffer})
-	]).then(arr => {
-		const result = arr[0];
-		result.stdout = arr[1];
-		result.stderr = arr[2];
-
-		if (result.error || result.code !== 0 || result.signal !== null) {
-			const err = makeError(result, {
-				joinedCmd,
-				parsed,
-				timedOut
-			});
-
-			// TODO: missing some timeout logic for killed
-			// https://github.com/nodejs/node/blob/master/lib/child_process.js#L203
-			// err.killed = spawned.killed || killed;
-			err.killed = err.killed || spawned.killed;
-
-			if (!parsed.opts.reject) {
-				return err;
-			}
-
-			throw err;
-		}
-
-		return {
-			stdout: handleOutput(parsed.opts, result.stdout),
-			stderr: handleOutput(parsed.opts, result.stderr),
-			code: 0,
-			failed: false,
-			killed: false,
-			signal: null,
-			cmd: joinedCmd,
-			timedOut: false
-		};
-	}), destroy);
-
-	crossSpawn._enoent.hookChildProcess(spawned, parsed.parsed);
-
-	handleInput(spawned, parsed.opts.input);
-
-	spawned.then = (onfulfilled, onrejected) => handlePromise().then(onfulfilled, onrejected);
-	spawned.catch = onrejected => handlePromise().catch(onrejected);
-
-	return spawned;
-};
-
-// TODO: set `stderr: 'ignore'` when that option is implemented
-module.exports.stdout = (...args) => module.exports(...args).then(x => x.stdout);
-
-// TODO: set `stdout: 'ignore'` when that option is implemented
-module.exports.stderr = (...args) => module.exports(...args).then(x => x.stderr);
-
-module.exports.shell = (cmd, opts) => handleShell(module.exports, cmd, opts);
-
-module.exports.sync = (cmd, args, opts) => {
-	const parsed = handleArgs(cmd, args, opts);
-	const joinedCmd = joinCmd(cmd, args);
-
-	if (isStream_1(parsed.opts.input)) {
-		throw new TypeError('The `input` option cannot be a stream in sync mode');
-	}
-
-	const result = child_process.spawnSync(parsed.cmd, parsed.args, parsed.opts);
-	result.code = result.status;
-
-	if (result.error || result.status !== 0 || result.signal !== null) {
-		const err = makeError(result, {
-			joinedCmd,
-			parsed
-		});
-
-		if (!parsed.opts.reject) {
-			return err;
-		}
-
-		throw err;
-	}
-
-	return {
-		stdout: handleOutput(parsed.opts, result.stdout),
-		stderr: handleOutput(parsed.opts, result.stderr),
-		code: 0,
-		failed: false,
-		signal: null,
-		cmd: joinedCmd,
-		timedOut: false
-	};
-};
-
-module.exports.shellSync = (cmd, opts) => handleShell(module.exports.sync, cmd, opts);
-});
-var execa_1 = execa.stdout;
-var execa_2 = execa.stderr;
-var execa_3 = execa.shell;
-var execa_4 = execa.sync;
-var execa_5 = execa.shellSync;
-
-// Reference: https://www.gaijin.at/en/lstwinver.php
-const names = new Map([
-	['10.0', '10'],
-	['6.3', '8.1'],
-	['6.2', '8'],
-	['6.1', '7'],
-	['6.0', 'Vista'],
-	['5.2', 'Server 2003'],
-	['5.1', 'XP'],
-	['5.0', '2000'],
-	['4.9', 'ME'],
-	['4.1', '98'],
-	['4.0', '95']
-]);
-
-const windowsRelease = release => {
-	const version = /\d+\.\d/.exec(release || os.release());
-
-	if (release && !version) {
-		throw new Error('`release` argument doesn\'t match `n.n`');
-	}
-
-	const ver = (version || [])[0];
-
-	// Server 2008, 2012 and 2016 versions are ambiguous with desktop versions and must be detected at runtime.
-	// If `release` is omitted or we're on a Windows system, and the version number is an ambiguous version
-	// then use `wmic` to get the OS caption: https://msdn.microsoft.com/en-us/library/aa394531(v=vs.85).aspx
-	// If the resulting caption contains the year 2008, 2012 or 2016, it is a server version, so return a server OS name.
-	if ((!release || release === os.release()) && ['6.1', '6.2', '6.3', '10.0'].includes(ver)) {
-		const stdout = execa.sync('wmic', ['os', 'get', 'Caption']).stdout || '';
-		const year = (stdout.match(/2008|2012|2016/) || [])[0];
-		if (year) {
-			return `Server ${year}`;
-		}
-	}
-
-	return names.get(ver);
-};
-
-var windowsRelease_1 = windowsRelease;
-
-const osName = (platform, release) => {
-	if (!platform && release) {
-		throw new Error('You can\'t specify a `release` without specifying `platform`');
-	}
-
-	platform = platform || os.platform();
-
-	let id;
-
-	if (platform === 'darwin') {
-		if (!release && os.platform() === 'darwin') {
-			release = os.release();
-		}
-
-		const prefix = release ? (Number(release.split('.')[0]) > 15 ? 'macOS' : 'OS X') : 'macOS';
-		id = release ? macosRelease_1(release).name : '';
-		return prefix + (id ? ' ' + id : '');
-	}
-
-	if (platform === 'linux') {
-		if (!release && os.platform() === 'linux') {
-			release = os.release();
-		}
-
-		id = release ? release.replace(/^(\d+\.\d+).*/, '$1') : '';
-		return 'Linux' + (id ? ' ' + id : '');
-	}
-
-	if (platform === 'win32') {
-		if (!release && os.platform() === 'win32') {
-			release = os.release();
-		}
-
-		id = release ? windowsRelease_1(release) : '';
-		return 'Windows' + (id ? ' ' + id : '');
-	}
-
-	return platform;
-};
-
-var osName_1 = osName;
-
-var distNode = createCommonjsModule(function (module, exports) {
-
-Object.defineProperty(exports, '__esModule', { value: true });
-
-function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
-
-var osName = _interopDefault(osName_1);
-
-function getUserAgent() {
-  try {
-    return `Node.js/${process.version.substr(1)} (${osName()}; ${process.arch})`;
-  } catch (error) {
-    if (/wmic os get Caption/.test(error.message)) {
-      return "Windows <version undetectable>";
-    }
-
-    throw error;
-  }
-}
-
-exports.getUserAgent = getUserAgent;
-
-});
-
-unwrapExports(distNode);
-var distNode_1 = distNode.getUserAgent;
+unwrapExports(isPlainObject_1);
+var isPlainObject_2 = isPlainObject_1.isPlainObject;
 
 var distNode$1 = createCommonjsModule(function (module, exports) {
 
 Object.defineProperty(exports, '__esModule', { value: true });
 
-function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
 
-var isPlainObject = _interopDefault(index_cjs);
 
 
 function lowercaseKeys(object) {
@@ -3823,7 +1535,7 @@ function lowercaseKeys(object) {
 function mergeDeep(defaults, options) {
   const result = Object.assign({}, defaults);
   Object.keys(options).forEach(key => {
-    if (isPlainObject(options[key])) {
+    if (isPlainObject_1.isPlainObject(options[key])) {
       if (!(key in defaults)) Object.assign(result, {
         [key]: options[key]
       });else result[key] = mergeDeep(defaults[key], options[key]);
@@ -3834,6 +1546,16 @@ function mergeDeep(defaults, options) {
     }
   });
   return result;
+}
+
+function removeUndefinedProperties(obj) {
+  for (const key in obj) {
+    if (obj[key] === undefined) {
+      delete obj[key];
+    }
+  }
+
+  return obj;
 }
 
 function merge(defaults, route, options) {
@@ -3850,7 +1572,10 @@ function merge(defaults, route, options) {
   } // lowercase header names before merging with defaults to avoid duplicates
 
 
-  options.headers = lowercaseKeys(options.headers);
+  options.headers = lowercaseKeys(options.headers); // remove properties with undefined values before merging
+
+  removeUndefinedProperties(options);
+  removeUndefinedProperties(options.headers);
   const mergedOptions = mergeDeep(defaults || {}, options); // mediaType.previews arrays are merged, instead of overwritten
 
   if (defaults && defaults.mediaType.previews.length) {
@@ -4072,7 +1797,7 @@ function parse(options) {
   // https://fetch.spec.whatwg.org/#methods
   let method = options.method.toUpperCase(); // replace :varname with {varname} to make it RFC 6570 compatible
 
-  let url = (options.url || "/").replace(/:([a-z]\w+)/g, "{+$1}");
+  let url = (options.url || "/").replace(/:([a-z]\w+)/g, "{$1}");
   let headers = Object.assign({}, options.headers);
   let body;
   let parameters = omit(options, ["method", "baseUrl", "url", "headers", "request", "mediaType"]); // extract variable names from URL to calculate remaining variables later
@@ -4086,9 +1811,9 @@ function parse(options) {
 
   const omittedParameters = Object.keys(options).filter(option => urlVariableNames.includes(option)).concat("baseUrl");
   const remainingParameters = omit(parameters, omittedParameters);
-  const isBinaryRequset = /application\/octet-stream/i.test(headers.accept);
+  const isBinaryRequest = /application\/octet-stream/i.test(headers.accept);
 
-  if (!isBinaryRequset) {
+  if (!isBinaryRequest) {
     if (options.mediaType.format) {
       // e.g. application/vnd.github.v3+json => application/vnd.github.v3.raw
       headers.accept = headers.accept.split(/,/).map(preview => preview.replace(/application\/vnd(\.\w+)(\.v3)?(\.\w+)?(\+json)?$/, `application/vnd$1$2.${options.mediaType.format}`)).join(",");
@@ -4157,7 +1882,7 @@ function withDefaults(oldDefaults, newDefaults) {
   });
 }
 
-const VERSION = "5.5.1";
+const VERSION = "6.0.10";
 
 const userAgent = `octokit-endpoint.js/${VERSION} ${distNode.getUserAgent()}`; // DEFAULTS has all properties set that EndpointOptions has, except url.
 // So we use RequestParameters and add method as additional required property.
@@ -4184,16 +1909,9 @@ exports.endpoint = endpoint;
 unwrapExports(distNode$1);
 var distNode_1$1 = distNode$1.endpoint;
 
-/*!
- * isobject <https://github.com/jonschlinkert/isobject>
- *
- * Copyright (c) 2014-2017, Jon Schlinkert.
- * Released under the MIT License.
- */
+var isPlainObject_1$1 = createCommonjsModule(function (module, exports) {
 
-function isObject$1(val) {
-  return val != null && typeof val === 'object' && Array.isArray(val) === false;
-}
+Object.defineProperty(exports, '__esModule', { value: true });
 
 /*!
  * is-plain-object <https://github.com/jonschlinkert/is-plain-object>
@@ -4202,23 +1920,22 @@ function isObject$1(val) {
  * Released under the MIT License.
  */
 
-function isObjectObject$1(o) {
-  return isObject$1(o) === true
-    && Object.prototype.toString.call(o) === '[object Object]';
+function isObject(o) {
+  return Object.prototype.toString.call(o) === '[object Object]';
 }
 
-function isPlainObject$1(o) {
+function isPlainObject(o) {
   var ctor,prot;
 
-  if (isObjectObject$1(o) === false) return false;
+  if (isObject(o) === false) return false;
 
   // If has modified constructor
   ctor = o.constructor;
-  if (typeof ctor !== 'function') return false;
+  if (ctor === undefined) return true;
 
   // If has modified prototype
   prot = ctor.prototype;
-  if (isObjectObject$1(prot) === false) return false;
+  if (isObject(prot) === false) return false;
 
   // If constructor does not have an Object-specific method
   if (prot.hasOwnProperty('isPrototypeOf') === false) {
@@ -4229,7 +1946,11 @@ function isPlainObject$1(o) {
   return true;
 }
 
-var index_cjs$1 = isPlainObject$1;
+exports.isPlainObject = isPlainObject;
+});
+
+unwrapExports(isPlainObject_1$1);
+var isPlainObject_2$1 = isPlainObject_1$1.isPlainObject;
 
 // Based on https://github.com/tmpvar/jsdom/blob/aa85b2abf07766ff7bf5c1f6daafb3726f2f2db5/lib/jsdom/living/blob.js
 
@@ -4386,7 +2107,7 @@ try {
 const INTERNALS = Symbol('Body internals');
 
 // fix an issue where "PassThrough" isn't a named export for node <10
-const PassThrough$1 = Stream.PassThrough;
+const PassThrough = Stream.PassThrough;
 
 /**
  * Body mixin
@@ -4686,6 +2407,12 @@ function convertBody(buffer, headers) {
 	// html4
 	if (!res && str) {
 		res = /<meta[\s]+?http-equiv=(['"])content-type\1[\s]+?content=(['"])(.+?)\2/i.exec(str);
+		if (!res) {
+			res = /<meta[\s]+?content=(['"])(.+?)\1[\s]+?http-equiv=(['"])content-type\3/i.exec(str);
+			if (res) {
+				res.pop(); // drop last quote
+			}
+		}
 
 		if (res) {
 			res = /charset=(.*)/i.exec(res.pop());
@@ -4757,8 +2484,8 @@ function clone(instance) {
 	// note: we can't clone the form-data object without having it as a dependency
 	if (body instanceof Stream && typeof body.getBoundary !== 'function') {
 		// tee instance body
-		p1 = new PassThrough$1();
-		p2 = new PassThrough$1();
+		p1 = new PassThrough();
+		p2 = new PassThrough();
 		body.pipe(p1);
 		body.pipe(p2);
 		// set instance body to teed body and return the other teed body
@@ -5369,7 +3096,7 @@ const streamDestructionSupported = 'destroy' in Stream.Readable.prototype;
  * @param   Mixed   input
  * @return  Boolean
  */
-function isRequest$2(input) {
+function isRequest(input) {
 	return typeof input === 'object' && typeof input[INTERNALS$2] === 'object';
 }
 
@@ -5392,7 +3119,7 @@ class Request {
 		let parsedURL;
 
 		// normalize input
-		if (!isRequest$2(input)) {
+		if (!isRequest(input)) {
 			if (input && input.href) {
 				// in order to support Node.js' Url objects; though WHATWG's URL objects
 				// will fall into this branch also (since their `toString()` will return
@@ -5410,11 +3137,11 @@ class Request {
 		let method = init.method || input.method || 'GET';
 		method = method.toUpperCase();
 
-		if ((init.body != null || isRequest$2(input) && input.body !== null) && (method === 'GET' || method === 'HEAD')) {
+		if ((init.body != null || isRequest(input) && input.body !== null) && (method === 'GET' || method === 'HEAD')) {
 			throw new TypeError('Request with GET/HEAD method cannot have body');
 		}
 
-		let inputBody = init.body != null ? init.body : isRequest$2(input) && input.body !== null ? clone(input) : null;
+		let inputBody = init.body != null ? init.body : isRequest(input) && input.body !== null ? clone(input) : null;
 
 		Body.call(this, inputBody, {
 			timeout: init.timeout || input.timeout || 0,
@@ -5430,7 +3157,7 @@ class Request {
 			}
 		}
 
-		let signal = isRequest$2(input) ? input.signal : null;
+		let signal = isRequest(input) ? input.signal : null;
 		if ('signal' in init) signal = init.signal;
 
 		if (signal != null && !isAbortSignal(signal)) {
@@ -5599,7 +3326,7 @@ AbortError.prototype.constructor = AbortError;
 AbortError.prototype.name = 'AbortError';
 
 // fix an issue where "PassThrough", "resolve" aren't a named export for node <10
-const PassThrough$1$1 = Stream.PassThrough;
+const PassThrough$1 = Stream.PassThrough;
 const resolve_url = Url.resolve;
 
 /**
@@ -5693,7 +3420,7 @@ function fetch(url, opts) {
 				// HTTP fetch step 5.5
 				switch (request.redirect) {
 					case 'error':
-						reject(new FetchError(`redirect mode is set to error: ${request.url}`, 'no-redirect'));
+						reject(new FetchError(`uri requested responds with a redirect, redirect mode is set to error: ${request.url}`, 'no-redirect'));
 						finalize();
 						return;
 					case 'manual':
@@ -5732,7 +3459,8 @@ function fetch(url, opts) {
 							method: request.method,
 							body: request.body,
 							signal: request.signal,
-							timeout: request.timeout
+							timeout: request.timeout,
+							size: request.size
 						};
 
 						// HTTP-redirect fetch step 9
@@ -5760,7 +3488,7 @@ function fetch(url, opts) {
 			res.once('end', function () {
 				if (signal) signal.removeEventListener('abort', abortAndFinalize);
 			});
-			let body = res.pipe(new PassThrough$1$1());
+			let body = res.pipe(new PassThrough$1());
 
 			const response_options = {
 				url: request.url,
@@ -5811,7 +3539,7 @@ function fetch(url, opts) {
 			if (codings == 'deflate' || codings == 'x-deflate') {
 				// handle the infamous raw deflate response from old servers
 				// a hack for old IIS and Apache servers
-				const raw = res.pipe(new PassThrough$1$1());
+				const raw = res.pipe(new PassThrough$1());
 				raw.once('data', function (chunk) {
 					// see http://stackoverflow.com/questions/37519828
 					if ((chunk[0] & 0x0F) === 0x08) {
@@ -5888,6 +3616,83 @@ exports.Deprecation = Deprecation;
 unwrapExports(distNode$2);
 var distNode_1$2 = distNode$2.Deprecation;
 
+// Returns a wrapper function that returns a wrapped callback
+// The wrapper function should do some stuff, and return a
+// presumably different callback function.
+// This makes sure that own properties are retained, so that
+// decorations and such are not lost along the way.
+var wrappy_1 = wrappy;
+function wrappy (fn, cb) {
+  if (fn && cb) return wrappy(fn)(cb)
+
+  if (typeof fn !== 'function')
+    throw new TypeError('need wrapper function')
+
+  Object.keys(fn).forEach(function (k) {
+    wrapper[k] = fn[k];
+  });
+
+  return wrapper
+
+  function wrapper() {
+    var args = new Array(arguments.length);
+    for (var i = 0; i < args.length; i++) {
+      args[i] = arguments[i];
+    }
+    var ret = fn.apply(this, args);
+    var cb = args[args.length-1];
+    if (typeof ret === 'function' && ret !== cb) {
+      Object.keys(cb).forEach(function (k) {
+        ret[k] = cb[k];
+      });
+    }
+    return ret
+  }
+}
+
+var once_1 = wrappy_1(once);
+var strict = wrappy_1(onceStrict);
+
+once.proto = once(function () {
+  Object.defineProperty(Function.prototype, 'once', {
+    value: function () {
+      return once(this)
+    },
+    configurable: true
+  });
+
+  Object.defineProperty(Function.prototype, 'onceStrict', {
+    value: function () {
+      return onceStrict(this)
+    },
+    configurable: true
+  });
+});
+
+function once (fn) {
+  var f = function () {
+    if (f.called) return f.value
+    f.called = true;
+    return f.value = fn.apply(this, arguments)
+  };
+  f.called = false;
+  return f
+}
+
+function onceStrict (fn) {
+  var f = function () {
+    if (f.called)
+      throw new Error(f.onceError)
+    f.called = true;
+    return f.value = fn.apply(this, arguments)
+  };
+  var name = fn.name || 'Function wrapped with `once`';
+  f.onceError = name + " shouldn't be called more than once";
+  f.called = false;
+  return f
+}
+once_1.strict = strict;
+
 var distNode$3 = createCommonjsModule(function (module, exports) {
 
 Object.defineProperty(exports, '__esModule', { value: true });
@@ -5948,7 +3753,7 @@ exports.RequestError = RequestError;
 unwrapExports(distNode$3);
 var distNode_1$3 = distNode$3.RequestError;
 
-var require$$1 = getCjsExportFromNamespace(lib);
+var require$$0 = getCjsExportFromNamespace(lib);
 
 var distNode$4 = createCommonjsModule(function (module, exports) {
 
@@ -5958,18 +3763,18 @@ function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'defau
 
 
 
-var isPlainObject = _interopDefault(index_cjs$1);
-var nodeFetch = _interopDefault(require$$1);
+
+var nodeFetch = _interopDefault(require$$0);
 
 
-const VERSION = "5.3.1";
+const VERSION = "5.4.12";
 
 function getBufferResponse(response) {
   return response.arrayBuffer();
 }
 
 function fetchWrapper(requestOptions) {
-  if (isPlainObject(requestOptions.body) || Array.isArray(requestOptions.body)) {
+  if (isPlainObject_1$1.isPlainObject(requestOptions.body) || Array.isArray(requestOptions.body)) {
     requestOptions.body = JSON.stringify(requestOptions.body);
   }
 
@@ -5992,7 +3797,7 @@ function fetchWrapper(requestOptions) {
 
     if (status === 204 || status === 205) {
       return;
-    } // GitHub API returns 200 for HEAD requsets
+    } // GitHub API returns 200 for HEAD requests
 
 
     if (requestOptions.method === "HEAD") {
@@ -6023,7 +3828,7 @@ function fetchWrapper(requestOptions) {
         try {
           let responseBody = JSON.parse(error.message);
           Object.assign(error, responseBody);
-          let errors = responseBody.errors; // Assumption `errors` would always be in Array Fotmat
+          let errors = responseBody.errors; // Assumption `errors` would always be in Array format
 
           error.message = error.message + ": " + errors.map(JSON.stringify).join(", ");
         } catch (e) {// ignore, see octokit/rest.js#684
@@ -6103,2194 +3908,1578 @@ exports.request = request;
 unwrapExports(distNode$4);
 var distNode_1$4 = distNode$4.request;
 
-var universalUserAgent = getUserAgentNode;
+var distNode$5 = createCommonjsModule(function (module, exports) {
+
+Object.defineProperty(exports, '__esModule', { value: true });
 
 
 
-function getUserAgentNode () {
-  try {
-    return `Node.js/${process.version.substr(1)} (${osName_1()}; ${process.arch})`
-  } catch (error) {
-    if (/wmic os get Caption/.test(error.message)) {
-      return 'Windows <version undetectable>'
-    }
 
-    throw error
-  }
-}
+const VERSION = "4.5.8";
 
-var name = "@octokit/graphql";
-var version = "2.1.3";
-var publishConfig = {
-	access: "public"
-};
-var description = "GitHub GraphQL API client for browsers and Node";
-var main = "index.js";
-var scripts = {
-	prebuild: "mkdirp dist/",
-	build: "npm-run-all build:*",
-	"build:development": "webpack --mode development --entry . --output-library=octokitGraphql --output=./dist/octokit-graphql.js --profile --json > dist/bundle-stats.json",
-	"build:production": "webpack --mode production --entry . --plugin=compression-webpack-plugin --output-library=octokitGraphql --output-path=./dist --output-filename=octokit-graphql.min.js --devtool source-map",
-	"bundle-report": "webpack-bundle-analyzer dist/bundle-stats.json --mode=static --no-open --report dist/bundle-report.html",
-	coverage: "nyc report --reporter=html && open coverage/index.html",
-	"coverage:upload": "nyc report --reporter=text-lcov | coveralls",
-	pretest: "standard",
-	test: "nyc mocha test/*-test.js",
-	"test:browser": "cypress run --browser chrome"
-};
-var repository = {
-	type: "git",
-	url: "https://github.com/octokit/graphql.js.git"
-};
-var keywords = [
-	"octokit",
-	"github",
-	"api",
-	"graphql"
-];
-var author = "Gregor Martynus (https://github.com/gr2m)";
-var license = "MIT";
-var bugs = {
-	url: "https://github.com/octokit/graphql.js/issues"
-};
-var homepage = "https://github.com/octokit/graphql.js#readme";
-var dependencies = {
-	"@octokit/request": "^5.0.0",
-	"universal-user-agent": "^2.0.3"
-};
-var devDependencies = {
-	chai: "^4.2.0",
-	"compression-webpack-plugin": "^2.0.0",
-	coveralls: "^3.0.3",
-	cypress: "^3.1.5",
-	"fetch-mock": "^7.3.1",
-	mkdirp: "^0.5.1",
-	mocha: "^6.0.0",
-	"npm-run-all": "^4.1.3",
-	nyc: "^14.0.0",
-	"semantic-release": "^15.13.3",
-	"simple-mock": "^0.8.0",
-	standard: "^12.0.1",
-	webpack: "^4.29.6",
-	"webpack-bundle-analyzer": "^3.1.0",
-	"webpack-cli": "^3.2.3"
-};
-var bundlesize = [
-	{
-		path: "./dist/octokit-graphql.min.js.gz",
-		maxSize: "5KB"
-	}
-];
-var release = {
-	publish: [
-		"@semantic-release/npm",
-		{
-			path: "@semantic-release/github",
-			assets: [
-				"dist/*",
-				"!dist/*.map.gz"
-			]
-		}
-	]
-};
-var standard = {
-	globals: [
-		"describe",
-		"before",
-		"beforeEach",
-		"afterEach",
-		"after",
-		"it",
-		"expect"
-	]
-};
-var files = [
-	"lib"
-];
-var _package = {
-	name: name,
-	version: version,
-	publishConfig: publishConfig,
-	description: description,
-	main: main,
-	scripts: scripts,
-	repository: repository,
-	keywords: keywords,
-	author: author,
-	license: license,
-	bugs: bugs,
-	homepage: homepage,
-	dependencies: dependencies,
-	devDependencies: devDependencies,
-	bundlesize: bundlesize,
-	release: release,
-	standard: standard,
-	files: files
-};
-
-var _package$1 = /*#__PURE__*/Object.freeze({
-	__proto__: null,
-	name: name,
-	version: version,
-	publishConfig: publishConfig,
-	description: description,
-	main: main,
-	scripts: scripts,
-	repository: repository,
-	keywords: keywords,
-	author: author,
-	license: license,
-	bugs: bugs,
-	homepage: homepage,
-	dependencies: dependencies,
-	devDependencies: devDependencies,
-	bundlesize: bundlesize,
-	release: release,
-	standard: standard,
-	files: files,
-	'default': _package
-});
-
-var error = class GraphqlError extends Error {
-  constructor (request, response) {
+class GraphqlError extends Error {
+  constructor(request, response) {
     const message = response.data.errors[0].message;
     super(message);
-
     Object.assign(this, response.data);
-    this.name = 'GraphqlError';
-    this.request = request;
+    Object.assign(this, {
+      headers: response.headers
+    });
+    this.name = "GraphqlError";
+    this.request = request; // Maintains proper stack trace (only available on V8)
 
-    // Maintains proper stack trace (only available on V8)
     /* istanbul ignore next */
+
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, this.constructor);
     }
   }
-};
 
-var graphql_1 = graphql;
+}
 
-
-
-const NON_VARIABLE_OPTIONS = ['method', 'baseUrl', 'url', 'headers', 'request', 'query'];
-
-function graphql (request, query, options) {
-  if (typeof query === 'string') {
-    options = Object.assign({ query }, options);
-  } else {
-    options = query;
+const NON_VARIABLE_OPTIONS = ["method", "baseUrl", "url", "headers", "request", "query", "mediaType"];
+const GHES_V3_SUFFIX_REGEX = /\/api\/v3\/?$/;
+function graphql(request, query, options) {
+  if (typeof query === "string" && options && "query" in options) {
+    return Promise.reject(new Error(`[@octokit/graphql] "query" cannot be used as variable name`));
   }
 
-  const requestOptions = Object.keys(options).reduce((result, key) => {
+  const parsedOptions = typeof query === "string" ? Object.assign({
+    query
+  }, options) : query;
+  const requestOptions = Object.keys(parsedOptions).reduce((result, key) => {
     if (NON_VARIABLE_OPTIONS.includes(key)) {
-      result[key] = options[key];
-      return result
+      result[key] = parsedOptions[key];
+      return result;
     }
 
     if (!result.variables) {
       result.variables = {};
     }
 
-    result.variables[key] = options[key];
-    return result
-  }, {});
+    result.variables[key] = parsedOptions[key];
+    return result;
+  }, {}); // workaround for GitHub Enterprise baseUrl set with /api/v3 suffix
+  // https://github.com/octokit/auth-app.js/issues/111#issuecomment-657610451
 
-  return request(requestOptions)
-    .then(response => {
-      if (response.data.errors) {
-        throw new error(requestOptions, response)
+  const baseUrl = parsedOptions.baseUrl || request.endpoint.DEFAULTS.baseUrl;
+
+  if (GHES_V3_SUFFIX_REGEX.test(baseUrl)) {
+    requestOptions.url = baseUrl.replace(GHES_V3_SUFFIX_REGEX, "/api/graphql");
+  }
+
+  return request(requestOptions).then(response => {
+    if (response.data.errors) {
+      const headers = {};
+
+      for (const key of Object.keys(response.headers)) {
+        headers[key] = response.headers[key];
       }
 
-      return response.data.data
-    })
-}
-
-var withDefaults_1 = withDefaults;
-
-
-
-function withDefaults (request, newDefaults) {
-  const newRequest = request.defaults(newDefaults);
-  const newApi = function (query, options) {
-    return graphql_1(newRequest, query, options)
-  };
-
-  newApi.defaults = withDefaults.bind(null, newRequest);
-  return newApi
-}
-
-var require$$1$1 = getCjsExportFromNamespace(_package$1);
-
-const { request } = distNode$4;
-
-
-const version$1 = require$$1$1.version;
-const userAgent = `octokit-graphql.js/${version$1} ${universalUserAgent()}`;
-
-
-
-var graphql$1 = withDefaults_1(request, {
-  method: 'POST',
-  url: '/graphql',
-  headers: {
-    'user-agent': userAgent
-  }
-});
-
-var register_1 = register;
-
-function register (state, name, method, options) {
-  if (typeof method !== 'function') {
-    throw new Error('method for before hook must be a function')
-  }
-
-  if (!options) {
-    options = {};
-  }
-
-  if (Array.isArray(name)) {
-    return name.reverse().reduce(function (callback, name) {
-      return register.bind(null, state, name, callback, options)
-    }, method)()
-  }
-
-  return Promise.resolve()
-    .then(function () {
-      if (!state.registry[name]) {
-        return method(options)
-      }
-
-      return (state.registry[name]).reduce(function (method, registered) {
-        return registered.hook.bind(null, method, options)
-      }, method)()
-    })
-}
-
-var add = addHook;
-
-function addHook (state, kind, name, hook) {
-  var orig = hook;
-  if (!state.registry[name]) {
-    state.registry[name] = [];
-  }
-
-  if (kind === 'before') {
-    hook = function (method, options) {
-      return Promise.resolve()
-        .then(orig.bind(null, options))
-        .then(method.bind(null, options))
-    };
-  }
-
-  if (kind === 'after') {
-    hook = function (method, options) {
-      var result;
-      return Promise.resolve()
-        .then(method.bind(null, options))
-        .then(function (result_) {
-          result = result_;
-          return orig(result, options)
-        })
-        .then(function () {
-          return result
-        })
-    };
-  }
-
-  if (kind === 'error') {
-    hook = function (method, options) {
-      return Promise.resolve()
-        .then(method.bind(null, options))
-        .catch(function (error) {
-          return orig(error, options)
-        })
-    };
-  }
-
-  state.registry[name].push({
-    hook: hook,
-    orig: orig
-  });
-}
-
-var remove = removeHook;
-
-function removeHook (state, name, method) {
-  if (!state.registry[name]) {
-    return
-  }
-
-  var index = state.registry[name]
-    .map(function (registered) { return registered.orig })
-    .indexOf(method);
-
-  if (index === -1) {
-    return
-  }
-
-  state.registry[name].splice(index, 1);
-}
-
-// bind with array of arguments: https://stackoverflow.com/a/21792913
-var bind = Function.bind;
-var bindable = bind.bind(bind);
-
-function bindApi (hook, state, name) {
-  var removeHookRef = bindable(remove, null).apply(null, name ? [state, name] : [state]);
-  hook.api = { remove: removeHookRef };
-  hook.remove = removeHookRef
-
-  ;['before', 'error', 'after', 'wrap'].forEach(function (kind) {
-    var args = name ? [state, kind, name] : [state, kind];
-    hook[kind] = hook.api[kind] = bindable(add, null).apply(null, args);
-  });
-}
-
-function HookSingular () {
-  var singularHookName = 'h';
-  var singularHookState = {
-    registry: {}
-  };
-  var singularHook = register_1.bind(null, singularHookState, singularHookName);
-  bindApi(singularHook, singularHookState, singularHookName);
-  return singularHook
-}
-
-function HookCollection () {
-  var state = {
-    registry: {}
-  };
-
-  var hook = register_1.bind(null, state);
-  bindApi(hook, state);
-
-  return hook
-}
-
-var collectionHookDeprecationMessageDisplayed = false;
-function Hook () {
-  if (!collectionHookDeprecationMessageDisplayed) {
-    console.warn('[before-after-hook]: "Hook()" repurposing warning, use "Hook.Collection()". Read more: https://git.io/upgrade-before-after-hook-to-1.4');
-    collectionHookDeprecationMessageDisplayed = true;
-  }
-  return HookCollection()
-}
-
-Hook.Singular = HookSingular.bind();
-Hook.Collection = HookCollection.bind();
-
-var beforeAfterHook = Hook;
-// expose constructors as a named property for TypeScript
-var Hook_1 = Hook;
-var Singular = Hook.Singular;
-var Collection = Hook.Collection;
-beforeAfterHook.Hook = Hook_1;
-beforeAfterHook.Singular = Singular;
-beforeAfterHook.Collection = Collection;
-
-var name$1 = "@octokit/rest";
-var version$2 = "16.35.0";
-var publishConfig$1 = {
-	access: "public"
-};
-var description$1 = "GitHub REST API client for Node.js";
-var keywords$1 = [
-	"octokit",
-	"github",
-	"rest",
-	"api-client"
-];
-var author$1 = "Gregor Martynus (https://github.com/gr2m)";
-var contributors = [
-	{
-		name: "Mike de Boer",
-		email: "info@mikedeboer.nl"
-	},
-	{
-		name: "Fabian Jakobs",
-		email: "fabian@c9.io"
-	},
-	{
-		name: "Joe Gallo",
-		email: "joe@brassafrax.com"
-	},
-	{
-		name: "Gregor Martynus",
-		url: "https://github.com/gr2m"
-	}
-];
-var repository$1 = "https://github.com/octokit/rest.js";
-var dependencies$1 = {
-	"@octokit/request": "^5.2.0",
-	"@octokit/request-error": "^1.0.2",
-	"atob-lite": "^2.0.0",
-	"before-after-hook": "^2.0.0",
-	"btoa-lite": "^1.0.0",
-	deprecation: "^2.0.0",
-	"lodash.get": "^4.4.2",
-	"lodash.set": "^4.3.2",
-	"lodash.uniq": "^4.5.0",
-	"octokit-pagination-methods": "^1.1.0",
-	once: "^1.4.0",
-	"universal-user-agent": "^4.0.0"
-};
-var devDependencies$1 = {
-	"@gimenete/type-writer": "^0.1.3",
-	"@octokit/fixtures-server": "^5.0.6",
-	"@octokit/graphql": "^4.2.0",
-	"@types/node": "^12.0.0",
-	bundlesize: "^0.18.0",
-	chai: "^4.1.2",
-	"compression-webpack-plugin": "^3.0.0",
-	cypress: "^3.0.0",
-	glob: "^7.1.2",
-	"http-proxy-agent": "^2.1.0",
-	"lodash.camelcase": "^4.3.0",
-	"lodash.merge": "^4.6.1",
-	"lodash.upperfirst": "^4.3.1",
-	mkdirp: "^0.5.1",
-	mocha: "^6.0.0",
-	mustache: "^3.0.0",
-	nock: "^11.3.3",
-	"npm-run-all": "^4.1.2",
-	nyc: "^14.0.0",
-	prettier: "^1.14.2",
-	proxy: "^1.0.0",
-	"semantic-release": "^15.0.0",
-	sinon: "^7.2.4",
-	"sinon-chai": "^3.0.0",
-	"sort-keys": "^4.0.0",
-	"string-to-arraybuffer": "^1.0.0",
-	"string-to-jsdoc-comment": "^1.0.0",
-	typescript: "^3.3.1",
-	webpack: "^4.0.0",
-	"webpack-bundle-analyzer": "^3.0.0",
-	"webpack-cli": "^3.0.0"
-};
-var types = "index.d.ts";
-var scripts$1 = {
-	coverage: "nyc report --reporter=html && open coverage/index.html",
-	lint: "prettier --check '{lib,plugins,scripts,test}/**/*.{js,json,ts}' 'docs/*.{js,json}' 'docs/src/**/*' index.js README.md package.json",
-	"lint:fix": "prettier --write '{lib,plugins,scripts,test}/**/*.{js,json,ts}' 'docs/*.{js,json}' 'docs/src/**/*' index.js README.md package.json",
-	pretest: "npm run -s lint",
-	test: "nyc mocha test/mocha-node-setup.js \"test/*/**/*-test.js\"",
-	"test:browser": "cypress run --browser chrome",
-	build: "npm-run-all build:*",
-	"build:ts": "npm run -s update-endpoints:typescript",
-	"prebuild:browser": "mkdirp dist/",
-	"build:browser": "npm-run-all build:browser:*",
-	"build:browser:development": "webpack --mode development --entry . --output-library=Octokit --output=./dist/octokit-rest.js --profile --json > dist/bundle-stats.json",
-	"build:browser:production": "webpack --mode production --entry . --plugin=compression-webpack-plugin --output-library=Octokit --output-path=./dist --output-filename=octokit-rest.min.js --devtool source-map",
-	"generate-bundle-report": "webpack-bundle-analyzer dist/bundle-stats.json --mode=static --no-open --report dist/bundle-report.html",
-	"update-endpoints": "npm-run-all update-endpoints:*",
-	"update-endpoints:fetch-json": "node scripts/update-endpoints/fetch-json",
-	"update-endpoints:code": "node scripts/update-endpoints/code",
-	"update-endpoints:typescript": "node scripts/update-endpoints/typescript",
-	"prevalidate:ts": "npm run -s build:ts",
-	"validate:ts": "tsc --target es6 --noImplicitAny index.d.ts",
-	"postvalidate:ts": "tsc --noEmit --target es6 test/typescript-validate.ts",
-	"start-fixtures-server": "octokit-fixtures-server"
-};
-var license$1 = "MIT";
-var files$1 = [
-	"index.js",
-	"index.d.ts",
-	"lib",
-	"plugins"
-];
-var nyc = {
-	ignore: [
-		"test"
-	]
-};
-var release$1 = {
-	publish: [
-		"@semantic-release/npm",
-		{
-			path: "@semantic-release/github",
-			assets: [
-				"dist/*",
-				"!dist/*.map.gz"
-			]
-		}
-	]
-};
-var bundlesize$1 = [
-	{
-		path: "./dist/octokit-rest.min.js.gz",
-		maxSize: "33 kB"
-	}
-];
-var _package$2 = {
-	name: name$1,
-	version: version$2,
-	publishConfig: publishConfig$1,
-	description: description$1,
-	keywords: keywords$1,
-	author: author$1,
-	contributors: contributors,
-	repository: repository$1,
-	dependencies: dependencies$1,
-	devDependencies: devDependencies$1,
-	types: types,
-	scripts: scripts$1,
-	license: license$1,
-	files: files$1,
-	nyc: nyc,
-	release: release$1,
-	bundlesize: bundlesize$1
-};
-
-var _package$3 = /*#__PURE__*/Object.freeze({
-	__proto__: null,
-	name: name$1,
-	version: version$2,
-	publishConfig: publishConfig$1,
-	description: description$1,
-	keywords: keywords$1,
-	author: author$1,
-	contributors: contributors,
-	repository: repository$1,
-	dependencies: dependencies$1,
-	devDependencies: devDependencies$1,
-	types: types,
-	scripts: scripts$1,
-	license: license$1,
-	files: files$1,
-	nyc: nyc,
-	release: release$1,
-	bundlesize: bundlesize$1,
-	'default': _package$2
-});
-
-var pkg = getCjsExportFromNamespace(_package$3);
-
-var parseClientOptions = parseOptions;
-
-const { Deprecation } = distNode$2;
-const { getUserAgent } = distNode;
-
-
-
-
-const deprecateOptionsTimeout = once_1((log, deprecation) =>
-  log.warn(deprecation)
-);
-const deprecateOptionsAgent = once_1((log, deprecation) => log.warn(deprecation));
-const deprecateOptionsHeaders = once_1((log, deprecation) =>
-  log.warn(deprecation)
-);
-
-function parseOptions(options, log, hook) {
-  if (options.headers) {
-    options.headers = Object.keys(options.headers).reduce((newObj, key) => {
-      newObj[key.toLowerCase()] = options.headers[key];
-      return newObj;
-    }, {});
-  }
-
-  const clientDefaults = {
-    headers: options.headers || {},
-    request: options.request || {},
-    mediaType: {
-      previews: [],
-      format: ""
+      throw new GraphqlError(requestOptions, {
+        headers,
+        data: response.data
+      });
     }
-  };
 
-  if (options.baseUrl) {
-    clientDefaults.baseUrl = options.baseUrl;
-  }
-
-  if (options.userAgent) {
-    clientDefaults.headers["user-agent"] = options.userAgent;
-  }
-
-  if (options.previews) {
-    clientDefaults.mediaType.previews = options.previews;
-  }
-
-  if (options.timeZone) {
-    clientDefaults.headers["time-zone"] = options.timeZone;
-  }
-
-  if (options.timeout) {
-    deprecateOptionsTimeout(
-      log,
-      new Deprecation(
-        "[@octokit/rest] new Octokit({timeout}) is deprecated. Use {request: {timeout}} instead. See https://github.com/octokit/request.js#request"
-      )
-    );
-    clientDefaults.request.timeout = options.timeout;
-  }
-
-  if (options.agent) {
-    deprecateOptionsAgent(
-      log,
-      new Deprecation(
-        "[@octokit/rest] new Octokit({agent}) is deprecated. Use {request: {agent}} instead. See https://github.com/octokit/request.js#request"
-      )
-    );
-    clientDefaults.request.agent = options.agent;
-  }
-
-  if (options.headers) {
-    deprecateOptionsHeaders(
-      log,
-      new Deprecation(
-        "[@octokit/rest] new Octokit({headers}) is deprecated. Use {userAgent, previews} instead. See https://github.com/octokit/request.js#request"
-      )
-    );
-  }
-
-  const userAgentOption = clientDefaults.headers["user-agent"];
-  const defaultUserAgent = `octokit.js/${pkg.version} ${getUserAgent()}`;
-
-  clientDefaults.headers["user-agent"] = [userAgentOption, defaultUserAgent]
-    .filter(Boolean)
-    .join(" ");
-
-  clientDefaults.request.hook = hook.bind(null, "request");
-
-  return clientDefaults;
+    return response.data.data;
+  });
 }
 
-var constructor_1 = Octokit;
+function withDefaults(request$1, newDefaults) {
+  const newRequest = request$1.defaults(newDefaults);
 
-const { request: request$1 } = distNode$4;
+  const newApi = (query, options) => {
+    return graphql(newRequest, query, options);
+  };
+
+  return Object.assign(newApi, {
+    defaults: withDefaults.bind(null, newRequest),
+    endpoint: distNode$4.request.endpoint
+  });
+}
+
+const graphql$1 = withDefaults(distNode$4.request, {
+  headers: {
+    "user-agent": `octokit-graphql.js/${VERSION} ${distNode.getUserAgent()}`
+  },
+  method: "POST",
+  url: "/graphql"
+});
+function withCustomRequest(customRequest) {
+  return withDefaults(customRequest, {
+    method: "POST",
+    url: "/graphql"
+  });
+}
+
+exports.graphql = graphql$1;
+exports.withCustomRequest = withCustomRequest;
+
+});
+
+unwrapExports(distNode$5);
+var distNode_1$5 = distNode$5.graphql;
+var distNode_2 = distNode$5.withCustomRequest;
+
+var distNode$6 = createCommonjsModule(function (module, exports) {
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+async function auth(token) {
+  const tokenType = token.split(/\./).length === 3 ? "app" : /^v\d+\./.test(token) ? "installation" : "oauth";
+  return {
+    type: "token",
+    token: token,
+    tokenType
+  };
+}
+
+/**
+ * Prefix token for usage in the Authorization header
+ *
+ * @param token OAuth token or JSON Web Token
+ */
+function withAuthorizationPrefix(token) {
+  if (token.split(/\./).length === 3) {
+    return `bearer ${token}`;
+  }
+
+  return `token ${token}`;
+}
+
+async function hook(token, request, route, parameters) {
+  const endpoint = request.endpoint.merge(route, parameters);
+  endpoint.headers.authorization = withAuthorizationPrefix(token);
+  return request(endpoint);
+}
+
+const createTokenAuth = function createTokenAuth(token) {
+  if (!token) {
+    throw new Error("[@octokit/auth-token] No token passed to createTokenAuth");
+  }
+
+  if (typeof token !== "string") {
+    throw new Error("[@octokit/auth-token] Token passed to createTokenAuth is not a string");
+  }
+
+  token = token.replace(/^(token|bearer) +/i, "");
+  return Object.assign(auth.bind(null, token), {
+    hook: hook.bind(null, token)
+  });
+};
+
+exports.createTokenAuth = createTokenAuth;
+
+});
+
+unwrapExports(distNode$6);
+var distNode_1$6 = distNode$6.createTokenAuth;
+
+var distNode$7 = createCommonjsModule(function (module, exports) {
+
+Object.defineProperty(exports, '__esModule', { value: true });
 
 
 
 
-function Octokit(plugins, options) {
-  options = options || {};
-  const hook = new beforeAfterHook.Collection();
-  const log = Object.assign(
-    {
+
+
+
+function _objectWithoutPropertiesLoose(source, excluded) {
+  if (source == null) return {};
+  var target = {};
+  var sourceKeys = Object.keys(source);
+  var key, i;
+
+  for (i = 0; i < sourceKeys.length; i++) {
+    key = sourceKeys[i];
+    if (excluded.indexOf(key) >= 0) continue;
+    target[key] = source[key];
+  }
+
+  return target;
+}
+
+function _objectWithoutProperties(source, excluded) {
+  if (source == null) return {};
+
+  var target = _objectWithoutPropertiesLoose(source, excluded);
+
+  var key, i;
+
+  if (Object.getOwnPropertySymbols) {
+    var sourceSymbolKeys = Object.getOwnPropertySymbols(source);
+
+    for (i = 0; i < sourceSymbolKeys.length; i++) {
+      key = sourceSymbolKeys[i];
+      if (excluded.indexOf(key) >= 0) continue;
+      if (!Object.prototype.propertyIsEnumerable.call(source, key)) continue;
+      target[key] = source[key];
+    }
+  }
+
+  return target;
+}
+
+const VERSION = "3.2.4";
+
+class Octokit {
+  constructor(options = {}) {
+    const hook = new beforeAfterHook.Collection();
+    const requestDefaults = {
+      baseUrl: distNode$4.request.endpoint.DEFAULTS.baseUrl,
+      headers: {},
+      request: Object.assign({}, options.request, {
+        hook: hook.bind(null, "request")
+      }),
+      mediaType: {
+        previews: [],
+        format: ""
+      }
+    }; // prepend default user agent with `options.userAgent` if set
+
+    requestDefaults.headers["user-agent"] = [options.userAgent, `octokit-core.js/${VERSION} ${distNode.getUserAgent()}`].filter(Boolean).join(" ");
+
+    if (options.baseUrl) {
+      requestDefaults.baseUrl = options.baseUrl;
+    }
+
+    if (options.previews) {
+      requestDefaults.mediaType.previews = options.previews;
+    }
+
+    if (options.timeZone) {
+      requestDefaults.headers["time-zone"] = options.timeZone;
+    }
+
+    this.request = distNode$4.request.defaults(requestDefaults);
+    this.graphql = distNode$5.withCustomRequest(this.request).defaults(requestDefaults);
+    this.log = Object.assign({
       debug: () => {},
       info: () => {},
-      warn: console.warn,
-      error: console.error
-    },
-    options && options.log
-  );
-  const api = {
-    hook,
-    log,
-    request: request$1.defaults(parseClientOptions(options, log, hook))
-  };
+      warn: console.warn.bind(console),
+      error: console.error.bind(console)
+    }, options.log);
+    this.hook = hook; // (1) If neither `options.authStrategy` nor `options.auth` are set, the `octokit` instance
+    //     is unauthenticated. The `this.auth()` method is a no-op and no request hook is registered.
+    // (2) If only `options.auth` is set, use the default token authentication strategy.
+    // (3) If `options.authStrategy` is set then use it and pass in `options.auth`. Always pass own request as many strategies accept a custom request instance.
+    // TODO: type `options.auth` based on `options.authStrategy`.
 
-  plugins.forEach(pluginFunction => pluginFunction(api, options));
+    if (!options.authStrategy) {
+      if (!options.auth) {
+        // (1)
+        this.auth = async () => ({
+          type: "unauthenticated"
+        });
+      } else {
+        // (2)
+        const auth = distNode$6.createTokenAuth(options.auth); // @ts-ignore  ¯\_(ツ)_/¯
 
-  return api;
-}
-
-var registerPlugin_1 = registerPlugin;
-
-
-
-function registerPlugin(plugins, pluginFunction) {
-  return factory_1(
-    plugins.includes(pluginFunction) ? plugins : plugins.concat(pluginFunction)
-  );
-}
-
-var factory_1 = factory;
-
-
-
-
-function factory(plugins) {
-  const Api = constructor_1.bind(null, plugins || []);
-  Api.plugin = registerPlugin_1.bind(null, plugins || []);
-  return Api;
-}
-
-var core$3 = factory_1();
-
-var log = octokitDebug;
-
-function octokitDebug(octokit) {
-  octokit.hook.wrap("request", (request, options) => {
-    octokit.log.debug("request", options);
-    const start = Date.now();
-    const requestOptions = octokit.request.endpoint.parse(options);
-    const path = requestOptions.url.replace(options.baseUrl, "");
-
-    return request(options)
-      .then(response => {
-        octokit.log.info(
-          `${requestOptions.method} ${path} - ${
-            response.status
-          } in ${Date.now() - start}ms`
-        );
-        return response;
-      })
-
-      .catch(error => {
-        octokit.log.info(
-          `${requestOptions.method} ${path} - ${error.status} in ${Date.now() -
-            start}ms`
-        );
-        throw error;
-      });
-  });
-}
-
-var authenticate_1 = authenticate;
-
-const { Deprecation: Deprecation$1 } = distNode$2;
-
-
-const deprecateAuthenticate = once_1((log, deprecation) => log.warn(deprecation));
-
-function authenticate(state, options) {
-  deprecateAuthenticate(
-    state.octokit.log,
-    new Deprecation$1(
-      '[@octokit/rest] octokit.authenticate() is deprecated. Use "auth" constructor option instead.'
-    )
-  );
-
-  if (!options) {
-    state.auth = false;
-    return;
-  }
-
-  switch (options.type) {
-    case "basic":
-      if (!options.username || !options.password) {
-        throw new Error(
-          "Basic authentication requires both a username and password to be set"
-        );
+        hook.wrap("request", auth.hook);
+        this.auth = auth;
       }
-      break;
-
-    case "oauth":
-      if (!options.token && !(options.key && options.secret)) {
-        throw new Error(
-          "OAuth2 authentication requires a token or key & secret to be set"
-        );
-      }
-      break;
-
-    case "token":
-    case "app":
-      if (!options.token) {
-        throw new Error("Token authentication requires a token to be set");
-      }
-      break;
-
-    default:
-      throw new Error(
-        "Invalid authentication type, must be 'basic', 'oauth', 'token' or 'app'"
-      );
-  }
-
-  state.auth = options;
-}
-
-var btoaNode = function btoa(str) {
-  return new Buffer(str).toString('base64')
-};
-
-/**
- * lodash (Custom Build) <https://lodash.com/>
- * Build: `lodash modularize exports="npm" -o ./`
- * Copyright jQuery Foundation and other contributors <https://jquery.org/>
- * Released under MIT license <https://lodash.com/license>
- * Based on Underscore.js 1.8.3 <http://underscorejs.org/LICENSE>
- * Copyright Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
- */
-
-/** Used as the size to enable large array optimizations. */
-var LARGE_ARRAY_SIZE = 200;
-
-/** Used to stand-in for `undefined` hash values. */
-var HASH_UNDEFINED = '__lodash_hash_undefined__';
-
-/** Used as references for various `Number` constants. */
-var INFINITY = 1 / 0;
-
-/** `Object#toString` result references. */
-var funcTag = '[object Function]',
-    genTag = '[object GeneratorFunction]';
-
-/**
- * Used to match `RegExp`
- * [syntax characters](http://ecma-international.org/ecma-262/7.0/#sec-patterns).
- */
-var reRegExpChar = /[\\^$.*+?()[\]{}|]/g;
-
-/** Used to detect host constructors (Safari). */
-var reIsHostCtor = /^\[object .+?Constructor\]$/;
-
-/** Detect free variable `global` from Node.js. */
-var freeGlobal = typeof commonjsGlobal == 'object' && commonjsGlobal && commonjsGlobal.Object === Object && commonjsGlobal;
-
-/** Detect free variable `self`. */
-var freeSelf = typeof self == 'object' && self && self.Object === Object && self;
-
-/** Used as a reference to the global object. */
-var root = freeGlobal || freeSelf || Function('return this')();
-
-/**
- * A specialized version of `_.includes` for arrays without support for
- * specifying an index to search from.
- *
- * @private
- * @param {Array} [array] The array to inspect.
- * @param {*} target The value to search for.
- * @returns {boolean} Returns `true` if `target` is found, else `false`.
- */
-function arrayIncludes(array, value) {
-  var length = array ? array.length : 0;
-  return !!length && baseIndexOf(array, value, 0) > -1;
-}
-
-/**
- * This function is like `arrayIncludes` except that it accepts a comparator.
- *
- * @private
- * @param {Array} [array] The array to inspect.
- * @param {*} target The value to search for.
- * @param {Function} comparator The comparator invoked per element.
- * @returns {boolean} Returns `true` if `target` is found, else `false`.
- */
-function arrayIncludesWith(array, value, comparator) {
-  var index = -1,
-      length = array ? array.length : 0;
-
-  while (++index < length) {
-    if (comparator(value, array[index])) {
-      return true;
-    }
-  }
-  return false;
-}
-
-/**
- * The base implementation of `_.findIndex` and `_.findLastIndex` without
- * support for iteratee shorthands.
- *
- * @private
- * @param {Array} array The array to inspect.
- * @param {Function} predicate The function invoked per iteration.
- * @param {number} fromIndex The index to search from.
- * @param {boolean} [fromRight] Specify iterating from right to left.
- * @returns {number} Returns the index of the matched value, else `-1`.
- */
-function baseFindIndex(array, predicate, fromIndex, fromRight) {
-  var length = array.length,
-      index = fromIndex + (fromRight ? 1 : -1);
-
-  while ((fromRight ? index-- : ++index < length)) {
-    if (predicate(array[index], index, array)) {
-      return index;
-    }
-  }
-  return -1;
-}
-
-/**
- * The base implementation of `_.indexOf` without `fromIndex` bounds checks.
- *
- * @private
- * @param {Array} array The array to inspect.
- * @param {*} value The value to search for.
- * @param {number} fromIndex The index to search from.
- * @returns {number} Returns the index of the matched value, else `-1`.
- */
-function baseIndexOf(array, value, fromIndex) {
-  if (value !== value) {
-    return baseFindIndex(array, baseIsNaN, fromIndex);
-  }
-  var index = fromIndex - 1,
-      length = array.length;
-
-  while (++index < length) {
-    if (array[index] === value) {
-      return index;
-    }
-  }
-  return -1;
-}
-
-/**
- * The base implementation of `_.isNaN` without support for number objects.
- *
- * @private
- * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is `NaN`, else `false`.
- */
-function baseIsNaN(value) {
-  return value !== value;
-}
-
-/**
- * Checks if a cache value for `key` exists.
- *
- * @private
- * @param {Object} cache The cache to query.
- * @param {string} key The key of the entry to check.
- * @returns {boolean} Returns `true` if an entry for `key` exists, else `false`.
- */
-function cacheHas(cache, key) {
-  return cache.has(key);
-}
-
-/**
- * Gets the value at `key` of `object`.
- *
- * @private
- * @param {Object} [object] The object to query.
- * @param {string} key The key of the property to get.
- * @returns {*} Returns the property value.
- */
-function getValue(object, key) {
-  return object == null ? undefined : object[key];
-}
-
-/**
- * Checks if `value` is a host object in IE < 9.
- *
- * @private
- * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is a host object, else `false`.
- */
-function isHostObject(value) {
-  // Many host objects are `Object` objects that can coerce to strings
-  // despite having improperly defined `toString` methods.
-  var result = false;
-  if (value != null && typeof value.toString != 'function') {
-    try {
-      result = !!(value + '');
-    } catch (e) {}
-  }
-  return result;
-}
-
-/**
- * Converts `set` to an array of its values.
- *
- * @private
- * @param {Object} set The set to convert.
- * @returns {Array} Returns the values.
- */
-function setToArray(set) {
-  var index = -1,
-      result = Array(set.size);
-
-  set.forEach(function(value) {
-    result[++index] = value;
-  });
-  return result;
-}
-
-/** Used for built-in method references. */
-var arrayProto = Array.prototype,
-    funcProto = Function.prototype,
-    objectProto = Object.prototype;
-
-/** Used to detect overreaching core-js shims. */
-var coreJsData = root['__core-js_shared__'];
-
-/** Used to detect methods masquerading as native. */
-var maskSrcKey = (function() {
-  var uid = /[^.]+$/.exec(coreJsData && coreJsData.keys && coreJsData.keys.IE_PROTO || '');
-  return uid ? ('Symbol(src)_1.' + uid) : '';
-}());
-
-/** Used to resolve the decompiled source of functions. */
-var funcToString = funcProto.toString;
-
-/** Used to check objects for own properties. */
-var hasOwnProperty = objectProto.hasOwnProperty;
-
-/**
- * Used to resolve the
- * [`toStringTag`](http://ecma-international.org/ecma-262/7.0/#sec-object.prototype.tostring)
- * of values.
- */
-var objectToString = objectProto.toString;
-
-/** Used to detect if a method is native. */
-var reIsNative = RegExp('^' +
-  funcToString.call(hasOwnProperty).replace(reRegExpChar, '\\$&')
-  .replace(/hasOwnProperty|(function).*?(?=\\\()| for .+?(?=\\\])/g, '$1.*?') + '$'
-);
-
-/** Built-in value references. */
-var splice = arrayProto.splice;
-
-/* Built-in method references that are verified to be native. */
-var Map$1 = getNative(root, 'Map'),
-    Set = getNative(root, 'Set'),
-    nativeCreate = getNative(Object, 'create');
-
-/**
- * Creates a hash object.
- *
- * @private
- * @constructor
- * @param {Array} [entries] The key-value pairs to cache.
- */
-function Hash(entries) {
-  var index = -1,
-      length = entries ? entries.length : 0;
-
-  this.clear();
-  while (++index < length) {
-    var entry = entries[index];
-    this.set(entry[0], entry[1]);
-  }
-}
-
-/**
- * Removes all key-value entries from the hash.
- *
- * @private
- * @name clear
- * @memberOf Hash
- */
-function hashClear() {
-  this.__data__ = nativeCreate ? nativeCreate(null) : {};
-}
-
-/**
- * Removes `key` and its value from the hash.
- *
- * @private
- * @name delete
- * @memberOf Hash
- * @param {Object} hash The hash to modify.
- * @param {string} key The key of the value to remove.
- * @returns {boolean} Returns `true` if the entry was removed, else `false`.
- */
-function hashDelete(key) {
-  return this.has(key) && delete this.__data__[key];
-}
-
-/**
- * Gets the hash value for `key`.
- *
- * @private
- * @name get
- * @memberOf Hash
- * @param {string} key The key of the value to get.
- * @returns {*} Returns the entry value.
- */
-function hashGet(key) {
-  var data = this.__data__;
-  if (nativeCreate) {
-    var result = data[key];
-    return result === HASH_UNDEFINED ? undefined : result;
-  }
-  return hasOwnProperty.call(data, key) ? data[key] : undefined;
-}
-
-/**
- * Checks if a hash value for `key` exists.
- *
- * @private
- * @name has
- * @memberOf Hash
- * @param {string} key The key of the entry to check.
- * @returns {boolean} Returns `true` if an entry for `key` exists, else `false`.
- */
-function hashHas(key) {
-  var data = this.__data__;
-  return nativeCreate ? data[key] !== undefined : hasOwnProperty.call(data, key);
-}
-
-/**
- * Sets the hash `key` to `value`.
- *
- * @private
- * @name set
- * @memberOf Hash
- * @param {string} key The key of the value to set.
- * @param {*} value The value to set.
- * @returns {Object} Returns the hash instance.
- */
-function hashSet(key, value) {
-  var data = this.__data__;
-  data[key] = (nativeCreate && value === undefined) ? HASH_UNDEFINED : value;
-  return this;
-}
-
-// Add methods to `Hash`.
-Hash.prototype.clear = hashClear;
-Hash.prototype['delete'] = hashDelete;
-Hash.prototype.get = hashGet;
-Hash.prototype.has = hashHas;
-Hash.prototype.set = hashSet;
-
-/**
- * Creates an list cache object.
- *
- * @private
- * @constructor
- * @param {Array} [entries] The key-value pairs to cache.
- */
-function ListCache(entries) {
-  var index = -1,
-      length = entries ? entries.length : 0;
-
-  this.clear();
-  while (++index < length) {
-    var entry = entries[index];
-    this.set(entry[0], entry[1]);
-  }
-}
-
-/**
- * Removes all key-value entries from the list cache.
- *
- * @private
- * @name clear
- * @memberOf ListCache
- */
-function listCacheClear() {
-  this.__data__ = [];
-}
-
-/**
- * Removes `key` and its value from the list cache.
- *
- * @private
- * @name delete
- * @memberOf ListCache
- * @param {string} key The key of the value to remove.
- * @returns {boolean} Returns `true` if the entry was removed, else `false`.
- */
-function listCacheDelete(key) {
-  var data = this.__data__,
-      index = assocIndexOf(data, key);
-
-  if (index < 0) {
-    return false;
-  }
-  var lastIndex = data.length - 1;
-  if (index == lastIndex) {
-    data.pop();
-  } else {
-    splice.call(data, index, 1);
-  }
-  return true;
-}
-
-/**
- * Gets the list cache value for `key`.
- *
- * @private
- * @name get
- * @memberOf ListCache
- * @param {string} key The key of the value to get.
- * @returns {*} Returns the entry value.
- */
-function listCacheGet(key) {
-  var data = this.__data__,
-      index = assocIndexOf(data, key);
-
-  return index < 0 ? undefined : data[index][1];
-}
-
-/**
- * Checks if a list cache value for `key` exists.
- *
- * @private
- * @name has
- * @memberOf ListCache
- * @param {string} key The key of the entry to check.
- * @returns {boolean} Returns `true` if an entry for `key` exists, else `false`.
- */
-function listCacheHas(key) {
-  return assocIndexOf(this.__data__, key) > -1;
-}
-
-/**
- * Sets the list cache `key` to `value`.
- *
- * @private
- * @name set
- * @memberOf ListCache
- * @param {string} key The key of the value to set.
- * @param {*} value The value to set.
- * @returns {Object} Returns the list cache instance.
- */
-function listCacheSet(key, value) {
-  var data = this.__data__,
-      index = assocIndexOf(data, key);
-
-  if (index < 0) {
-    data.push([key, value]);
-  } else {
-    data[index][1] = value;
-  }
-  return this;
-}
-
-// Add methods to `ListCache`.
-ListCache.prototype.clear = listCacheClear;
-ListCache.prototype['delete'] = listCacheDelete;
-ListCache.prototype.get = listCacheGet;
-ListCache.prototype.has = listCacheHas;
-ListCache.prototype.set = listCacheSet;
-
-/**
- * Creates a map cache object to store key-value pairs.
- *
- * @private
- * @constructor
- * @param {Array} [entries] The key-value pairs to cache.
- */
-function MapCache(entries) {
-  var index = -1,
-      length = entries ? entries.length : 0;
-
-  this.clear();
-  while (++index < length) {
-    var entry = entries[index];
-    this.set(entry[0], entry[1]);
-  }
-}
-
-/**
- * Removes all key-value entries from the map.
- *
- * @private
- * @name clear
- * @memberOf MapCache
- */
-function mapCacheClear() {
-  this.__data__ = {
-    'hash': new Hash,
-    'map': new (Map$1 || ListCache),
-    'string': new Hash
-  };
-}
-
-/**
- * Removes `key` and its value from the map.
- *
- * @private
- * @name delete
- * @memberOf MapCache
- * @param {string} key The key of the value to remove.
- * @returns {boolean} Returns `true` if the entry was removed, else `false`.
- */
-function mapCacheDelete(key) {
-  return getMapData(this, key)['delete'](key);
-}
-
-/**
- * Gets the map value for `key`.
- *
- * @private
- * @name get
- * @memberOf MapCache
- * @param {string} key The key of the value to get.
- * @returns {*} Returns the entry value.
- */
-function mapCacheGet(key) {
-  return getMapData(this, key).get(key);
-}
-
-/**
- * Checks if a map value for `key` exists.
- *
- * @private
- * @name has
- * @memberOf MapCache
- * @param {string} key The key of the entry to check.
- * @returns {boolean} Returns `true` if an entry for `key` exists, else `false`.
- */
-function mapCacheHas(key) {
-  return getMapData(this, key).has(key);
-}
-
-/**
- * Sets the map `key` to `value`.
- *
- * @private
- * @name set
- * @memberOf MapCache
- * @param {string} key The key of the value to set.
- * @param {*} value The value to set.
- * @returns {Object} Returns the map cache instance.
- */
-function mapCacheSet(key, value) {
-  getMapData(this, key).set(key, value);
-  return this;
-}
-
-// Add methods to `MapCache`.
-MapCache.prototype.clear = mapCacheClear;
-MapCache.prototype['delete'] = mapCacheDelete;
-MapCache.prototype.get = mapCacheGet;
-MapCache.prototype.has = mapCacheHas;
-MapCache.prototype.set = mapCacheSet;
-
-/**
- *
- * Creates an array cache object to store unique values.
- *
- * @private
- * @constructor
- * @param {Array} [values] The values to cache.
- */
-function SetCache(values) {
-  var index = -1,
-      length = values ? values.length : 0;
-
-  this.__data__ = new MapCache;
-  while (++index < length) {
-    this.add(values[index]);
-  }
-}
-
-/**
- * Adds `value` to the array cache.
- *
- * @private
- * @name add
- * @memberOf SetCache
- * @alias push
- * @param {*} value The value to cache.
- * @returns {Object} Returns the cache instance.
- */
-function setCacheAdd(value) {
-  this.__data__.set(value, HASH_UNDEFINED);
-  return this;
-}
-
-/**
- * Checks if `value` is in the array cache.
- *
- * @private
- * @name has
- * @memberOf SetCache
- * @param {*} value The value to search for.
- * @returns {number} Returns `true` if `value` is found, else `false`.
- */
-function setCacheHas(value) {
-  return this.__data__.has(value);
-}
-
-// Add methods to `SetCache`.
-SetCache.prototype.add = SetCache.prototype.push = setCacheAdd;
-SetCache.prototype.has = setCacheHas;
-
-/**
- * Gets the index at which the `key` is found in `array` of key-value pairs.
- *
- * @private
- * @param {Array} array The array to inspect.
- * @param {*} key The key to search for.
- * @returns {number} Returns the index of the matched value, else `-1`.
- */
-function assocIndexOf(array, key) {
-  var length = array.length;
-  while (length--) {
-    if (eq(array[length][0], key)) {
-      return length;
-    }
-  }
-  return -1;
-}
-
-/**
- * The base implementation of `_.isNative` without bad shim checks.
- *
- * @private
- * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is a native function,
- *  else `false`.
- */
-function baseIsNative(value) {
-  if (!isObject$2(value) || isMasked(value)) {
-    return false;
-  }
-  var pattern = (isFunction(value) || isHostObject(value)) ? reIsNative : reIsHostCtor;
-  return pattern.test(toSource(value));
-}
-
-/**
- * The base implementation of `_.uniqBy` without support for iteratee shorthands.
- *
- * @private
- * @param {Array} array The array to inspect.
- * @param {Function} [iteratee] The iteratee invoked per element.
- * @param {Function} [comparator] The comparator invoked per element.
- * @returns {Array} Returns the new duplicate free array.
- */
-function baseUniq(array, iteratee, comparator) {
-  var index = -1,
-      includes = arrayIncludes,
-      length = array.length,
-      isCommon = true,
-      result = [],
-      seen = result;
-
-  if (comparator) {
-    isCommon = false;
-    includes = arrayIncludesWith;
-  }
-  else if (length >= LARGE_ARRAY_SIZE) {
-    var set = iteratee ? null : createSet(array);
-    if (set) {
-      return setToArray(set);
-    }
-    isCommon = false;
-    includes = cacheHas;
-    seen = new SetCache;
-  }
-  else {
-    seen = iteratee ? [] : result;
-  }
-  outer:
-  while (++index < length) {
-    var value = array[index],
-        computed = iteratee ? iteratee(value) : value;
-
-    value = (comparator || value !== 0) ? value : 0;
-    if (isCommon && computed === computed) {
-      var seenIndex = seen.length;
-      while (seenIndex--) {
-        if (seen[seenIndex] === computed) {
-          continue outer;
-        }
-      }
-      if (iteratee) {
-        seen.push(computed);
-      }
-      result.push(value);
-    }
-    else if (!includes(seen, computed, comparator)) {
-      if (seen !== result) {
-        seen.push(computed);
-      }
-      result.push(value);
-    }
-  }
-  return result;
-}
-
-/**
- * Creates a set object of `values`.
- *
- * @private
- * @param {Array} values The values to add to the set.
- * @returns {Object} Returns the new set.
- */
-var createSet = !(Set && (1 / setToArray(new Set([,-0]))[1]) == INFINITY) ? noop$2 : function(values) {
-  return new Set(values);
-};
-
-/**
- * Gets the data for `map`.
- *
- * @private
- * @param {Object} map The map to query.
- * @param {string} key The reference key.
- * @returns {*} Returns the map data.
- */
-function getMapData(map, key) {
-  var data = map.__data__;
-  return isKeyable(key)
-    ? data[typeof key == 'string' ? 'string' : 'hash']
-    : data.map;
-}
-
-/**
- * Gets the native function at `key` of `object`.
- *
- * @private
- * @param {Object} object The object to query.
- * @param {string} key The key of the method to get.
- * @returns {*} Returns the function if it's native, else `undefined`.
- */
-function getNative(object, key) {
-  var value = getValue(object, key);
-  return baseIsNative(value) ? value : undefined;
-}
-
-/**
- * Checks if `value` is suitable for use as unique object key.
- *
- * @private
- * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is suitable, else `false`.
- */
-function isKeyable(value) {
-  var type = typeof value;
-  return (type == 'string' || type == 'number' || type == 'symbol' || type == 'boolean')
-    ? (value !== '__proto__')
-    : (value === null);
-}
-
-/**
- * Checks if `func` has its source masked.
- *
- * @private
- * @param {Function} func The function to check.
- * @returns {boolean} Returns `true` if `func` is masked, else `false`.
- */
-function isMasked(func) {
-  return !!maskSrcKey && (maskSrcKey in func);
-}
-
-/**
- * Converts `func` to its source code.
- *
- * @private
- * @param {Function} func The function to process.
- * @returns {string} Returns the source code.
- */
-function toSource(func) {
-  if (func != null) {
-    try {
-      return funcToString.call(func);
-    } catch (e) {}
-    try {
-      return (func + '');
-    } catch (e) {}
-  }
-  return '';
-}
-
-/**
- * Creates a duplicate-free version of an array, using
- * [`SameValueZero`](http://ecma-international.org/ecma-262/7.0/#sec-samevaluezero)
- * for equality comparisons, in which only the first occurrence of each
- * element is kept.
- *
- * @static
- * @memberOf _
- * @since 0.1.0
- * @category Array
- * @param {Array} array The array to inspect.
- * @returns {Array} Returns the new duplicate free array.
- * @example
- *
- * _.uniq([2, 1, 2]);
- * // => [2, 1]
- */
-function uniq(array) {
-  return (array && array.length)
-    ? baseUniq(array)
-    : [];
-}
-
-/**
- * Performs a
- * [`SameValueZero`](http://ecma-international.org/ecma-262/7.0/#sec-samevaluezero)
- * comparison between two values to determine if they are equivalent.
- *
- * @static
- * @memberOf _
- * @since 4.0.0
- * @category Lang
- * @param {*} value The value to compare.
- * @param {*} other The other value to compare.
- * @returns {boolean} Returns `true` if the values are equivalent, else `false`.
- * @example
- *
- * var object = { 'a': 1 };
- * var other = { 'a': 1 };
- *
- * _.eq(object, object);
- * // => true
- *
- * _.eq(object, other);
- * // => false
- *
- * _.eq('a', 'a');
- * // => true
- *
- * _.eq('a', Object('a'));
- * // => false
- *
- * _.eq(NaN, NaN);
- * // => true
- */
-function eq(value, other) {
-  return value === other || (value !== value && other !== other);
-}
-
-/**
- * Checks if `value` is classified as a `Function` object.
- *
- * @static
- * @memberOf _
- * @since 0.1.0
- * @category Lang
- * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is a function, else `false`.
- * @example
- *
- * _.isFunction(_);
- * // => true
- *
- * _.isFunction(/abc/);
- * // => false
- */
-function isFunction(value) {
-  // The use of `Object#toString` avoids issues with the `typeof` operator
-  // in Safari 8-9 which returns 'object' for typed array and other constructors.
-  var tag = isObject$2(value) ? objectToString.call(value) : '';
-  return tag == funcTag || tag == genTag;
-}
-
-/**
- * Checks if `value` is the
- * [language type](http://www.ecma-international.org/ecma-262/7.0/#sec-ecmascript-language-types)
- * of `Object`. (e.g. arrays, functions, objects, regexes, `new Number(0)`, and `new String('')`)
- *
- * @static
- * @memberOf _
- * @since 0.1.0
- * @category Lang
- * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is an object, else `false`.
- * @example
- *
- * _.isObject({});
- * // => true
- *
- * _.isObject([1, 2, 3]);
- * // => true
- *
- * _.isObject(_.noop);
- * // => true
- *
- * _.isObject(null);
- * // => false
- */
-function isObject$2(value) {
-  var type = typeof value;
-  return !!value && (type == 'object' || type == 'function');
-}
-
-/**
- * This method returns `undefined`.
- *
- * @static
- * @memberOf _
- * @since 2.3.0
- * @category Util
- * @example
- *
- * _.times(2, _.noop);
- * // => [undefined, undefined]
- */
-function noop$2() {
-  // No operation performed.
-}
-
-var lodash_uniq = uniq;
-
-var beforeRequest = authenticationBeforeRequest;
-
-
-
-
-function authenticationBeforeRequest(state, options) {
-  if (!state.auth.type) {
-    return;
-  }
-
-  if (state.auth.type === "basic") {
-    const hash = btoaNode(`${state.auth.username}:${state.auth.password}`);
-    options.headers.authorization = `Basic ${hash}`;
-    return;
-  }
-
-  if (state.auth.type === "token") {
-    options.headers.authorization = `token ${state.auth.token}`;
-    return;
-  }
-
-  if (state.auth.type === "app") {
-    options.headers.authorization = `Bearer ${state.auth.token}`;
-    const acceptHeaders = options.headers.accept
-      .split(",")
-      .concat("application/vnd.github.machine-man-preview+json");
-    options.headers.accept = lodash_uniq(acceptHeaders)
-      .filter(Boolean)
-      .join(",");
-    return;
-  }
-
-  options.url += options.url.indexOf("?") === -1 ? "?" : "&";
-
-  if (state.auth.token) {
-    options.url += `access_token=${encodeURIComponent(state.auth.token)}`;
-    return;
-  }
-
-  const key = encodeURIComponent(state.auth.key);
-  const secret = encodeURIComponent(state.auth.secret);
-  options.url += `client_id=${key}&client_secret=${secret}`;
-}
-
-var requestError = authenticationRequestError;
-
-const { RequestError } = distNode$3;
-
-function authenticationRequestError(state, error, options) {
-  /* istanbul ignore next */
-  if (!error.headers) throw error;
-
-  const otpRequired = /required/.test(error.headers["x-github-otp"] || "");
-  // handle "2FA required" error only
-  if (error.status !== 401 || !otpRequired) {
-    throw error;
-  }
-
-  if (
-    error.status === 401 &&
-    otpRequired &&
-    error.request &&
-    error.request.headers["x-github-otp"]
-  ) {
-    throw new RequestError(
-      "Invalid one-time password for two-factor authentication",
-      401,
-      {
-        headers: error.headers,
-        request: options
-      }
-    );
-  }
-
-  if (typeof state.auth.on2fa !== "function") {
-    throw new RequestError(
-      "2FA required, but options.on2fa is not a function. See https://github.com/octokit/rest.js#authentication",
-      401,
-      {
-        headers: error.headers,
-        request: options
-      }
-    );
-  }
-
-  return Promise.resolve()
-    .then(() => {
-      return state.auth.on2fa();
-    })
-    .then(oneTimePassword => {
-      const newOptions = Object.assign(options, {
-        headers: Object.assign(
-          { "x-github-otp": oneTimePassword },
-          options.headers
-        )
-      });
-      return state.octokit.request(newOptions);
-    });
-}
-
-var authenticationDeprecated = authenticationPlugin;
-
-const { Deprecation: Deprecation$2 } = distNode$2;
-
-
-const deprecateAuthenticate$1 = once_1((log, deprecation) => log.warn(deprecation));
-
-
-
-
-
-function authenticationPlugin(octokit, options) {
-  if (options.auth) {
-    octokit.authenticate = () => {
-      deprecateAuthenticate$1(
-        octokit.log,
-        new Deprecation$2(
-          '[@octokit/rest] octokit.authenticate() is deprecated and has no effect when "auth" option is set on Octokit constructor'
-        )
-      );
-    };
-    return;
-  }
-  const state = {
-    octokit,
-    auth: false
-  };
-  octokit.authenticate = authenticate_1.bind(null, state);
-  octokit.hook.before("request", beforeRequest.bind(null, state));
-  octokit.hook.error("request", requestError.bind(null, state));
-}
-
-var atobNode = function atob(str) {
-  return Buffer.from(str, 'base64').toString('binary')
-};
-
-var withAuthorizationPrefix_1 = withAuthorizationPrefix;
-
-
-
-const REGEX_IS_BASIC_AUTH = /^[\w-]+:/;
-
-function withAuthorizationPrefix(authorization) {
-  if (/^(basic|bearer|token) /i.test(authorization)) {
-    return authorization;
-  }
-
-  try {
-    if (REGEX_IS_BASIC_AUTH.test(atobNode(authorization))) {
-      return `basic ${authorization}`;
-    }
-  } catch (error) {}
-
-  if (authorization.split(/\./).length === 3) {
-    return `bearer ${authorization}`;
-  }
-
-  return `token ${authorization}`;
-}
-
-var beforeRequest$1 = authenticationBeforeRequest$1;
-
-
-
-
-
-function authenticationBeforeRequest$1(state, options) {
-  if (typeof state.auth === "string") {
-    options.headers.authorization = withAuthorizationPrefix_1(state.auth);
-
-    // https://developer.github.com/v3/previews/#integrations
-    if (
-      /^bearer /i.test(state.auth) &&
-      !/machine-man/.test(options.headers.accept)
-    ) {
-      const acceptHeaders = options.headers.accept
-        .split(",")
-        .concat("application/vnd.github.machine-man-preview+json");
-      options.headers.accept = acceptHeaders.filter(Boolean).join(",");
-    }
-
-    return;
-  }
-
-  if (state.auth.username) {
-    const hash = btoaNode(`${state.auth.username}:${state.auth.password}`);
-    options.headers.authorization = `Basic ${hash}`;
-    if (state.otp) {
-      options.headers["x-github-otp"] = state.otp;
-    }
-    return;
-  }
-
-  if (state.auth.clientId) {
-    // There is a special case for OAuth applications, when `clientId` and `clientSecret` is passed as
-    // Basic Authorization instead of query parameters. The only routes where that applies share the same
-    // URL though: `/applications/:client_id/tokens/:access_token`.
-    //
-    //  1. [Check an authorization](https://developer.github.com/v3/oauth_authorizations/#check-an-authorization)
-    //  2. [Reset an authorization](https://developer.github.com/v3/oauth_authorizations/#reset-an-authorization)
-    //  3. [Revoke an authorization for an application](https://developer.github.com/v3/oauth_authorizations/#revoke-an-authorization-for-an-application)
-    //
-    // We identify by checking the URL. It must merge both "/applications/:client_id/tokens/:access_token"
-    // as well as "/applications/123/tokens/token456"
-    if (/\/applications\/:?[\w_]+\/tokens\/:?[\w_]+($|\?)/.test(options.url)) {
-      const hash = btoaNode(`${state.auth.clientId}:${state.auth.clientSecret}`);
-      options.headers.authorization = `Basic ${hash}`;
-      return;
-    }
-
-    options.url += options.url.indexOf("?") === -1 ? "?" : "&";
-    options.url += `client_id=${state.auth.clientId}&client_secret=${state.auth.clientSecret}`;
-    return;
-  }
-
-  return Promise.resolve()
-
-    .then(() => {
-      return state.auth();
-    })
-
-    .then(authorization => {
-      options.headers.authorization = withAuthorizationPrefix_1(authorization);
-    });
-}
-
-var requestError$1 = authenticationRequestError$1;
-
-const { RequestError: RequestError$1 } = distNode$3;
-
-function authenticationRequestError$1(state, error, options) {
-  if (!error.headers) throw error;
-
-  const otpRequired = /required/.test(error.headers["x-github-otp"] || "");
-  // handle "2FA required" error only
-  if (error.status !== 401 || !otpRequired) {
-    throw error;
-  }
-
-  if (
-    error.status === 401 &&
-    otpRequired &&
-    error.request &&
-    error.request.headers["x-github-otp"]
-  ) {
-    if (state.otp) {
-      delete state.otp; // no longer valid, request again
     } else {
-      throw new RequestError$1(
-        "Invalid one-time password for two-factor authentication",
-        401,
-        {
-          headers: error.headers,
-          request: options
+      const {
+        authStrategy
+      } = options,
+            otherOptions = _objectWithoutProperties(options, ["authStrategy"]);
+
+      const auth = authStrategy(Object.assign({
+        request: this.request,
+        log: this.log,
+        // we pass the current octokit instance as well as its constructor options
+        // to allow for authentication strategies that return a new octokit instance
+        // that shares the same internal state as the current one. The original
+        // requirement for this was the "event-octokit" authentication strategy
+        // of https://github.com/probot/octokit-auth-probot.
+        octokit: this,
+        octokitOptions: otherOptions
+      }, options.auth)); // @ts-ignore  ¯\_(ツ)_/¯
+
+      hook.wrap("request", auth.hook);
+      this.auth = auth;
+    } // apply plugins
+    // https://stackoverflow.com/a/16345172
+
+
+    const classConstructor = this.constructor;
+    classConstructor.plugins.forEach(plugin => {
+      Object.assign(this, plugin(this, options));
+    });
+  }
+
+  static defaults(defaults) {
+    const OctokitWithDefaults = class extends this {
+      constructor(...args) {
+        const options = args[0] || {};
+
+        if (typeof defaults === "function") {
+          super(defaults(options));
+          return;
         }
-      );
+
+        super(Object.assign({}, defaults, options, options.userAgent && defaults.userAgent ? {
+          userAgent: `${options.userAgent} ${defaults.userAgent}`
+        } : null));
+      }
+
+    };
+    return OctokitWithDefaults;
+  }
+  /**
+   * Attach a plugin (or many) to your Octokit instance.
+   *
+   * @example
+   * const API = Octokit.plugin(plugin1, plugin2, plugin3, ...)
+   */
+
+
+  static plugin(...newPlugins) {
+    var _a;
+
+    const currentPlugins = this.plugins;
+    const NewOctokit = (_a = class extends this {}, _a.plugins = currentPlugins.concat(newPlugins.filter(plugin => !currentPlugins.includes(plugin))), _a);
+    return NewOctokit;
+  }
+
+}
+Octokit.VERSION = VERSION;
+Octokit.plugins = [];
+
+exports.Octokit = Octokit;
+
+});
+
+unwrapExports(distNode$7);
+var distNode_1$7 = distNode$7.Octokit;
+
+var distNode$8 = createCommonjsModule(function (module, exports) {
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+const Endpoints = {
+  actions: {
+    addSelectedRepoToOrgSecret: ["PUT /orgs/{org}/actions/secrets/{secret_name}/repositories/{repository_id}"],
+    cancelWorkflowRun: ["POST /repos/{owner}/{repo}/actions/runs/{run_id}/cancel"],
+    createOrUpdateOrgSecret: ["PUT /orgs/{org}/actions/secrets/{secret_name}"],
+    createOrUpdateRepoSecret: ["PUT /repos/{owner}/{repo}/actions/secrets/{secret_name}"],
+    createRegistrationTokenForOrg: ["POST /orgs/{org}/actions/runners/registration-token"],
+    createRegistrationTokenForRepo: ["POST /repos/{owner}/{repo}/actions/runners/registration-token"],
+    createRemoveTokenForOrg: ["POST /orgs/{org}/actions/runners/remove-token"],
+    createRemoveTokenForRepo: ["POST /repos/{owner}/{repo}/actions/runners/remove-token"],
+    createWorkflowDispatch: ["POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches"],
+    deleteArtifact: ["DELETE /repos/{owner}/{repo}/actions/artifacts/{artifact_id}"],
+    deleteOrgSecret: ["DELETE /orgs/{org}/actions/secrets/{secret_name}"],
+    deleteRepoSecret: ["DELETE /repos/{owner}/{repo}/actions/secrets/{secret_name}"],
+    deleteSelfHostedRunnerFromOrg: ["DELETE /orgs/{org}/actions/runners/{runner_id}"],
+    deleteSelfHostedRunnerFromRepo: ["DELETE /repos/{owner}/{repo}/actions/runners/{runner_id}"],
+    deleteWorkflowRun: ["DELETE /repos/{owner}/{repo}/actions/runs/{run_id}"],
+    deleteWorkflowRunLogs: ["DELETE /repos/{owner}/{repo}/actions/runs/{run_id}/logs"],
+    disableSelectedRepositoryGithubActionsOrganization: ["DELETE /orgs/{org}/actions/permissions/repositories/{repository_id}"],
+    disableWorkflow: ["PUT /repos/{owner}/{repo}/actions/workflows/{workflow_id}/disable"],
+    downloadArtifact: ["GET /repos/{owner}/{repo}/actions/artifacts/{artifact_id}/{archive_format}"],
+    downloadJobLogsForWorkflowRun: ["GET /repos/{owner}/{repo}/actions/jobs/{job_id}/logs"],
+    downloadWorkflowRunLogs: ["GET /repos/{owner}/{repo}/actions/runs/{run_id}/logs"],
+    enableSelectedRepositoryGithubActionsOrganization: ["PUT /orgs/{org}/actions/permissions/repositories/{repository_id}"],
+    enableWorkflow: ["PUT /repos/{owner}/{repo}/actions/workflows/{workflow_id}/enable"],
+    getAllowedActionsOrganization: ["GET /orgs/{org}/actions/permissions/selected-actions"],
+    getAllowedActionsRepository: ["GET /repos/{owner}/{repo}/actions/permissions/selected-actions"],
+    getArtifact: ["GET /repos/{owner}/{repo}/actions/artifacts/{artifact_id}"],
+    getGithubActionsPermissionsOrganization: ["GET /orgs/{org}/actions/permissions"],
+    getGithubActionsPermissionsRepository: ["GET /repos/{owner}/{repo}/actions/permissions"],
+    getJobForWorkflowRun: ["GET /repos/{owner}/{repo}/actions/jobs/{job_id}"],
+    getOrgPublicKey: ["GET /orgs/{org}/actions/secrets/public-key"],
+    getOrgSecret: ["GET /orgs/{org}/actions/secrets/{secret_name}"],
+    getRepoPermissions: ["GET /repos/{owner}/{repo}/actions/permissions", {}, {
+      renamed: ["actions", "getGithubActionsPermissionsRepository"]
+    }],
+    getRepoPublicKey: ["GET /repos/{owner}/{repo}/actions/secrets/public-key"],
+    getRepoSecret: ["GET /repos/{owner}/{repo}/actions/secrets/{secret_name}"],
+    getSelfHostedRunnerForOrg: ["GET /orgs/{org}/actions/runners/{runner_id}"],
+    getSelfHostedRunnerForRepo: ["GET /repos/{owner}/{repo}/actions/runners/{runner_id}"],
+    getWorkflow: ["GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}"],
+    getWorkflowRun: ["GET /repos/{owner}/{repo}/actions/runs/{run_id}"],
+    getWorkflowRunUsage: ["GET /repos/{owner}/{repo}/actions/runs/{run_id}/timing"],
+    getWorkflowUsage: ["GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/timing"],
+    listArtifactsForRepo: ["GET /repos/{owner}/{repo}/actions/artifacts"],
+    listJobsForWorkflowRun: ["GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs"],
+    listOrgSecrets: ["GET /orgs/{org}/actions/secrets"],
+    listRepoSecrets: ["GET /repos/{owner}/{repo}/actions/secrets"],
+    listRepoWorkflows: ["GET /repos/{owner}/{repo}/actions/workflows"],
+    listRunnerApplicationsForOrg: ["GET /orgs/{org}/actions/runners/downloads"],
+    listRunnerApplicationsForRepo: ["GET /repos/{owner}/{repo}/actions/runners/downloads"],
+    listSelectedReposForOrgSecret: ["GET /orgs/{org}/actions/secrets/{secret_name}/repositories"],
+    listSelectedRepositoriesEnabledGithubActionsOrganization: ["GET /orgs/{org}/actions/permissions/repositories"],
+    listSelfHostedRunnersForOrg: ["GET /orgs/{org}/actions/runners"],
+    listSelfHostedRunnersForRepo: ["GET /repos/{owner}/{repo}/actions/runners"],
+    listWorkflowRunArtifacts: ["GET /repos/{owner}/{repo}/actions/runs/{run_id}/artifacts"],
+    listWorkflowRuns: ["GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs"],
+    listWorkflowRunsForRepo: ["GET /repos/{owner}/{repo}/actions/runs"],
+    reRunWorkflow: ["POST /repos/{owner}/{repo}/actions/runs/{run_id}/rerun"],
+    removeSelectedRepoFromOrgSecret: ["DELETE /orgs/{org}/actions/secrets/{secret_name}/repositories/{repository_id}"],
+    setAllowedActionsOrganization: ["PUT /orgs/{org}/actions/permissions/selected-actions"],
+    setAllowedActionsRepository: ["PUT /repos/{owner}/{repo}/actions/permissions/selected-actions"],
+    setGithubActionsPermissionsOrganization: ["PUT /orgs/{org}/actions/permissions"],
+    setGithubActionsPermissionsRepository: ["PUT /repos/{owner}/{repo}/actions/permissions"],
+    setSelectedReposForOrgSecret: ["PUT /orgs/{org}/actions/secrets/{secret_name}/repositories"],
+    setSelectedRepositoriesEnabledGithubActionsOrganization: ["PUT /orgs/{org}/actions/permissions/repositories"]
+  },
+  activity: {
+    checkRepoIsStarredByAuthenticatedUser: ["GET /user/starred/{owner}/{repo}"],
+    deleteRepoSubscription: ["DELETE /repos/{owner}/{repo}/subscription"],
+    deleteThreadSubscription: ["DELETE /notifications/threads/{thread_id}/subscription"],
+    getFeeds: ["GET /feeds"],
+    getRepoSubscription: ["GET /repos/{owner}/{repo}/subscription"],
+    getThread: ["GET /notifications/threads/{thread_id}"],
+    getThreadSubscriptionForAuthenticatedUser: ["GET /notifications/threads/{thread_id}/subscription"],
+    listEventsForAuthenticatedUser: ["GET /users/{username}/events"],
+    listNotificationsForAuthenticatedUser: ["GET /notifications"],
+    listOrgEventsForAuthenticatedUser: ["GET /users/{username}/events/orgs/{org}"],
+    listPublicEvents: ["GET /events"],
+    listPublicEventsForRepoNetwork: ["GET /networks/{owner}/{repo}/events"],
+    listPublicEventsForUser: ["GET /users/{username}/events/public"],
+    listPublicOrgEvents: ["GET /orgs/{org}/events"],
+    listReceivedEventsForUser: ["GET /users/{username}/received_events"],
+    listReceivedPublicEventsForUser: ["GET /users/{username}/received_events/public"],
+    listRepoEvents: ["GET /repos/{owner}/{repo}/events"],
+    listRepoNotificationsForAuthenticatedUser: ["GET /repos/{owner}/{repo}/notifications"],
+    listReposStarredByAuthenticatedUser: ["GET /user/starred"],
+    listReposStarredByUser: ["GET /users/{username}/starred"],
+    listReposWatchedByUser: ["GET /users/{username}/subscriptions"],
+    listStargazersForRepo: ["GET /repos/{owner}/{repo}/stargazers"],
+    listWatchedReposForAuthenticatedUser: ["GET /user/subscriptions"],
+    listWatchersForRepo: ["GET /repos/{owner}/{repo}/subscribers"],
+    markNotificationsAsRead: ["PUT /notifications"],
+    markRepoNotificationsAsRead: ["PUT /repos/{owner}/{repo}/notifications"],
+    markThreadAsRead: ["PATCH /notifications/threads/{thread_id}"],
+    setRepoSubscription: ["PUT /repos/{owner}/{repo}/subscription"],
+    setThreadSubscription: ["PUT /notifications/threads/{thread_id}/subscription"],
+    starRepoForAuthenticatedUser: ["PUT /user/starred/{owner}/{repo}"],
+    unstarRepoForAuthenticatedUser: ["DELETE /user/starred/{owner}/{repo}"]
+  },
+  apps: {
+    addRepoToInstallation: ["PUT /user/installations/{installation_id}/repositories/{repository_id}"],
+    checkToken: ["POST /applications/{client_id}/token"],
+    createContentAttachment: ["POST /content_references/{content_reference_id}/attachments", {
+      mediaType: {
+        previews: ["corsair"]
+      }
+    }],
+    createFromManifest: ["POST /app-manifests/{code}/conversions"],
+    createInstallationAccessToken: ["POST /app/installations/{installation_id}/access_tokens"],
+    deleteAuthorization: ["DELETE /applications/{client_id}/grant"],
+    deleteInstallation: ["DELETE /app/installations/{installation_id}"],
+    deleteToken: ["DELETE /applications/{client_id}/token"],
+    getAuthenticated: ["GET /app"],
+    getBySlug: ["GET /apps/{app_slug}"],
+    getInstallation: ["GET /app/installations/{installation_id}"],
+    getOrgInstallation: ["GET /orgs/{org}/installation"],
+    getRepoInstallation: ["GET /repos/{owner}/{repo}/installation"],
+    getSubscriptionPlanForAccount: ["GET /marketplace_listing/accounts/{account_id}"],
+    getSubscriptionPlanForAccountStubbed: ["GET /marketplace_listing/stubbed/accounts/{account_id}"],
+    getUserInstallation: ["GET /users/{username}/installation"],
+    getWebhookConfigForApp: ["GET /app/hook/config"],
+    listAccountsForPlan: ["GET /marketplace_listing/plans/{plan_id}/accounts"],
+    listAccountsForPlanStubbed: ["GET /marketplace_listing/stubbed/plans/{plan_id}/accounts"],
+    listInstallationReposForAuthenticatedUser: ["GET /user/installations/{installation_id}/repositories"],
+    listInstallations: ["GET /app/installations"],
+    listInstallationsForAuthenticatedUser: ["GET /user/installations"],
+    listPlans: ["GET /marketplace_listing/plans"],
+    listPlansStubbed: ["GET /marketplace_listing/stubbed/plans"],
+    listReposAccessibleToInstallation: ["GET /installation/repositories"],
+    listSubscriptionsForAuthenticatedUser: ["GET /user/marketplace_purchases"],
+    listSubscriptionsForAuthenticatedUserStubbed: ["GET /user/marketplace_purchases/stubbed"],
+    removeRepoFromInstallation: ["DELETE /user/installations/{installation_id}/repositories/{repository_id}"],
+    resetToken: ["PATCH /applications/{client_id}/token"],
+    revokeInstallationAccessToken: ["DELETE /installation/token"],
+    suspendInstallation: ["PUT /app/installations/{installation_id}/suspended"],
+    unsuspendInstallation: ["DELETE /app/installations/{installation_id}/suspended"],
+    updateWebhookConfigForApp: ["PATCH /app/hook/config"]
+  },
+  billing: {
+    getGithubActionsBillingOrg: ["GET /orgs/{org}/settings/billing/actions"],
+    getGithubActionsBillingUser: ["GET /users/{username}/settings/billing/actions"],
+    getGithubPackagesBillingOrg: ["GET /orgs/{org}/settings/billing/packages"],
+    getGithubPackagesBillingUser: ["GET /users/{username}/settings/billing/packages"],
+    getSharedStorageBillingOrg: ["GET /orgs/{org}/settings/billing/shared-storage"],
+    getSharedStorageBillingUser: ["GET /users/{username}/settings/billing/shared-storage"]
+  },
+  checks: {
+    create: ["POST /repos/{owner}/{repo}/check-runs"],
+    createSuite: ["POST /repos/{owner}/{repo}/check-suites"],
+    get: ["GET /repos/{owner}/{repo}/check-runs/{check_run_id}"],
+    getSuite: ["GET /repos/{owner}/{repo}/check-suites/{check_suite_id}"],
+    listAnnotations: ["GET /repos/{owner}/{repo}/check-runs/{check_run_id}/annotations"],
+    listForRef: ["GET /repos/{owner}/{repo}/commits/{ref}/check-runs"],
+    listForSuite: ["GET /repos/{owner}/{repo}/check-suites/{check_suite_id}/check-runs"],
+    listSuitesForRef: ["GET /repos/{owner}/{repo}/commits/{ref}/check-suites"],
+    rerequestSuite: ["POST /repos/{owner}/{repo}/check-suites/{check_suite_id}/rerequest"],
+    setSuitesPreferences: ["PATCH /repos/{owner}/{repo}/check-suites/preferences"],
+    update: ["PATCH /repos/{owner}/{repo}/check-runs/{check_run_id}"]
+  },
+  codeScanning: {
+    getAlert: ["GET /repos/{owner}/{repo}/code-scanning/alerts/{alert_number}", {}, {
+      renamedParameters: {
+        alert_id: "alert_number"
+      }
+    }],
+    listAlertsForRepo: ["GET /repos/{owner}/{repo}/code-scanning/alerts"],
+    listRecentAnalyses: ["GET /repos/{owner}/{repo}/code-scanning/analyses"],
+    updateAlert: ["PATCH /repos/{owner}/{repo}/code-scanning/alerts/{alert_number}"],
+    uploadSarif: ["POST /repos/{owner}/{repo}/code-scanning/sarifs"]
+  },
+  codesOfConduct: {
+    getAllCodesOfConduct: ["GET /codes_of_conduct", {
+      mediaType: {
+        previews: ["scarlet-witch"]
+      }
+    }],
+    getConductCode: ["GET /codes_of_conduct/{key}", {
+      mediaType: {
+        previews: ["scarlet-witch"]
+      }
+    }],
+    getForRepo: ["GET /repos/{owner}/{repo}/community/code_of_conduct", {
+      mediaType: {
+        previews: ["scarlet-witch"]
+      }
+    }]
+  },
+  emojis: {
+    get: ["GET /emojis"]
+  },
+  enterpriseAdmin: {
+    disableSelectedOrganizationGithubActionsEnterprise: ["DELETE /enterprises/{enterprise}/actions/permissions/organizations/{org_id}"],
+    enableSelectedOrganizationGithubActionsEnterprise: ["PUT /enterprises/{enterprise}/actions/permissions/organizations/{org_id}"],
+    getAllowedActionsEnterprise: ["GET /enterprises/{enterprise}/actions/permissions/selected-actions"],
+    getGithubActionsPermissionsEnterprise: ["GET /enterprises/{enterprise}/actions/permissions"],
+    listSelectedOrganizationsEnabledGithubActionsEnterprise: ["GET /enterprises/{enterprise}/actions/permissions/organizations"],
+    setAllowedActionsEnterprise: ["PUT /enterprises/{enterprise}/actions/permissions/selected-actions"],
+    setGithubActionsPermissionsEnterprise: ["PUT /enterprises/{enterprise}/actions/permissions"],
+    setSelectedOrganizationsEnabledGithubActionsEnterprise: ["PUT /enterprises/{enterprise}/actions/permissions/organizations"]
+  },
+  gists: {
+    checkIsStarred: ["GET /gists/{gist_id}/star"],
+    create: ["POST /gists"],
+    createComment: ["POST /gists/{gist_id}/comments"],
+    delete: ["DELETE /gists/{gist_id}"],
+    deleteComment: ["DELETE /gists/{gist_id}/comments/{comment_id}"],
+    fork: ["POST /gists/{gist_id}/forks"],
+    get: ["GET /gists/{gist_id}"],
+    getComment: ["GET /gists/{gist_id}/comments/{comment_id}"],
+    getRevision: ["GET /gists/{gist_id}/{sha}"],
+    list: ["GET /gists"],
+    listComments: ["GET /gists/{gist_id}/comments"],
+    listCommits: ["GET /gists/{gist_id}/commits"],
+    listForUser: ["GET /users/{username}/gists"],
+    listForks: ["GET /gists/{gist_id}/forks"],
+    listPublic: ["GET /gists/public"],
+    listStarred: ["GET /gists/starred"],
+    star: ["PUT /gists/{gist_id}/star"],
+    unstar: ["DELETE /gists/{gist_id}/star"],
+    update: ["PATCH /gists/{gist_id}"],
+    updateComment: ["PATCH /gists/{gist_id}/comments/{comment_id}"]
+  },
+  git: {
+    createBlob: ["POST /repos/{owner}/{repo}/git/blobs"],
+    createCommit: ["POST /repos/{owner}/{repo}/git/commits"],
+    createRef: ["POST /repos/{owner}/{repo}/git/refs"],
+    createTag: ["POST /repos/{owner}/{repo}/git/tags"],
+    createTree: ["POST /repos/{owner}/{repo}/git/trees"],
+    deleteRef: ["DELETE /repos/{owner}/{repo}/git/refs/{ref}"],
+    getBlob: ["GET /repos/{owner}/{repo}/git/blobs/{file_sha}"],
+    getCommit: ["GET /repos/{owner}/{repo}/git/commits/{commit_sha}"],
+    getRef: ["GET /repos/{owner}/{repo}/git/ref/{ref}"],
+    getTag: ["GET /repos/{owner}/{repo}/git/tags/{tag_sha}"],
+    getTree: ["GET /repos/{owner}/{repo}/git/trees/{tree_sha}"],
+    listMatchingRefs: ["GET /repos/{owner}/{repo}/git/matching-refs/{ref}"],
+    updateRef: ["PATCH /repos/{owner}/{repo}/git/refs/{ref}"]
+  },
+  gitignore: {
+    getAllTemplates: ["GET /gitignore/templates"],
+    getTemplate: ["GET /gitignore/templates/{name}"]
+  },
+  interactions: {
+    getRestrictionsForOrg: ["GET /orgs/{org}/interaction-limits"],
+    getRestrictionsForRepo: ["GET /repos/{owner}/{repo}/interaction-limits"],
+    getRestrictionsForYourPublicRepos: ["GET /user/interaction-limits"],
+    removeRestrictionsForOrg: ["DELETE /orgs/{org}/interaction-limits"],
+    removeRestrictionsForRepo: ["DELETE /repos/{owner}/{repo}/interaction-limits"],
+    removeRestrictionsForYourPublicRepos: ["DELETE /user/interaction-limits"],
+    setRestrictionsForOrg: ["PUT /orgs/{org}/interaction-limits"],
+    setRestrictionsForRepo: ["PUT /repos/{owner}/{repo}/interaction-limits"],
+    setRestrictionsForYourPublicRepos: ["PUT /user/interaction-limits"]
+  },
+  issues: {
+    addAssignees: ["POST /repos/{owner}/{repo}/issues/{issue_number}/assignees"],
+    addLabels: ["POST /repos/{owner}/{repo}/issues/{issue_number}/labels"],
+    checkUserCanBeAssigned: ["GET /repos/{owner}/{repo}/assignees/{assignee}"],
+    create: ["POST /repos/{owner}/{repo}/issues"],
+    createComment: ["POST /repos/{owner}/{repo}/issues/{issue_number}/comments"],
+    createLabel: ["POST /repos/{owner}/{repo}/labels"],
+    createMilestone: ["POST /repos/{owner}/{repo}/milestones"],
+    deleteComment: ["DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}"],
+    deleteLabel: ["DELETE /repos/{owner}/{repo}/labels/{name}"],
+    deleteMilestone: ["DELETE /repos/{owner}/{repo}/milestones/{milestone_number}"],
+    get: ["GET /repos/{owner}/{repo}/issues/{issue_number}"],
+    getComment: ["GET /repos/{owner}/{repo}/issues/comments/{comment_id}"],
+    getEvent: ["GET /repos/{owner}/{repo}/issues/events/{event_id}"],
+    getLabel: ["GET /repos/{owner}/{repo}/labels/{name}"],
+    getMilestone: ["GET /repos/{owner}/{repo}/milestones/{milestone_number}"],
+    list: ["GET /issues"],
+    listAssignees: ["GET /repos/{owner}/{repo}/assignees"],
+    listComments: ["GET /repos/{owner}/{repo}/issues/{issue_number}/comments"],
+    listCommentsForRepo: ["GET /repos/{owner}/{repo}/issues/comments"],
+    listEvents: ["GET /repos/{owner}/{repo}/issues/{issue_number}/events"],
+    listEventsForRepo: ["GET /repos/{owner}/{repo}/issues/events"],
+    listEventsForTimeline: ["GET /repos/{owner}/{repo}/issues/{issue_number}/timeline", {
+      mediaType: {
+        previews: ["mockingbird"]
+      }
+    }],
+    listForAuthenticatedUser: ["GET /user/issues"],
+    listForOrg: ["GET /orgs/{org}/issues"],
+    listForRepo: ["GET /repos/{owner}/{repo}/issues"],
+    listLabelsForMilestone: ["GET /repos/{owner}/{repo}/milestones/{milestone_number}/labels"],
+    listLabelsForRepo: ["GET /repos/{owner}/{repo}/labels"],
+    listLabelsOnIssue: ["GET /repos/{owner}/{repo}/issues/{issue_number}/labels"],
+    listMilestones: ["GET /repos/{owner}/{repo}/milestones"],
+    lock: ["PUT /repos/{owner}/{repo}/issues/{issue_number}/lock"],
+    removeAllLabels: ["DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels"],
+    removeAssignees: ["DELETE /repos/{owner}/{repo}/issues/{issue_number}/assignees"],
+    removeLabel: ["DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels/{name}"],
+    setLabels: ["PUT /repos/{owner}/{repo}/issues/{issue_number}/labels"],
+    unlock: ["DELETE /repos/{owner}/{repo}/issues/{issue_number}/lock"],
+    update: ["PATCH /repos/{owner}/{repo}/issues/{issue_number}"],
+    updateComment: ["PATCH /repos/{owner}/{repo}/issues/comments/{comment_id}"],
+    updateLabel: ["PATCH /repos/{owner}/{repo}/labels/{name}"],
+    updateMilestone: ["PATCH /repos/{owner}/{repo}/milestones/{milestone_number}"]
+  },
+  licenses: {
+    get: ["GET /licenses/{license}"],
+    getAllCommonlyUsed: ["GET /licenses"],
+    getForRepo: ["GET /repos/{owner}/{repo}/license"]
+  },
+  markdown: {
+    render: ["POST /markdown"],
+    renderRaw: ["POST /markdown/raw", {
+      headers: {
+        "content-type": "text/plain; charset=utf-8"
+      }
+    }]
+  },
+  meta: {
+    get: ["GET /meta"],
+    getOctocat: ["GET /octocat"],
+    getZen: ["GET /zen"],
+    root: ["GET /"]
+  },
+  migrations: {
+    cancelImport: ["DELETE /repos/{owner}/{repo}/import"],
+    deleteArchiveForAuthenticatedUser: ["DELETE /user/migrations/{migration_id}/archive", {
+      mediaType: {
+        previews: ["wyandotte"]
+      }
+    }],
+    deleteArchiveForOrg: ["DELETE /orgs/{org}/migrations/{migration_id}/archive", {
+      mediaType: {
+        previews: ["wyandotte"]
+      }
+    }],
+    downloadArchiveForOrg: ["GET /orgs/{org}/migrations/{migration_id}/archive", {
+      mediaType: {
+        previews: ["wyandotte"]
+      }
+    }],
+    getArchiveForAuthenticatedUser: ["GET /user/migrations/{migration_id}/archive", {
+      mediaType: {
+        previews: ["wyandotte"]
+      }
+    }],
+    getCommitAuthors: ["GET /repos/{owner}/{repo}/import/authors"],
+    getImportStatus: ["GET /repos/{owner}/{repo}/import"],
+    getLargeFiles: ["GET /repos/{owner}/{repo}/import/large_files"],
+    getStatusForAuthenticatedUser: ["GET /user/migrations/{migration_id}", {
+      mediaType: {
+        previews: ["wyandotte"]
+      }
+    }],
+    getStatusForOrg: ["GET /orgs/{org}/migrations/{migration_id}", {
+      mediaType: {
+        previews: ["wyandotte"]
+      }
+    }],
+    listForAuthenticatedUser: ["GET /user/migrations", {
+      mediaType: {
+        previews: ["wyandotte"]
+      }
+    }],
+    listForOrg: ["GET /orgs/{org}/migrations", {
+      mediaType: {
+        previews: ["wyandotte"]
+      }
+    }],
+    listReposForOrg: ["GET /orgs/{org}/migrations/{migration_id}/repositories", {
+      mediaType: {
+        previews: ["wyandotte"]
+      }
+    }],
+    listReposForUser: ["GET /user/migrations/{migration_id}/repositories", {
+      mediaType: {
+        previews: ["wyandotte"]
+      }
+    }],
+    mapCommitAuthor: ["PATCH /repos/{owner}/{repo}/import/authors/{author_id}"],
+    setLfsPreference: ["PATCH /repos/{owner}/{repo}/import/lfs"],
+    startForAuthenticatedUser: ["POST /user/migrations"],
+    startForOrg: ["POST /orgs/{org}/migrations"],
+    startImport: ["PUT /repos/{owner}/{repo}/import"],
+    unlockRepoForAuthenticatedUser: ["DELETE /user/migrations/{migration_id}/repos/{repo_name}/lock", {
+      mediaType: {
+        previews: ["wyandotte"]
+      }
+    }],
+    unlockRepoForOrg: ["DELETE /orgs/{org}/migrations/{migration_id}/repos/{repo_name}/lock", {
+      mediaType: {
+        previews: ["wyandotte"]
+      }
+    }],
+    updateImport: ["PATCH /repos/{owner}/{repo}/import"]
+  },
+  orgs: {
+    blockUser: ["PUT /orgs/{org}/blocks/{username}"],
+    checkBlockedUser: ["GET /orgs/{org}/blocks/{username}"],
+    checkMembershipForUser: ["GET /orgs/{org}/members/{username}"],
+    checkPublicMembershipForUser: ["GET /orgs/{org}/public_members/{username}"],
+    convertMemberToOutsideCollaborator: ["PUT /orgs/{org}/outside_collaborators/{username}"],
+    createInvitation: ["POST /orgs/{org}/invitations"],
+    createWebhook: ["POST /orgs/{org}/hooks"],
+    deleteWebhook: ["DELETE /orgs/{org}/hooks/{hook_id}"],
+    get: ["GET /orgs/{org}"],
+    getMembershipForAuthenticatedUser: ["GET /user/memberships/orgs/{org}"],
+    getMembershipForUser: ["GET /orgs/{org}/memberships/{username}"],
+    getWebhook: ["GET /orgs/{org}/hooks/{hook_id}"],
+    getWebhookConfigForOrg: ["GET /orgs/{org}/hooks/{hook_id}/config"],
+    list: ["GET /organizations"],
+    listAppInstallations: ["GET /orgs/{org}/installations"],
+    listBlockedUsers: ["GET /orgs/{org}/blocks"],
+    listForAuthenticatedUser: ["GET /user/orgs"],
+    listForUser: ["GET /users/{username}/orgs"],
+    listInvitationTeams: ["GET /orgs/{org}/invitations/{invitation_id}/teams"],
+    listMembers: ["GET /orgs/{org}/members"],
+    listMembershipsForAuthenticatedUser: ["GET /user/memberships/orgs"],
+    listOutsideCollaborators: ["GET /orgs/{org}/outside_collaborators"],
+    listPendingInvitations: ["GET /orgs/{org}/invitations"],
+    listPublicMembers: ["GET /orgs/{org}/public_members"],
+    listWebhooks: ["GET /orgs/{org}/hooks"],
+    pingWebhook: ["POST /orgs/{org}/hooks/{hook_id}/pings"],
+    removeMember: ["DELETE /orgs/{org}/members/{username}"],
+    removeMembershipForUser: ["DELETE /orgs/{org}/memberships/{username}"],
+    removeOutsideCollaborator: ["DELETE /orgs/{org}/outside_collaborators/{username}"],
+    removePublicMembershipForAuthenticatedUser: ["DELETE /orgs/{org}/public_members/{username}"],
+    setMembershipForUser: ["PUT /orgs/{org}/memberships/{username}"],
+    setPublicMembershipForAuthenticatedUser: ["PUT /orgs/{org}/public_members/{username}"],
+    unblockUser: ["DELETE /orgs/{org}/blocks/{username}"],
+    update: ["PATCH /orgs/{org}"],
+    updateMembershipForAuthenticatedUser: ["PATCH /user/memberships/orgs/{org}"],
+    updateWebhook: ["PATCH /orgs/{org}/hooks/{hook_id}"],
+    updateWebhookConfigForOrg: ["PATCH /orgs/{org}/hooks/{hook_id}/config"]
+  },
+  projects: {
+    addCollaborator: ["PUT /projects/{project_id}/collaborators/{username}", {
+      mediaType: {
+        previews: ["inertia"]
+      }
+    }],
+    createCard: ["POST /projects/columns/{column_id}/cards", {
+      mediaType: {
+        previews: ["inertia"]
+      }
+    }],
+    createColumn: ["POST /projects/{project_id}/columns", {
+      mediaType: {
+        previews: ["inertia"]
+      }
+    }],
+    createForAuthenticatedUser: ["POST /user/projects", {
+      mediaType: {
+        previews: ["inertia"]
+      }
+    }],
+    createForOrg: ["POST /orgs/{org}/projects", {
+      mediaType: {
+        previews: ["inertia"]
+      }
+    }],
+    createForRepo: ["POST /repos/{owner}/{repo}/projects", {
+      mediaType: {
+        previews: ["inertia"]
+      }
+    }],
+    delete: ["DELETE /projects/{project_id}", {
+      mediaType: {
+        previews: ["inertia"]
+      }
+    }],
+    deleteCard: ["DELETE /projects/columns/cards/{card_id}", {
+      mediaType: {
+        previews: ["inertia"]
+      }
+    }],
+    deleteColumn: ["DELETE /projects/columns/{column_id}", {
+      mediaType: {
+        previews: ["inertia"]
+      }
+    }],
+    get: ["GET /projects/{project_id}", {
+      mediaType: {
+        previews: ["inertia"]
+      }
+    }],
+    getCard: ["GET /projects/columns/cards/{card_id}", {
+      mediaType: {
+        previews: ["inertia"]
+      }
+    }],
+    getColumn: ["GET /projects/columns/{column_id}", {
+      mediaType: {
+        previews: ["inertia"]
+      }
+    }],
+    getPermissionForUser: ["GET /projects/{project_id}/collaborators/{username}/permission", {
+      mediaType: {
+        previews: ["inertia"]
+      }
+    }],
+    listCards: ["GET /projects/columns/{column_id}/cards", {
+      mediaType: {
+        previews: ["inertia"]
+      }
+    }],
+    listCollaborators: ["GET /projects/{project_id}/collaborators", {
+      mediaType: {
+        previews: ["inertia"]
+      }
+    }],
+    listColumns: ["GET /projects/{project_id}/columns", {
+      mediaType: {
+        previews: ["inertia"]
+      }
+    }],
+    listForOrg: ["GET /orgs/{org}/projects", {
+      mediaType: {
+        previews: ["inertia"]
+      }
+    }],
+    listForRepo: ["GET /repos/{owner}/{repo}/projects", {
+      mediaType: {
+        previews: ["inertia"]
+      }
+    }],
+    listForUser: ["GET /users/{username}/projects", {
+      mediaType: {
+        previews: ["inertia"]
+      }
+    }],
+    moveCard: ["POST /projects/columns/cards/{card_id}/moves", {
+      mediaType: {
+        previews: ["inertia"]
+      }
+    }],
+    moveColumn: ["POST /projects/columns/{column_id}/moves", {
+      mediaType: {
+        previews: ["inertia"]
+      }
+    }],
+    removeCollaborator: ["DELETE /projects/{project_id}/collaborators/{username}", {
+      mediaType: {
+        previews: ["inertia"]
+      }
+    }],
+    update: ["PATCH /projects/{project_id}", {
+      mediaType: {
+        previews: ["inertia"]
+      }
+    }],
+    updateCard: ["PATCH /projects/columns/cards/{card_id}", {
+      mediaType: {
+        previews: ["inertia"]
+      }
+    }],
+    updateColumn: ["PATCH /projects/columns/{column_id}", {
+      mediaType: {
+        previews: ["inertia"]
+      }
+    }]
+  },
+  pulls: {
+    checkIfMerged: ["GET /repos/{owner}/{repo}/pulls/{pull_number}/merge"],
+    create: ["POST /repos/{owner}/{repo}/pulls"],
+    createReplyForReviewComment: ["POST /repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies"],
+    createReview: ["POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews"],
+    createReviewComment: ["POST /repos/{owner}/{repo}/pulls/{pull_number}/comments"],
+    deletePendingReview: ["DELETE /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}"],
+    deleteReviewComment: ["DELETE /repos/{owner}/{repo}/pulls/comments/{comment_id}"],
+    dismissReview: ["PUT /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/dismissals"],
+    get: ["GET /repos/{owner}/{repo}/pulls/{pull_number}"],
+    getReview: ["GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}"],
+    getReviewComment: ["GET /repos/{owner}/{repo}/pulls/comments/{comment_id}"],
+    list: ["GET /repos/{owner}/{repo}/pulls"],
+    listCommentsForReview: ["GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/comments"],
+    listCommits: ["GET /repos/{owner}/{repo}/pulls/{pull_number}/commits"],
+    listFiles: ["GET /repos/{owner}/{repo}/pulls/{pull_number}/files"],
+    listRequestedReviewers: ["GET /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers"],
+    listReviewComments: ["GET /repos/{owner}/{repo}/pulls/{pull_number}/comments"],
+    listReviewCommentsForRepo: ["GET /repos/{owner}/{repo}/pulls/comments"],
+    listReviews: ["GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews"],
+    merge: ["PUT /repos/{owner}/{repo}/pulls/{pull_number}/merge"],
+    removeRequestedReviewers: ["DELETE /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers"],
+    requestReviewers: ["POST /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers"],
+    submitReview: ["POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/events"],
+    update: ["PATCH /repos/{owner}/{repo}/pulls/{pull_number}"],
+    updateBranch: ["PUT /repos/{owner}/{repo}/pulls/{pull_number}/update-branch", {
+      mediaType: {
+        previews: ["lydian"]
+      }
+    }],
+    updateReview: ["PUT /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}"],
+    updateReviewComment: ["PATCH /repos/{owner}/{repo}/pulls/comments/{comment_id}"]
+  },
+  rateLimit: {
+    get: ["GET /rate_limit"]
+  },
+  reactions: {
+    createForCommitComment: ["POST /repos/{owner}/{repo}/comments/{comment_id}/reactions", {
+      mediaType: {
+        previews: ["squirrel-girl"]
+      }
+    }],
+    createForIssue: ["POST /repos/{owner}/{repo}/issues/{issue_number}/reactions", {
+      mediaType: {
+        previews: ["squirrel-girl"]
+      }
+    }],
+    createForIssueComment: ["POST /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions", {
+      mediaType: {
+        previews: ["squirrel-girl"]
+      }
+    }],
+    createForPullRequestReviewComment: ["POST /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions", {
+      mediaType: {
+        previews: ["squirrel-girl"]
+      }
+    }],
+    createForTeamDiscussionCommentInOrg: ["POST /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions", {
+      mediaType: {
+        previews: ["squirrel-girl"]
+      }
+    }],
+    createForTeamDiscussionInOrg: ["POST /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions", {
+      mediaType: {
+        previews: ["squirrel-girl"]
+      }
+    }],
+    deleteForCommitComment: ["DELETE /repos/{owner}/{repo}/comments/{comment_id}/reactions/{reaction_id}", {
+      mediaType: {
+        previews: ["squirrel-girl"]
+      }
+    }],
+    deleteForIssue: ["DELETE /repos/{owner}/{repo}/issues/{issue_number}/reactions/{reaction_id}", {
+      mediaType: {
+        previews: ["squirrel-girl"]
+      }
+    }],
+    deleteForIssueComment: ["DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions/{reaction_id}", {
+      mediaType: {
+        previews: ["squirrel-girl"]
+      }
+    }],
+    deleteForPullRequestComment: ["DELETE /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions/{reaction_id}", {
+      mediaType: {
+        previews: ["squirrel-girl"]
+      }
+    }],
+    deleteForTeamDiscussion: ["DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions/{reaction_id}", {
+      mediaType: {
+        previews: ["squirrel-girl"]
+      }
+    }],
+    deleteForTeamDiscussionComment: ["DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions/{reaction_id}", {
+      mediaType: {
+        previews: ["squirrel-girl"]
+      }
+    }],
+    deleteLegacy: ["DELETE /reactions/{reaction_id}", {
+      mediaType: {
+        previews: ["squirrel-girl"]
+      }
+    }, {
+      deprecated: "octokit.reactions.deleteLegacy() is deprecated, see https://docs.github.com/v3/reactions/#delete-a-reaction-legacy"
+    }],
+    listForCommitComment: ["GET /repos/{owner}/{repo}/comments/{comment_id}/reactions", {
+      mediaType: {
+        previews: ["squirrel-girl"]
+      }
+    }],
+    listForIssue: ["GET /repos/{owner}/{repo}/issues/{issue_number}/reactions", {
+      mediaType: {
+        previews: ["squirrel-girl"]
+      }
+    }],
+    listForIssueComment: ["GET /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions", {
+      mediaType: {
+        previews: ["squirrel-girl"]
+      }
+    }],
+    listForPullRequestReviewComment: ["GET /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions", {
+      mediaType: {
+        previews: ["squirrel-girl"]
+      }
+    }],
+    listForTeamDiscussionCommentInOrg: ["GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions", {
+      mediaType: {
+        previews: ["squirrel-girl"]
+      }
+    }],
+    listForTeamDiscussionInOrg: ["GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions", {
+      mediaType: {
+        previews: ["squirrel-girl"]
+      }
+    }]
+  },
+  repos: {
+    acceptInvitation: ["PATCH /user/repository_invitations/{invitation_id}"],
+    addAppAccessRestrictions: ["POST /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps", {}, {
+      mapToData: "apps"
+    }],
+    addCollaborator: ["PUT /repos/{owner}/{repo}/collaborators/{username}"],
+    addStatusCheckContexts: ["POST /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts", {}, {
+      mapToData: "contexts"
+    }],
+    addTeamAccessRestrictions: ["POST /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams", {}, {
+      mapToData: "teams"
+    }],
+    addUserAccessRestrictions: ["POST /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users", {}, {
+      mapToData: "users"
+    }],
+    checkCollaborator: ["GET /repos/{owner}/{repo}/collaborators/{username}"],
+    checkVulnerabilityAlerts: ["GET /repos/{owner}/{repo}/vulnerability-alerts", {
+      mediaType: {
+        previews: ["dorian"]
+      }
+    }],
+    compareCommits: ["GET /repos/{owner}/{repo}/compare/{base}...{head}"],
+    createCommitComment: ["POST /repos/{owner}/{repo}/commits/{commit_sha}/comments"],
+    createCommitSignatureProtection: ["POST /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures", {
+      mediaType: {
+        previews: ["zzzax"]
+      }
+    }],
+    createCommitStatus: ["POST /repos/{owner}/{repo}/statuses/{sha}"],
+    createDeployKey: ["POST /repos/{owner}/{repo}/keys"],
+    createDeployment: ["POST /repos/{owner}/{repo}/deployments"],
+    createDeploymentStatus: ["POST /repos/{owner}/{repo}/deployments/{deployment_id}/statuses"],
+    createDispatchEvent: ["POST /repos/{owner}/{repo}/dispatches"],
+    createForAuthenticatedUser: ["POST /user/repos"],
+    createFork: ["POST /repos/{owner}/{repo}/forks"],
+    createInOrg: ["POST /orgs/{org}/repos"],
+    createOrUpdateFileContents: ["PUT /repos/{owner}/{repo}/contents/{path}"],
+    createPagesSite: ["POST /repos/{owner}/{repo}/pages", {
+      mediaType: {
+        previews: ["switcheroo"]
+      }
+    }],
+    createRelease: ["POST /repos/{owner}/{repo}/releases"],
+    createUsingTemplate: ["POST /repos/{template_owner}/{template_repo}/generate", {
+      mediaType: {
+        previews: ["baptiste"]
+      }
+    }],
+    createWebhook: ["POST /repos/{owner}/{repo}/hooks"],
+    declineInvitation: ["DELETE /user/repository_invitations/{invitation_id}"],
+    delete: ["DELETE /repos/{owner}/{repo}"],
+    deleteAccessRestrictions: ["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/restrictions"],
+    deleteAdminBranchProtection: ["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins"],
+    deleteBranchProtection: ["DELETE /repos/{owner}/{repo}/branches/{branch}/protection"],
+    deleteCommitComment: ["DELETE /repos/{owner}/{repo}/comments/{comment_id}"],
+    deleteCommitSignatureProtection: ["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures", {
+      mediaType: {
+        previews: ["zzzax"]
+      }
+    }],
+    deleteDeployKey: ["DELETE /repos/{owner}/{repo}/keys/{key_id}"],
+    deleteDeployment: ["DELETE /repos/{owner}/{repo}/deployments/{deployment_id}"],
+    deleteFile: ["DELETE /repos/{owner}/{repo}/contents/{path}"],
+    deleteInvitation: ["DELETE /repos/{owner}/{repo}/invitations/{invitation_id}"],
+    deletePagesSite: ["DELETE /repos/{owner}/{repo}/pages", {
+      mediaType: {
+        previews: ["switcheroo"]
+      }
+    }],
+    deletePullRequestReviewProtection: ["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews"],
+    deleteRelease: ["DELETE /repos/{owner}/{repo}/releases/{release_id}"],
+    deleteReleaseAsset: ["DELETE /repos/{owner}/{repo}/releases/assets/{asset_id}"],
+    deleteWebhook: ["DELETE /repos/{owner}/{repo}/hooks/{hook_id}"],
+    disableAutomatedSecurityFixes: ["DELETE /repos/{owner}/{repo}/automated-security-fixes", {
+      mediaType: {
+        previews: ["london"]
+      }
+    }],
+    disableVulnerabilityAlerts: ["DELETE /repos/{owner}/{repo}/vulnerability-alerts", {
+      mediaType: {
+        previews: ["dorian"]
+      }
+    }],
+    downloadArchive: ["GET /repos/{owner}/{repo}/zipball/{ref}", {}, {
+      renamed: ["repos", "downloadZipballArchive"]
+    }],
+    downloadTarballArchive: ["GET /repos/{owner}/{repo}/tarball/{ref}"],
+    downloadZipballArchive: ["GET /repos/{owner}/{repo}/zipball/{ref}"],
+    enableAutomatedSecurityFixes: ["PUT /repos/{owner}/{repo}/automated-security-fixes", {
+      mediaType: {
+        previews: ["london"]
+      }
+    }],
+    enableVulnerabilityAlerts: ["PUT /repos/{owner}/{repo}/vulnerability-alerts", {
+      mediaType: {
+        previews: ["dorian"]
+      }
+    }],
+    get: ["GET /repos/{owner}/{repo}"],
+    getAccessRestrictions: ["GET /repos/{owner}/{repo}/branches/{branch}/protection/restrictions"],
+    getAdminBranchProtection: ["GET /repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins"],
+    getAllStatusCheckContexts: ["GET /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts"],
+    getAllTopics: ["GET /repos/{owner}/{repo}/topics", {
+      mediaType: {
+        previews: ["mercy"]
+      }
+    }],
+    getAppsWithAccessToProtectedBranch: ["GET /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps"],
+    getBranch: ["GET /repos/{owner}/{repo}/branches/{branch}"],
+    getBranchProtection: ["GET /repos/{owner}/{repo}/branches/{branch}/protection"],
+    getClones: ["GET /repos/{owner}/{repo}/traffic/clones"],
+    getCodeFrequencyStats: ["GET /repos/{owner}/{repo}/stats/code_frequency"],
+    getCollaboratorPermissionLevel: ["GET /repos/{owner}/{repo}/collaborators/{username}/permission"],
+    getCombinedStatusForRef: ["GET /repos/{owner}/{repo}/commits/{ref}/status"],
+    getCommit: ["GET /repos/{owner}/{repo}/commits/{ref}"],
+    getCommitActivityStats: ["GET /repos/{owner}/{repo}/stats/commit_activity"],
+    getCommitComment: ["GET /repos/{owner}/{repo}/comments/{comment_id}"],
+    getCommitSignatureProtection: ["GET /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures", {
+      mediaType: {
+        previews: ["zzzax"]
+      }
+    }],
+    getCommunityProfileMetrics: ["GET /repos/{owner}/{repo}/community/profile"],
+    getContent: ["GET /repos/{owner}/{repo}/contents/{path}"],
+    getContributorsStats: ["GET /repos/{owner}/{repo}/stats/contributors"],
+    getDeployKey: ["GET /repos/{owner}/{repo}/keys/{key_id}"],
+    getDeployment: ["GET /repos/{owner}/{repo}/deployments/{deployment_id}"],
+    getDeploymentStatus: ["GET /repos/{owner}/{repo}/deployments/{deployment_id}/statuses/{status_id}"],
+    getLatestPagesBuild: ["GET /repos/{owner}/{repo}/pages/builds/latest"],
+    getLatestRelease: ["GET /repos/{owner}/{repo}/releases/latest"],
+    getPages: ["GET /repos/{owner}/{repo}/pages"],
+    getPagesBuild: ["GET /repos/{owner}/{repo}/pages/builds/{build_id}"],
+    getParticipationStats: ["GET /repos/{owner}/{repo}/stats/participation"],
+    getPullRequestReviewProtection: ["GET /repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews"],
+    getPunchCardStats: ["GET /repos/{owner}/{repo}/stats/punch_card"],
+    getReadme: ["GET /repos/{owner}/{repo}/readme"],
+    getRelease: ["GET /repos/{owner}/{repo}/releases/{release_id}"],
+    getReleaseAsset: ["GET /repos/{owner}/{repo}/releases/assets/{asset_id}"],
+    getReleaseByTag: ["GET /repos/{owner}/{repo}/releases/tags/{tag}"],
+    getStatusChecksProtection: ["GET /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks"],
+    getTeamsWithAccessToProtectedBranch: ["GET /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams"],
+    getTopPaths: ["GET /repos/{owner}/{repo}/traffic/popular/paths"],
+    getTopReferrers: ["GET /repos/{owner}/{repo}/traffic/popular/referrers"],
+    getUsersWithAccessToProtectedBranch: ["GET /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users"],
+    getViews: ["GET /repos/{owner}/{repo}/traffic/views"],
+    getWebhook: ["GET /repos/{owner}/{repo}/hooks/{hook_id}"],
+    getWebhookConfigForRepo: ["GET /repos/{owner}/{repo}/hooks/{hook_id}/config"],
+    listBranches: ["GET /repos/{owner}/{repo}/branches"],
+    listBranchesForHeadCommit: ["GET /repos/{owner}/{repo}/commits/{commit_sha}/branches-where-head", {
+      mediaType: {
+        previews: ["groot"]
+      }
+    }],
+    listCollaborators: ["GET /repos/{owner}/{repo}/collaborators"],
+    listCommentsForCommit: ["GET /repos/{owner}/{repo}/commits/{commit_sha}/comments"],
+    listCommitCommentsForRepo: ["GET /repos/{owner}/{repo}/comments"],
+    listCommitStatusesForRef: ["GET /repos/{owner}/{repo}/commits/{ref}/statuses"],
+    listCommits: ["GET /repos/{owner}/{repo}/commits"],
+    listContributors: ["GET /repos/{owner}/{repo}/contributors"],
+    listDeployKeys: ["GET /repos/{owner}/{repo}/keys"],
+    listDeploymentStatuses: ["GET /repos/{owner}/{repo}/deployments/{deployment_id}/statuses"],
+    listDeployments: ["GET /repos/{owner}/{repo}/deployments"],
+    listForAuthenticatedUser: ["GET /user/repos"],
+    listForOrg: ["GET /orgs/{org}/repos"],
+    listForUser: ["GET /users/{username}/repos"],
+    listForks: ["GET /repos/{owner}/{repo}/forks"],
+    listInvitations: ["GET /repos/{owner}/{repo}/invitations"],
+    listInvitationsForAuthenticatedUser: ["GET /user/repository_invitations"],
+    listLanguages: ["GET /repos/{owner}/{repo}/languages"],
+    listPagesBuilds: ["GET /repos/{owner}/{repo}/pages/builds"],
+    listPublic: ["GET /repositories"],
+    listPullRequestsAssociatedWithCommit: ["GET /repos/{owner}/{repo}/commits/{commit_sha}/pulls", {
+      mediaType: {
+        previews: ["groot"]
+      }
+    }],
+    listReleaseAssets: ["GET /repos/{owner}/{repo}/releases/{release_id}/assets"],
+    listReleases: ["GET /repos/{owner}/{repo}/releases"],
+    listTags: ["GET /repos/{owner}/{repo}/tags"],
+    listTeams: ["GET /repos/{owner}/{repo}/teams"],
+    listWebhooks: ["GET /repos/{owner}/{repo}/hooks"],
+    merge: ["POST /repos/{owner}/{repo}/merges"],
+    pingWebhook: ["POST /repos/{owner}/{repo}/hooks/{hook_id}/pings"],
+    removeAppAccessRestrictions: ["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps", {}, {
+      mapToData: "apps"
+    }],
+    removeCollaborator: ["DELETE /repos/{owner}/{repo}/collaborators/{username}"],
+    removeStatusCheckContexts: ["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts", {}, {
+      mapToData: "contexts"
+    }],
+    removeStatusCheckProtection: ["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks"],
+    removeTeamAccessRestrictions: ["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams", {}, {
+      mapToData: "teams"
+    }],
+    removeUserAccessRestrictions: ["DELETE /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users", {}, {
+      mapToData: "users"
+    }],
+    replaceAllTopics: ["PUT /repos/{owner}/{repo}/topics", {
+      mediaType: {
+        previews: ["mercy"]
+      }
+    }],
+    requestPagesBuild: ["POST /repos/{owner}/{repo}/pages/builds"],
+    setAdminBranchProtection: ["POST /repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins"],
+    setAppAccessRestrictions: ["PUT /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps", {}, {
+      mapToData: "apps"
+    }],
+    setStatusCheckContexts: ["PUT /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts", {}, {
+      mapToData: "contexts"
+    }],
+    setTeamAccessRestrictions: ["PUT /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams", {}, {
+      mapToData: "teams"
+    }],
+    setUserAccessRestrictions: ["PUT /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users", {}, {
+      mapToData: "users"
+    }],
+    testPushWebhook: ["POST /repos/{owner}/{repo}/hooks/{hook_id}/tests"],
+    transfer: ["POST /repos/{owner}/{repo}/transfer"],
+    update: ["PATCH /repos/{owner}/{repo}"],
+    updateBranchProtection: ["PUT /repos/{owner}/{repo}/branches/{branch}/protection"],
+    updateCommitComment: ["PATCH /repos/{owner}/{repo}/comments/{comment_id}"],
+    updateInformationAboutPagesSite: ["PUT /repos/{owner}/{repo}/pages"],
+    updateInvitation: ["PATCH /repos/{owner}/{repo}/invitations/{invitation_id}"],
+    updatePullRequestReviewProtection: ["PATCH /repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews"],
+    updateRelease: ["PATCH /repos/{owner}/{repo}/releases/{release_id}"],
+    updateReleaseAsset: ["PATCH /repos/{owner}/{repo}/releases/assets/{asset_id}"],
+    updateStatusCheckPotection: ["PATCH /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks", {}, {
+      renamed: ["repos", "updateStatusCheckProtection"]
+    }],
+    updateStatusCheckProtection: ["PATCH /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks"],
+    updateWebhook: ["PATCH /repos/{owner}/{repo}/hooks/{hook_id}"],
+    updateWebhookConfigForRepo: ["PATCH /repos/{owner}/{repo}/hooks/{hook_id}/config"],
+    uploadReleaseAsset: ["POST /repos/{owner}/{repo}/releases/{release_id}/assets{?name,label}", {
+      baseUrl: "https://uploads.github.com"
+    }]
+  },
+  search: {
+    code: ["GET /search/code"],
+    commits: ["GET /search/commits", {
+      mediaType: {
+        previews: ["cloak"]
+      }
+    }],
+    issuesAndPullRequests: ["GET /search/issues"],
+    labels: ["GET /search/labels"],
+    repos: ["GET /search/repositories"],
+    topics: ["GET /search/topics", {
+      mediaType: {
+        previews: ["mercy"]
+      }
+    }],
+    users: ["GET /search/users"]
+  },
+  secretScanning: {
+    getAlert: ["GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}"],
+    listAlertsForRepo: ["GET /repos/{owner}/{repo}/secret-scanning/alerts"],
+    updateAlert: ["PATCH /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}"]
+  },
+  teams: {
+    addOrUpdateMembershipForUserInOrg: ["PUT /orgs/{org}/teams/{team_slug}/memberships/{username}"],
+    addOrUpdateProjectPermissionsInOrg: ["PUT /orgs/{org}/teams/{team_slug}/projects/{project_id}", {
+      mediaType: {
+        previews: ["inertia"]
+      }
+    }],
+    addOrUpdateRepoPermissionsInOrg: ["PUT /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}"],
+    checkPermissionsForProjectInOrg: ["GET /orgs/{org}/teams/{team_slug}/projects/{project_id}", {
+      mediaType: {
+        previews: ["inertia"]
+      }
+    }],
+    checkPermissionsForRepoInOrg: ["GET /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}"],
+    create: ["POST /orgs/{org}/teams"],
+    createDiscussionCommentInOrg: ["POST /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments"],
+    createDiscussionInOrg: ["POST /orgs/{org}/teams/{team_slug}/discussions"],
+    deleteDiscussionCommentInOrg: ["DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}"],
+    deleteDiscussionInOrg: ["DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}"],
+    deleteInOrg: ["DELETE /orgs/{org}/teams/{team_slug}"],
+    getByName: ["GET /orgs/{org}/teams/{team_slug}"],
+    getDiscussionCommentInOrg: ["GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}"],
+    getDiscussionInOrg: ["GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}"],
+    getMembershipForUserInOrg: ["GET /orgs/{org}/teams/{team_slug}/memberships/{username}"],
+    list: ["GET /orgs/{org}/teams"],
+    listChildInOrg: ["GET /orgs/{org}/teams/{team_slug}/teams"],
+    listDiscussionCommentsInOrg: ["GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments"],
+    listDiscussionsInOrg: ["GET /orgs/{org}/teams/{team_slug}/discussions"],
+    listForAuthenticatedUser: ["GET /user/teams"],
+    listMembersInOrg: ["GET /orgs/{org}/teams/{team_slug}/members"],
+    listPendingInvitationsInOrg: ["GET /orgs/{org}/teams/{team_slug}/invitations"],
+    listProjectsInOrg: ["GET /orgs/{org}/teams/{team_slug}/projects", {
+      mediaType: {
+        previews: ["inertia"]
+      }
+    }],
+    listReposInOrg: ["GET /orgs/{org}/teams/{team_slug}/repos"],
+    removeMembershipForUserInOrg: ["DELETE /orgs/{org}/teams/{team_slug}/memberships/{username}"],
+    removeProjectInOrg: ["DELETE /orgs/{org}/teams/{team_slug}/projects/{project_id}"],
+    removeRepoInOrg: ["DELETE /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}"],
+    updateDiscussionCommentInOrg: ["PATCH /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}"],
+    updateDiscussionInOrg: ["PATCH /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}"],
+    updateInOrg: ["PATCH /orgs/{org}/teams/{team_slug}"]
+  },
+  users: {
+    addEmailForAuthenticated: ["POST /user/emails"],
+    block: ["PUT /user/blocks/{username}"],
+    checkBlocked: ["GET /user/blocks/{username}"],
+    checkFollowingForUser: ["GET /users/{username}/following/{target_user}"],
+    checkPersonIsFollowedByAuthenticated: ["GET /user/following/{username}"],
+    createGpgKeyForAuthenticated: ["POST /user/gpg_keys"],
+    createPublicSshKeyForAuthenticated: ["POST /user/keys"],
+    deleteEmailForAuthenticated: ["DELETE /user/emails"],
+    deleteGpgKeyForAuthenticated: ["DELETE /user/gpg_keys/{gpg_key_id}"],
+    deletePublicSshKeyForAuthenticated: ["DELETE /user/keys/{key_id}"],
+    follow: ["PUT /user/following/{username}"],
+    getAuthenticated: ["GET /user"],
+    getByUsername: ["GET /users/{username}"],
+    getContextForUser: ["GET /users/{username}/hovercard"],
+    getGpgKeyForAuthenticated: ["GET /user/gpg_keys/{gpg_key_id}"],
+    getPublicSshKeyForAuthenticated: ["GET /user/keys/{key_id}"],
+    list: ["GET /users"],
+    listBlockedByAuthenticated: ["GET /user/blocks"],
+    listEmailsForAuthenticated: ["GET /user/emails"],
+    listFollowedByAuthenticated: ["GET /user/following"],
+    listFollowersForAuthenticatedUser: ["GET /user/followers"],
+    listFollowersForUser: ["GET /users/{username}/followers"],
+    listFollowingForUser: ["GET /users/{username}/following"],
+    listGpgKeysForAuthenticated: ["GET /user/gpg_keys"],
+    listGpgKeysForUser: ["GET /users/{username}/gpg_keys"],
+    listPublicEmailsForAuthenticated: ["GET /user/public_emails"],
+    listPublicKeysForUser: ["GET /users/{username}/keys"],
+    listPublicSshKeysForAuthenticated: ["GET /user/keys"],
+    setPrimaryEmailVisibilityForAuthenticated: ["PATCH /user/email/visibility"],
+    unblock: ["DELETE /user/blocks/{username}"],
+    unfollow: ["DELETE /user/following/{username}"],
+    updateAuthenticated: ["PATCH /user"]
+  }
+};
+
+const VERSION = "4.4.1";
+
+function endpointsToMethods(octokit, endpointsMap) {
+  const newMethods = {};
+
+  for (const [scope, endpoints] of Object.entries(endpointsMap)) {
+    for (const [methodName, endpoint] of Object.entries(endpoints)) {
+      const [route, defaults, decorations] = endpoint;
+      const [method, url] = route.split(/ /);
+      const endpointDefaults = Object.assign({
+        method,
+        url
+      }, defaults);
+
+      if (!newMethods[scope]) {
+        newMethods[scope] = {};
+      }
+
+      const scopeMethods = newMethods[scope];
+
+      if (decorations) {
+        scopeMethods[methodName] = decorate(octokit, scope, methodName, endpointDefaults, decorations);
+        continue;
+      }
+
+      scopeMethods[methodName] = octokit.request.defaults(endpointDefaults);
     }
   }
 
-  if (typeof state.auth.on2fa !== "function") {
-    throw new RequestError$1(
-      "2FA required, but options.on2fa is not a function. See https://github.com/octokit/rest.js#authentication",
-      401,
-      {
-        headers: error.headers,
-        request: options
+  return newMethods;
+}
+
+function decorate(octokit, scope, methodName, defaults, decorations) {
+  const requestWithDefaults = octokit.request.defaults(defaults);
+  /* istanbul ignore next */
+
+  function withDecorations(...args) {
+    // @ts-ignore https://github.com/microsoft/TypeScript/issues/25488
+    let options = requestWithDefaults.endpoint.merge(...args); // There are currently no other decorations than `.mapToData`
+
+    if (decorations.mapToData) {
+      options = Object.assign({}, options, {
+        data: options[decorations.mapToData],
+        [decorations.mapToData]: undefined
+      });
+      return requestWithDefaults(options);
+    }
+
+    if (decorations.renamed) {
+      const [newScope, newMethodName] = decorations.renamed;
+      octokit.log.warn(`octokit.${scope}.${methodName}() has been renamed to octokit.${newScope}.${newMethodName}()`);
+    }
+
+    if (decorations.deprecated) {
+      octokit.log.warn(decorations.deprecated);
+    }
+
+    if (decorations.renamedParameters) {
+      // @ts-ignore https://github.com/microsoft/TypeScript/issues/25488
+      const options = requestWithDefaults.endpoint.merge(...args);
+
+      for (const [name, alias] of Object.entries(decorations.renamedParameters)) {
+        if (name in options) {
+          octokit.log.warn(`"${name}" parameter is deprecated for "octokit.${scope}.${methodName}()". Use "${alias}" instead`);
+
+          if (!(alias in options)) {
+            options[alias] = options[name];
+          }
+
+          delete options[name];
+        }
       }
-    );
+
+      return requestWithDefaults(options);
+    } // @ts-ignore https://github.com/microsoft/TypeScript/issues/25488
+
+
+    return requestWithDefaults(...args);
   }
 
-  return Promise.resolve()
-    .then(() => {
-      return state.auth.on2fa();
-    })
-    .then(oneTimePassword => {
-      const newOptions = Object.assign(options, {
-        headers: Object.assign(options.headers, {
-          "x-github-otp": oneTimePassword
-        })
-      });
-      return state.octokit.request(newOptions).then(response => {
-        // If OTP still valid, then persist it for following requests
-        state.otp = oneTimePassword;
-        return response;
-      });
-    });
+  return Object.assign(withDecorations, requestWithDefaults);
 }
 
-var validate = validateAuth;
+/**
+ * This plugin is a 1:1 copy of internal @octokit/rest plugins. The primary
+ * goal is to rebuild @octokit/rest on top of @octokit/core. Once that is
+ * done, we will remove the registerEndpoints methods and return the methods
+ * directly as with the other plugins. At that point we will also remove the
+ * legacy workarounds and deprecations.
+ *
+ * See the plan at
+ * https://github.com/octokit/plugin-rest-endpoint-methods.js/pull/1
+ */
 
-function validateAuth(auth) {
-  if (typeof auth === "string") {
-    return;
-  }
-
-  if (typeof auth === "function") {
-    return;
-  }
-
-  if (auth.username && auth.password) {
-    return;
-  }
-
-  if (auth.clientId && auth.clientSecret) {
-    return;
-  }
-
-  throw new Error(`Invalid "auth" option: ${JSON.stringify(auth)}`);
+function restEndpointMethods(octokit) {
+  return endpointsToMethods(octokit, Endpoints);
 }
+restEndpointMethods.VERSION = VERSION;
 
-var authentication = authenticationPlugin$1;
+exports.restEndpointMethods = restEndpointMethods;
 
+});
 
+unwrapExports(distNode$8);
+var distNode_1$8 = distNode$8.restEndpointMethods;
 
+var distNode$9 = createCommonjsModule(function (module, exports) {
 
+Object.defineProperty(exports, '__esModule', { value: true });
 
-function authenticationPlugin$1(octokit, options) {
-  if (!options.auth) {
-    return;
-  }
-
-  validate(options.auth);
-
-  const state = {
-    octokit,
-    auth: options.auth
-  };
-
-  octokit.hook.before("request", beforeRequest$1.bind(null, state));
-  octokit.hook.error("request", requestError$1.bind(null, state));
-}
+const VERSION = "2.6.2";
 
 /**
  * Some “list” response that can be paginated have a different response structure
  *
  * They have a `total_count` key in the response (search also has `incomplete_results`,
  * /installation/repositories also has `repository_selection`), as well as a key with
- * the list of the items which name varies from endpoint to endpoint:
- *
- * - https://developer.github.com/v3/search/#example (key `items`)
- * - https://developer.github.com/v3/checks/runs/#response-3 (key: `check_runs`)
- * - https://developer.github.com/v3/checks/suites/#response-1 (key: `check_suites`)
- * - https://developer.github.com/v3/apps/installations/#list-repositories (key: `repositories`)
- * - https://developer.github.com/v3/apps/installations/#list-installations-for-a-user (key `installations`)
- * - https://developer.github.com/v3/orgs/#list-installations-for-an-organization (key `installations`)
+ * the list of the items which name varies from endpoint to endpoint.
  *
  * Octokit normalizes these responses so that paginated results are always returned following
  * the same structure. One challenge is that if the list response has only one page, no Link
  * header is provided, so this header alone is not sufficient to check wether a response is
- * paginated or not. For the exceptions with the namespace, a fallback check for the route
- * paths has to be added in order to normalize the response. We cannot check for the total_count
- * property because it also exists in the response of Get the combined status for a specific ref.
+ * paginated or not.
+ *
+ * We check if a "total_count" key is present in the response data, but also make sure that
+ * a "url" property is not, as the "Get the combined status for a specific ref" endpoint would
+ * otherwise match: https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref
  */
+function normalizePaginatedListResponse(response) {
+  const responseNeedsNormalization = "total_count" in response.data && !("url" in response.data);
+  if (!responseNeedsNormalization) return response; // keep the additional properties intact as there is currently no other way
+  // to retrieve the same information.
 
-var normalizePaginatedListResponse_1 = normalizePaginatedListResponse;
-
-const { Deprecation: Deprecation$3 } = distNode$2;
-
-
-const deprecateIncompleteResults = once_1((log, deprecation) =>
-  log.warn(deprecation)
-);
-const deprecateTotalCount = once_1((log, deprecation) => log.warn(deprecation));
-const deprecateNamespace = once_1((log, deprecation) => log.warn(deprecation));
-
-const REGEX_IS_SEARCH_PATH = /^\/search\//;
-const REGEX_IS_CHECKS_PATH = /^\/repos\/[^/]+\/[^/]+\/commits\/[^/]+\/(check-runs|check-suites)/;
-const REGEX_IS_INSTALLATION_REPOSITORIES_PATH = /^\/installation\/repositories/;
-const REGEX_IS_USER_INSTALLATIONS_PATH = /^\/user\/installations/;
-const REGEX_IS_ORG_INSTALLATIONS_PATH = /^\/orgs\/[^/]+\/installations/;
-
-function normalizePaginatedListResponse(octokit, url, response) {
-  const path = url.replace(octokit.request.endpoint.DEFAULTS.baseUrl, "");
-  if (
-    !REGEX_IS_SEARCH_PATH.test(path) &&
-    !REGEX_IS_CHECKS_PATH.test(path) &&
-    !REGEX_IS_INSTALLATION_REPOSITORIES_PATH.test(path) &&
-    !REGEX_IS_USER_INSTALLATIONS_PATH.test(path) &&
-    !REGEX_IS_ORG_INSTALLATIONS_PATH.test(path)
-  ) {
-    return;
-  }
-
-  // keep the additional properties intact to avoid a breaking change,
-  // but log a deprecation warning when accessed
   const incompleteResults = response.data.incomplete_results;
   const repositorySelection = response.data.repository_selection;
   const totalCount = response.data.total_count;
   delete response.data.incomplete_results;
   delete response.data.repository_selection;
   delete response.data.total_count;
-
   const namespaceKey = Object.keys(response.data)[0];
-
-  response.data = response.data[namespaceKey];
-
-  Object.defineProperty(response.data, namespaceKey, {
-    get() {
-      deprecateNamespace(
-        octokit.log,
-        new Deprecation$3(
-          `[@octokit/rest] "result.data.${namespaceKey}" is deprecated. Use "result.data" instead`
-        )
-      );
-      return response.data;
-    }
-  });
+  const data = response.data[namespaceKey];
+  response.data = data;
 
   if (typeof incompleteResults !== "undefined") {
-    Object.defineProperty(response.data, "incomplete_results", {
-      get() {
-        deprecateIncompleteResults(
-          octokit.log,
-          new Deprecation$3(
-            '[@octokit/rest] "result.data.incomplete_results" is deprecated.'
-          )
-        );
-        return incompleteResults;
-      }
-    });
+    response.data.incomplete_results = incompleteResults;
   }
 
   if (typeof repositorySelection !== "undefined") {
-    Object.defineProperty(response.data, "repository_selection", {
-      get() {
-        deprecateTotalCount(
-          octokit.log,
-          new Deprecation$3(
-            '[@octokit/rest] "result.data.repository_selection" is deprecated.'
-          )
-        );
-        return repositorySelection;
-      }
-    });
+    response.data.repository_selection = repositorySelection;
   }
 
-  Object.defineProperty(response.data, "total_count", {
-    get() {
-      deprecateTotalCount(
-        octokit.log,
-        new Deprecation$3(
-          '[@octokit/rest] "result.data.total_count" is deprecated.'
-        )
-      );
-      return totalCount;
-    }
-  });
+  response.data.total_count = totalCount;
+  return response;
 }
 
-var iterator_1 = iterator;
-
-
-
-function iterator(octokit, options) {
+function iterator(octokit, route, parameters) {
+  const options = typeof route === "function" ? route.endpoint(parameters) : octokit.request.endpoint(route, parameters);
+  const requestMethod = typeof route === "function" ? route : octokit.request;
+  const method = options.method;
   const headers = options.headers;
-  let url = octokit.request.endpoint(options).url;
-
+  let url = options.url;
   return {
     [Symbol.asyncIterator]: () => ({
-      next() {
-        if (!url) {
-          return Promise.resolve({ done: true });
-        }
+      async next() {
+        if (!url) return {
+          done: true
+        };
+        const response = await requestMethod({
+          method,
+          url,
+          headers
+        });
+        const normalizedResponse = normalizePaginatedListResponse(response); // `response.headers.link` format:
+        // '<https://api.github.com/users/aseemk/followers?page=2>; rel="next", <https://api.github.com/users/aseemk/followers?page=2>; rel="last"'
+        // sets `url` to undefined if "next" URL is not present or `link` header is not set
 
-        return octokit
-          .request({ url, headers })
-
-          .then(response => {
-            normalizePaginatedListResponse_1(octokit, url, response);
-
-            // `response.headers.link` format:
-            // '<https://api.github.com/users/aseemk/followers?page=2>; rel="next", <https://api.github.com/users/aseemk/followers?page=2>; rel="last"'
-            // sets `url` to undefined if "next" URL is not present or `link` header is not set
-            url = ((response.headers.link || "").match(
-              /<([^>]+)>;\s*rel="next"/
-            ) || [])[1];
-
-            return { value: response };
-          });
+        url = ((normalizedResponse.headers.link || "").match(/<([^>]+)>;\s*rel="next"/) || [])[1];
+        return {
+          value: normalizedResponse
+        };
       }
+
     })
   };
 }
 
-var paginate_1 = paginate;
-
-
-
-function paginate(octokit, route, options, mapFn) {
-  if (typeof options === "function") {
-    mapFn = options;
-    options = undefined;
+function paginate(octokit, route, parameters, mapFn) {
+  if (typeof parameters === "function") {
+    mapFn = parameters;
+    parameters = undefined;
   }
-  options = octokit.request.endpoint.merge(route, options);
-  return gather(
-    octokit,
-    [],
-    iterator_1(octokit, options)[Symbol.asyncIterator](),
-    mapFn
-  );
+
+  return gather(octokit, [], iterator(octokit, route, parameters)[Symbol.asyncIterator](), mapFn);
 }
 
 function gather(octokit, results, iterator, mapFn) {
@@ -8300,13 +5489,12 @@ function gather(octokit, results, iterator, mapFn) {
     }
 
     let earlyExit = false;
+
     function done() {
       earlyExit = true;
     }
 
-    results = results.concat(
-      mapFn ? mapFn(result.value, done) : result.value.data
-    );
+    results = results.concat(mapFn ? mapFn(result.value, done) : result.value.data);
 
     if (earlyExit) {
       return results;
@@ -8316,14297 +5504,135 @@ function gather(octokit, results, iterator, mapFn) {
   });
 }
 
-var pagination = paginatePlugin;
-
-
-
-
-function paginatePlugin(octokit) {
-  octokit.paginate = paginate_1.bind(null, octokit);
-  octokit.paginate.iterator = iterator_1.bind(null, octokit);
-}
-
-var registerEndpoints_1 = registerEndpoints;
-
-const { Deprecation: Deprecation$4 } = distNode$2;
-
-function registerEndpoints(octokit, routes) {
-  Object.keys(routes).forEach(namespaceName => {
-    if (!octokit[namespaceName]) {
-      octokit[namespaceName] = {};
-    }
-
-    Object.keys(routes[namespaceName]).forEach(apiName => {
-      const apiOptions = routes[namespaceName][apiName];
-
-      const endpointDefaults = ["method", "url", "headers"].reduce(
-        (map, key) => {
-          if (typeof apiOptions[key] !== "undefined") {
-            map[key] = apiOptions[key];
-          }
-
-          return map;
-        },
-        {}
-      );
-
-      endpointDefaults.request = {
-        validate: apiOptions.params
-      };
-
-      let request = octokit.request.defaults(endpointDefaults);
-
-      // patch request & endpoint methods to support deprecated parameters.
-      // Not the most elegant solution, but we don’t want to move deprecation
-      // logic into octokit/endpoint.js as it’s out of scope
-      const hasDeprecatedParam = Object.keys(apiOptions.params || {}).find(
-        key => apiOptions.params[key].deprecated
-      );
-      if (hasDeprecatedParam) {
-        const patch = patchForDeprecation.bind(null, octokit, apiOptions);
-        request = patch(
-          octokit.request.defaults(endpointDefaults),
-          `.${namespaceName}.${apiName}()`
-        );
-        request.endpoint = patch(
-          request.endpoint,
-          `.${namespaceName}.${apiName}.endpoint()`
-        );
-        request.endpoint.merge = patch(
-          request.endpoint.merge,
-          `.${namespaceName}.${apiName}.endpoint.merge()`
-        );
-      }
-
-      if (apiOptions.deprecated) {
-        octokit[namespaceName][apiName] = function deprecatedEndpointMethod() {
-          octokit.log.warn(
-            new Deprecation$4(`[@octokit/rest] ${apiOptions.deprecated}`)
-          );
-          octokit[namespaceName][apiName] = request;
-          return request.apply(null, arguments);
-        };
-
-        return;
-      }
-
-      octokit[namespaceName][apiName] = request;
-    });
-  });
-}
-
-function patchForDeprecation(octokit, apiOptions, method, methodName) {
-  const patchedMethod = options => {
-    options = Object.assign({}, options);
-
-    Object.keys(options).forEach(key => {
-      if (apiOptions.params[key] && apiOptions.params[key].deprecated) {
-        const aliasKey = apiOptions.params[key].alias;
-
-        octokit.log.warn(
-          new Deprecation$4(
-            `[@octokit/rest] "${key}" parameter is deprecated for "${methodName}". Use "${aliasKey}" instead`
-          )
-        );
-
-        if (!(aliasKey in options)) {
-          options[aliasKey] = options[key];
-        }
-        delete options[key];
-      }
-    });
-
-    return method(options);
-  };
-  Object.keys(method).forEach(key => {
-    patchedMethod[key] = method[key];
-  });
-
-  return patchedMethod;
-}
-
-var registerEndpoints_1$1 = octokitRegisterEndpoints;
-
-
-
-function octokitRegisterEndpoints(octokit) {
-  octokit.registerEndpoints = registerEndpoints_1.bind(null, octokit);
-}
-
-var activity = {
-	checkStarringRepo: {
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/user/starred/:owner/:repo"
-	},
-	deleteRepoSubscription: {
-		method: "DELETE",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/subscription"
-	},
-	deleteThreadSubscription: {
-		method: "DELETE",
-		params: {
-			thread_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/notifications/threads/:thread_id/subscription"
-	},
-	getRepoSubscription: {
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/subscription"
-	},
-	getThread: {
-		method: "GET",
-		params: {
-			thread_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/notifications/threads/:thread_id"
-	},
-	getThreadSubscription: {
-		method: "GET",
-		params: {
-			thread_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/notifications/threads/:thread_id/subscription"
-	},
-	listEventsForOrg: {
-		method: "GET",
-		params: {
-			org: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			username: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/users/:username/events/orgs/:org"
-	},
-	listEventsForUser: {
-		method: "GET",
-		params: {
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			username: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/users/:username/events"
-	},
-	listFeeds: {
-		method: "GET",
-		params: {
-		},
-		url: "/feeds"
-	},
-	listNotifications: {
-		method: "GET",
-		params: {
-			all: {
-				type: "boolean"
-			},
-			before: {
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			participating: {
-				type: "boolean"
-			},
-			per_page: {
-				type: "integer"
-			},
-			since: {
-				type: "string"
-			}
-		},
-		url: "/notifications"
-	},
-	listNotificationsForRepo: {
-		method: "GET",
-		params: {
-			all: {
-				type: "boolean"
-			},
-			before: {
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			participating: {
-				type: "boolean"
-			},
-			per_page: {
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			since: {
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/notifications"
-	},
-	listPublicEvents: {
-		method: "GET",
-		params: {
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			}
-		},
-		url: "/events"
-	},
-	listPublicEventsForOrg: {
-		method: "GET",
-		params: {
-			org: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			}
-		},
-		url: "/orgs/:org/events"
-	},
-	listPublicEventsForRepoNetwork: {
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/networks/:owner/:repo/events"
-	},
-	listPublicEventsForUser: {
-		method: "GET",
-		params: {
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			username: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/users/:username/events/public"
-	},
-	listReceivedEventsForUser: {
-		method: "GET",
-		params: {
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			username: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/users/:username/received_events"
-	},
-	listReceivedPublicEventsForUser: {
-		method: "GET",
-		params: {
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			username: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/users/:username/received_events/public"
-	},
-	listRepoEvents: {
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/events"
-	},
-	listReposStarredByAuthenticatedUser: {
-		method: "GET",
-		params: {
-			direction: {
-				"enum": [
-					"asc",
-					"desc"
-				],
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			sort: {
-				"enum": [
-					"created",
-					"updated"
-				],
-				type: "string"
-			}
-		},
-		url: "/user/starred"
-	},
-	listReposStarredByUser: {
-		method: "GET",
-		params: {
-			direction: {
-				"enum": [
-					"asc",
-					"desc"
-				],
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			sort: {
-				"enum": [
-					"created",
-					"updated"
-				],
-				type: "string"
-			},
-			username: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/users/:username/starred"
-	},
-	listReposWatchedByUser: {
-		method: "GET",
-		params: {
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			username: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/users/:username/subscriptions"
-	},
-	listStargazersForRepo: {
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/stargazers"
-	},
-	listWatchedReposForAuthenticatedUser: {
-		method: "GET",
-		params: {
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			}
-		},
-		url: "/user/subscriptions"
-	},
-	listWatchersForRepo: {
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/subscribers"
-	},
-	markAsRead: {
-		method: "PUT",
-		params: {
-			last_read_at: {
-				type: "string"
-			}
-		},
-		url: "/notifications"
-	},
-	markNotificationsAsReadForRepo: {
-		method: "PUT",
-		params: {
-			last_read_at: {
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/notifications"
-	},
-	markThreadAsRead: {
-		method: "PATCH",
-		params: {
-			thread_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/notifications/threads/:thread_id"
-	},
-	setRepoSubscription: {
-		method: "PUT",
-		params: {
-			ignored: {
-				type: "boolean"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			subscribed: {
-				type: "boolean"
-			}
-		},
-		url: "/repos/:owner/:repo/subscription"
-	},
-	setThreadSubscription: {
-		method: "PUT",
-		params: {
-			ignored: {
-				type: "boolean"
-			},
-			thread_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/notifications/threads/:thread_id/subscription"
-	},
-	starRepo: {
-		method: "PUT",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/user/starred/:owner/:repo"
-	},
-	unstarRepo: {
-		method: "DELETE",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/user/starred/:owner/:repo"
-	}
-};
-var apps = {
-	addRepoToInstallation: {
-		headers: {
-			accept: "application/vnd.github.machine-man-preview+json"
-		},
-		method: "PUT",
-		params: {
-			installation_id: {
-				required: true,
-				type: "integer"
-			},
-			repository_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/user/installations/:installation_id/repositories/:repository_id"
-	},
-	checkAccountIsAssociatedWithAny: {
-		method: "GET",
-		params: {
-			account_id: {
-				required: true,
-				type: "integer"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			}
-		},
-		url: "/marketplace_listing/accounts/:account_id"
-	},
-	checkAccountIsAssociatedWithAnyStubbed: {
-		method: "GET",
-		params: {
-			account_id: {
-				required: true,
-				type: "integer"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			}
-		},
-		url: "/marketplace_listing/stubbed/accounts/:account_id"
-	},
-	checkAuthorization: {
-		deprecated: "octokit.oauthAuthorizations.checkAuthorization() has been renamed to octokit.apps.checkAuthorization() (2019-11-05)",
-		method: "GET",
-		params: {
-			access_token: {
-				required: true,
-				type: "string"
-			},
-			client_id: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/applications/:client_id/tokens/:access_token"
-	},
-	checkToken: {
-		headers: {
-			accept: "application/vnd.github.doctor-strange-preview+json"
-		},
-		method: "POST",
-		params: {
-			access_token: {
-				type: "string"
-			},
-			client_id: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/applications/:client_id/token"
-	},
-	createContentAttachment: {
-		headers: {
-			accept: "application/vnd.github.corsair-preview+json"
-		},
-		method: "POST",
-		params: {
-			body: {
-				required: true,
-				type: "string"
-			},
-			content_reference_id: {
-				required: true,
-				type: "integer"
-			},
-			title: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/content_references/:content_reference_id/attachments"
-	},
-	createFromManifest: {
-		headers: {
-			accept: "application/vnd.github.fury-preview+json"
-		},
-		method: "POST",
-		params: {
-			code: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/app-manifests/:code/conversions"
-	},
-	createInstallationToken: {
-		headers: {
-			accept: "application/vnd.github.machine-man-preview+json"
-		},
-		method: "POST",
-		params: {
-			installation_id: {
-				required: true,
-				type: "integer"
-			},
-			permissions: {
-				type: "object"
-			},
-			repository_ids: {
-				type: "integer[]"
-			}
-		},
-		url: "/app/installations/:installation_id/access_tokens"
-	},
-	deleteAuthorization: {
-		headers: {
-			accept: "application/vnd.github.doctor-strange-preview+json"
-		},
-		method: "DELETE",
-		params: {
-			access_token: {
-				type: "string"
-			},
-			client_id: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/applications/:client_id/grant"
-	},
-	deleteInstallation: {
-		headers: {
-			accept: "application/vnd.github.gambit-preview+json,application/vnd.github.machine-man-preview+json"
-		},
-		method: "DELETE",
-		params: {
-			installation_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/app/installations/:installation_id"
-	},
-	deleteToken: {
-		headers: {
-			accept: "application/vnd.github.doctor-strange-preview+json"
-		},
-		method: "DELETE",
-		params: {
-			access_token: {
-				type: "string"
-			},
-			client_id: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/applications/:client_id/token"
-	},
-	findOrgInstallation: {
-		deprecated: "octokit.apps.findOrgInstallation() has been renamed to octokit.apps.getOrgInstallation() (2019-04-10)",
-		headers: {
-			accept: "application/vnd.github.machine-man-preview+json"
-		},
-		method: "GET",
-		params: {
-			org: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/orgs/:org/installation"
-	},
-	findRepoInstallation: {
-		deprecated: "octokit.apps.findRepoInstallation() has been renamed to octokit.apps.getRepoInstallation() (2019-04-10)",
-		headers: {
-			accept: "application/vnd.github.machine-man-preview+json"
-		},
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/installation"
-	},
-	findUserInstallation: {
-		deprecated: "octokit.apps.findUserInstallation() has been renamed to octokit.apps.getUserInstallation() (2019-04-10)",
-		headers: {
-			accept: "application/vnd.github.machine-man-preview+json"
-		},
-		method: "GET",
-		params: {
-			username: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/users/:username/installation"
-	},
-	getAuthenticated: {
-		headers: {
-			accept: "application/vnd.github.machine-man-preview+json"
-		},
-		method: "GET",
-		params: {
-		},
-		url: "/app"
-	},
-	getBySlug: {
-		headers: {
-			accept: "application/vnd.github.machine-man-preview+json"
-		},
-		method: "GET",
-		params: {
-			app_slug: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/apps/:app_slug"
-	},
-	getInstallation: {
-		headers: {
-			accept: "application/vnd.github.machine-man-preview+json"
-		},
-		method: "GET",
-		params: {
-			installation_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/app/installations/:installation_id"
-	},
-	getOrgInstallation: {
-		headers: {
-			accept: "application/vnd.github.machine-man-preview+json"
-		},
-		method: "GET",
-		params: {
-			org: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/orgs/:org/installation"
-	},
-	getRepoInstallation: {
-		headers: {
-			accept: "application/vnd.github.machine-man-preview+json"
-		},
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/installation"
-	},
-	getUserInstallation: {
-		headers: {
-			accept: "application/vnd.github.machine-man-preview+json"
-		},
-		method: "GET",
-		params: {
-			username: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/users/:username/installation"
-	},
-	listAccountsUserOrOrgOnPlan: {
-		method: "GET",
-		params: {
-			direction: {
-				"enum": [
-					"asc",
-					"desc"
-				],
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			plan_id: {
-				required: true,
-				type: "integer"
-			},
-			sort: {
-				"enum": [
-					"created",
-					"updated"
-				],
-				type: "string"
-			}
-		},
-		url: "/marketplace_listing/plans/:plan_id/accounts"
-	},
-	listAccountsUserOrOrgOnPlanStubbed: {
-		method: "GET",
-		params: {
-			direction: {
-				"enum": [
-					"asc",
-					"desc"
-				],
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			plan_id: {
-				required: true,
-				type: "integer"
-			},
-			sort: {
-				"enum": [
-					"created",
-					"updated"
-				],
-				type: "string"
-			}
-		},
-		url: "/marketplace_listing/stubbed/plans/:plan_id/accounts"
-	},
-	listInstallationReposForAuthenticatedUser: {
-		headers: {
-			accept: "application/vnd.github.machine-man-preview+json"
-		},
-		method: "GET",
-		params: {
-			installation_id: {
-				required: true,
-				type: "integer"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			}
-		},
-		url: "/user/installations/:installation_id/repositories"
-	},
-	listInstallations: {
-		headers: {
-			accept: "application/vnd.github.machine-man-preview+json"
-		},
-		method: "GET",
-		params: {
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			}
-		},
-		url: "/app/installations"
-	},
-	listInstallationsForAuthenticatedUser: {
-		headers: {
-			accept: "application/vnd.github.machine-man-preview+json"
-		},
-		method: "GET",
-		params: {
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			}
-		},
-		url: "/user/installations"
-	},
-	listMarketplacePurchasesForAuthenticatedUser: {
-		method: "GET",
-		params: {
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			}
-		},
-		url: "/user/marketplace_purchases"
-	},
-	listMarketplacePurchasesForAuthenticatedUserStubbed: {
-		method: "GET",
-		params: {
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			}
-		},
-		url: "/user/marketplace_purchases/stubbed"
-	},
-	listPlans: {
-		method: "GET",
-		params: {
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			}
-		},
-		url: "/marketplace_listing/plans"
-	},
-	listPlansStubbed: {
-		method: "GET",
-		params: {
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			}
-		},
-		url: "/marketplace_listing/stubbed/plans"
-	},
-	listRepos: {
-		headers: {
-			accept: "application/vnd.github.machine-man-preview+json"
-		},
-		method: "GET",
-		params: {
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			}
-		},
-		url: "/installation/repositories"
-	},
-	removeRepoFromInstallation: {
-		headers: {
-			accept: "application/vnd.github.machine-man-preview+json"
-		},
-		method: "DELETE",
-		params: {
-			installation_id: {
-				required: true,
-				type: "integer"
-			},
-			repository_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/user/installations/:installation_id/repositories/:repository_id"
-	},
-	resetAuthorization: {
-		deprecated: "octokit.oauthAuthorizations.resetAuthorization() has been renamed to octokit.apps.resetAuthorization() (2019-11-05)",
-		method: "POST",
-		params: {
-			access_token: {
-				required: true,
-				type: "string"
-			},
-			client_id: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/applications/:client_id/tokens/:access_token"
-	},
-	resetToken: {
-		headers: {
-			accept: "application/vnd.github.doctor-strange-preview+json"
-		},
-		method: "PATCH",
-		params: {
-			access_token: {
-				type: "string"
-			},
-			client_id: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/applications/:client_id/token"
-	},
-	revokeAuthorizationForApplication: {
-		deprecated: "octokit.oauthAuthorizations.revokeAuthorizationForApplication() has been renamed to octokit.apps.revokeAuthorizationForApplication() (2019-11-05)",
-		method: "DELETE",
-		params: {
-			access_token: {
-				required: true,
-				type: "string"
-			},
-			client_id: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/applications/:client_id/tokens/:access_token"
-	},
-	revokeGrantForApplication: {
-		deprecated: "octokit.oauthAuthorizations.revokeGrantForApplication() has been renamed to octokit.apps.revokeGrantForApplication() (2019-11-05)",
-		method: "DELETE",
-		params: {
-			access_token: {
-				required: true,
-				type: "string"
-			},
-			client_id: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/applications/:client_id/grants/:access_token"
-	}
-};
-var checks = {
-	create: {
-		headers: {
-			accept: "application/vnd.github.antiope-preview+json"
-		},
-		method: "POST",
-		params: {
-			actions: {
-				type: "object[]"
-			},
-			"actions[].description": {
-				required: true,
-				type: "string"
-			},
-			"actions[].identifier": {
-				required: true,
-				type: "string"
-			},
-			"actions[].label": {
-				required: true,
-				type: "string"
-			},
-			completed_at: {
-				type: "string"
-			},
-			conclusion: {
-				"enum": [
-					"success",
-					"failure",
-					"neutral",
-					"cancelled",
-					"timed_out",
-					"action_required"
-				],
-				type: "string"
-			},
-			details_url: {
-				type: "string"
-			},
-			external_id: {
-				type: "string"
-			},
-			head_sha: {
-				required: true,
-				type: "string"
-			},
-			name: {
-				required: true,
-				type: "string"
-			},
-			output: {
-				type: "object"
-			},
-			"output.annotations": {
-				type: "object[]"
-			},
-			"output.annotations[].annotation_level": {
-				"enum": [
-					"notice",
-					"warning",
-					"failure"
-				],
-				required: true,
-				type: "string"
-			},
-			"output.annotations[].end_column": {
-				type: "integer"
-			},
-			"output.annotations[].end_line": {
-				required: true,
-				type: "integer"
-			},
-			"output.annotations[].message": {
-				required: true,
-				type: "string"
-			},
-			"output.annotations[].path": {
-				required: true,
-				type: "string"
-			},
-			"output.annotations[].raw_details": {
-				type: "string"
-			},
-			"output.annotations[].start_column": {
-				type: "integer"
-			},
-			"output.annotations[].start_line": {
-				required: true,
-				type: "integer"
-			},
-			"output.annotations[].title": {
-				type: "string"
-			},
-			"output.images": {
-				type: "object[]"
-			},
-			"output.images[].alt": {
-				required: true,
-				type: "string"
-			},
-			"output.images[].caption": {
-				type: "string"
-			},
-			"output.images[].image_url": {
-				required: true,
-				type: "string"
-			},
-			"output.summary": {
-				required: true,
-				type: "string"
-			},
-			"output.text": {
-				type: "string"
-			},
-			"output.title": {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			started_at: {
-				type: "string"
-			},
-			status: {
-				"enum": [
-					"queued",
-					"in_progress",
-					"completed"
-				],
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/check-runs"
-	},
-	createSuite: {
-		headers: {
-			accept: "application/vnd.github.antiope-preview+json"
-		},
-		method: "POST",
-		params: {
-			head_sha: {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/check-suites"
-	},
-	get: {
-		headers: {
-			accept: "application/vnd.github.antiope-preview+json"
-		},
-		method: "GET",
-		params: {
-			check_run_id: {
-				required: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/check-runs/:check_run_id"
-	},
-	getSuite: {
-		headers: {
-			accept: "application/vnd.github.antiope-preview+json"
-		},
-		method: "GET",
-		params: {
-			check_suite_id: {
-				required: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/check-suites/:check_suite_id"
-	},
-	listAnnotations: {
-		headers: {
-			accept: "application/vnd.github.antiope-preview+json"
-		},
-		method: "GET",
-		params: {
-			check_run_id: {
-				required: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/check-runs/:check_run_id/annotations"
-	},
-	listForRef: {
-		headers: {
-			accept: "application/vnd.github.antiope-preview+json"
-		},
-		method: "GET",
-		params: {
-			check_name: {
-				type: "string"
-			},
-			filter: {
-				"enum": [
-					"latest",
-					"all"
-				],
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			ref: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			status: {
-				"enum": [
-					"queued",
-					"in_progress",
-					"completed"
-				],
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/commits/:ref/check-runs"
-	},
-	listForSuite: {
-		headers: {
-			accept: "application/vnd.github.antiope-preview+json"
-		},
-		method: "GET",
-		params: {
-			check_name: {
-				type: "string"
-			},
-			check_suite_id: {
-				required: true,
-				type: "integer"
-			},
-			filter: {
-				"enum": [
-					"latest",
-					"all"
-				],
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			status: {
-				"enum": [
-					"queued",
-					"in_progress",
-					"completed"
-				],
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/check-suites/:check_suite_id/check-runs"
-	},
-	listSuitesForRef: {
-		headers: {
-			accept: "application/vnd.github.antiope-preview+json"
-		},
-		method: "GET",
-		params: {
-			app_id: {
-				type: "integer"
-			},
-			check_name: {
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			ref: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/commits/:ref/check-suites"
-	},
-	rerequestSuite: {
-		headers: {
-			accept: "application/vnd.github.antiope-preview+json"
-		},
-		method: "POST",
-		params: {
-			check_suite_id: {
-				required: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/check-suites/:check_suite_id/rerequest"
-	},
-	setSuitesPreferences: {
-		headers: {
-			accept: "application/vnd.github.antiope-preview+json"
-		},
-		method: "PATCH",
-		params: {
-			auto_trigger_checks: {
-				type: "object[]"
-			},
-			"auto_trigger_checks[].app_id": {
-				required: true,
-				type: "integer"
-			},
-			"auto_trigger_checks[].setting": {
-				required: true,
-				type: "boolean"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/check-suites/preferences"
-	},
-	update: {
-		headers: {
-			accept: "application/vnd.github.antiope-preview+json"
-		},
-		method: "PATCH",
-		params: {
-			actions: {
-				type: "object[]"
-			},
-			"actions[].description": {
-				required: true,
-				type: "string"
-			},
-			"actions[].identifier": {
-				required: true,
-				type: "string"
-			},
-			"actions[].label": {
-				required: true,
-				type: "string"
-			},
-			check_run_id: {
-				required: true,
-				type: "integer"
-			},
-			completed_at: {
-				type: "string"
-			},
-			conclusion: {
-				"enum": [
-					"success",
-					"failure",
-					"neutral",
-					"cancelled",
-					"timed_out",
-					"action_required"
-				],
-				type: "string"
-			},
-			details_url: {
-				type: "string"
-			},
-			external_id: {
-				type: "string"
-			},
-			name: {
-				type: "string"
-			},
-			output: {
-				type: "object"
-			},
-			"output.annotations": {
-				type: "object[]"
-			},
-			"output.annotations[].annotation_level": {
-				"enum": [
-					"notice",
-					"warning",
-					"failure"
-				],
-				required: true,
-				type: "string"
-			},
-			"output.annotations[].end_column": {
-				type: "integer"
-			},
-			"output.annotations[].end_line": {
-				required: true,
-				type: "integer"
-			},
-			"output.annotations[].message": {
-				required: true,
-				type: "string"
-			},
-			"output.annotations[].path": {
-				required: true,
-				type: "string"
-			},
-			"output.annotations[].raw_details": {
-				type: "string"
-			},
-			"output.annotations[].start_column": {
-				type: "integer"
-			},
-			"output.annotations[].start_line": {
-				required: true,
-				type: "integer"
-			},
-			"output.annotations[].title": {
-				type: "string"
-			},
-			"output.images": {
-				type: "object[]"
-			},
-			"output.images[].alt": {
-				required: true,
-				type: "string"
-			},
-			"output.images[].caption": {
-				type: "string"
-			},
-			"output.images[].image_url": {
-				required: true,
-				type: "string"
-			},
-			"output.summary": {
-				required: true,
-				type: "string"
-			},
-			"output.text": {
-				type: "string"
-			},
-			"output.title": {
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			started_at: {
-				type: "string"
-			},
-			status: {
-				"enum": [
-					"queued",
-					"in_progress",
-					"completed"
-				],
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/check-runs/:check_run_id"
-	}
-};
-var codesOfConduct = {
-	getConductCode: {
-		headers: {
-			accept: "application/vnd.github.scarlet-witch-preview+json"
-		},
-		method: "GET",
-		params: {
-			key: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/codes_of_conduct/:key"
-	},
-	getForRepo: {
-		headers: {
-			accept: "application/vnd.github.scarlet-witch-preview+json"
-		},
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/community/code_of_conduct"
-	},
-	listConductCodes: {
-		headers: {
-			accept: "application/vnd.github.scarlet-witch-preview+json"
-		},
-		method: "GET",
-		params: {
-		},
-		url: "/codes_of_conduct"
-	}
-};
-var emojis = {
-	get: {
-		method: "GET",
-		params: {
-		},
-		url: "/emojis"
-	}
-};
-var gists = {
-	checkIsStarred: {
-		method: "GET",
-		params: {
-			gist_id: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/gists/:gist_id/star"
-	},
-	create: {
-		method: "POST",
-		params: {
-			description: {
-				type: "string"
-			},
-			files: {
-				required: true,
-				type: "object"
-			},
-			"files.content": {
-				type: "string"
-			},
-			"public": {
-				type: "boolean"
-			}
-		},
-		url: "/gists"
-	},
-	createComment: {
-		method: "POST",
-		params: {
-			body: {
-				required: true,
-				type: "string"
-			},
-			gist_id: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/gists/:gist_id/comments"
-	},
-	"delete": {
-		method: "DELETE",
-		params: {
-			gist_id: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/gists/:gist_id"
-	},
-	deleteComment: {
-		method: "DELETE",
-		params: {
-			comment_id: {
-				required: true,
-				type: "integer"
-			},
-			gist_id: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/gists/:gist_id/comments/:comment_id"
-	},
-	fork: {
-		method: "POST",
-		params: {
-			gist_id: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/gists/:gist_id/forks"
-	},
-	get: {
-		method: "GET",
-		params: {
-			gist_id: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/gists/:gist_id"
-	},
-	getComment: {
-		method: "GET",
-		params: {
-			comment_id: {
-				required: true,
-				type: "integer"
-			},
-			gist_id: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/gists/:gist_id/comments/:comment_id"
-	},
-	getRevision: {
-		method: "GET",
-		params: {
-			gist_id: {
-				required: true,
-				type: "string"
-			},
-			sha: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/gists/:gist_id/:sha"
-	},
-	list: {
-		method: "GET",
-		params: {
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			since: {
-				type: "string"
-			}
-		},
-		url: "/gists"
-	},
-	listComments: {
-		method: "GET",
-		params: {
-			gist_id: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			}
-		},
-		url: "/gists/:gist_id/comments"
-	},
-	listCommits: {
-		method: "GET",
-		params: {
-			gist_id: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			}
-		},
-		url: "/gists/:gist_id/commits"
-	},
-	listForks: {
-		method: "GET",
-		params: {
-			gist_id: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			}
-		},
-		url: "/gists/:gist_id/forks"
-	},
-	listPublic: {
-		method: "GET",
-		params: {
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			since: {
-				type: "string"
-			}
-		},
-		url: "/gists/public"
-	},
-	listPublicForUser: {
-		method: "GET",
-		params: {
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			since: {
-				type: "string"
-			},
-			username: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/users/:username/gists"
-	},
-	listStarred: {
-		method: "GET",
-		params: {
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			since: {
-				type: "string"
-			}
-		},
-		url: "/gists/starred"
-	},
-	star: {
-		method: "PUT",
-		params: {
-			gist_id: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/gists/:gist_id/star"
-	},
-	unstar: {
-		method: "DELETE",
-		params: {
-			gist_id: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/gists/:gist_id/star"
-	},
-	update: {
-		method: "PATCH",
-		params: {
-			description: {
-				type: "string"
-			},
-			files: {
-				type: "object"
-			},
-			"files.content": {
-				type: "string"
-			},
-			"files.filename": {
-				type: "string"
-			},
-			gist_id: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/gists/:gist_id"
-	},
-	updateComment: {
-		method: "PATCH",
-		params: {
-			body: {
-				required: true,
-				type: "string"
-			},
-			comment_id: {
-				required: true,
-				type: "integer"
-			},
-			gist_id: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/gists/:gist_id/comments/:comment_id"
-	}
-};
-var git = {
-	createBlob: {
-		method: "POST",
-		params: {
-			content: {
-				required: true,
-				type: "string"
-			},
-			encoding: {
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/git/blobs"
-	},
-	createCommit: {
-		method: "POST",
-		params: {
-			author: {
-				type: "object"
-			},
-			"author.date": {
-				type: "string"
-			},
-			"author.email": {
-				type: "string"
-			},
-			"author.name": {
-				type: "string"
-			},
-			committer: {
-				type: "object"
-			},
-			"committer.date": {
-				type: "string"
-			},
-			"committer.email": {
-				type: "string"
-			},
-			"committer.name": {
-				type: "string"
-			},
-			message: {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			parents: {
-				required: true,
-				type: "string[]"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			signature: {
-				type: "string"
-			},
-			tree: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/git/commits"
-	},
-	createRef: {
-		method: "POST",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			ref: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			sha: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/git/refs"
-	},
-	createTag: {
-		method: "POST",
-		params: {
-			message: {
-				required: true,
-				type: "string"
-			},
-			object: {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			tag: {
-				required: true,
-				type: "string"
-			},
-			tagger: {
-				type: "object"
-			},
-			"tagger.date": {
-				type: "string"
-			},
-			"tagger.email": {
-				type: "string"
-			},
-			"tagger.name": {
-				type: "string"
-			},
-			type: {
-				"enum": [
-					"commit",
-					"tree",
-					"blob"
-				],
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/git/tags"
-	},
-	createTree: {
-		method: "POST",
-		params: {
-			base_tree: {
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			tree: {
-				required: true,
-				type: "object[]"
-			},
-			"tree[].content": {
-				type: "string"
-			},
-			"tree[].mode": {
-				"enum": [
-					"100644",
-					"100755",
-					"040000",
-					"160000",
-					"120000"
-				],
-				type: "string"
-			},
-			"tree[].path": {
-				type: "string"
-			},
-			"tree[].sha": {
-				allowNull: true,
-				type: "string"
-			},
-			"tree[].type": {
-				"enum": [
-					"blob",
-					"tree",
-					"commit"
-				],
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/git/trees"
-	},
-	deleteRef: {
-		method: "DELETE",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			ref: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/git/refs/:ref"
-	},
-	getBlob: {
-		method: "GET",
-		params: {
-			file_sha: {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/git/blobs/:file_sha"
-	},
-	getCommit: {
-		method: "GET",
-		params: {
-			commit_sha: {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/git/commits/:commit_sha"
-	},
-	getRef: {
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			ref: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/git/ref/:ref"
-	},
-	getTag: {
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			tag_sha: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/git/tags/:tag_sha"
-	},
-	getTree: {
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			recursive: {
-				"enum": [
-					"1"
-				],
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			tree_sha: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/git/trees/:tree_sha"
-	},
-	listMatchingRefs: {
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			ref: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/git/matching-refs/:ref"
-	},
-	listRefs: {
-		method: "GET",
-		params: {
-			namespace: {
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/git/refs/:namespace"
-	},
-	updateRef: {
-		method: "PATCH",
-		params: {
-			force: {
-				type: "boolean"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			ref: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			sha: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/git/refs/:ref"
-	}
-};
-var gitignore = {
-	getTemplate: {
-		method: "GET",
-		params: {
-			name: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/gitignore/templates/:name"
-	},
-	listTemplates: {
-		method: "GET",
-		params: {
-		},
-		url: "/gitignore/templates"
-	}
-};
-var interactions = {
-	addOrUpdateRestrictionsForOrg: {
-		headers: {
-			accept: "application/vnd.github.sombra-preview+json"
-		},
-		method: "PUT",
-		params: {
-			limit: {
-				"enum": [
-					"existing_users",
-					"contributors_only",
-					"collaborators_only"
-				],
-				required: true,
-				type: "string"
-			},
-			org: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/orgs/:org/interaction-limits"
-	},
-	addOrUpdateRestrictionsForRepo: {
-		headers: {
-			accept: "application/vnd.github.sombra-preview+json"
-		},
-		method: "PUT",
-		params: {
-			limit: {
-				"enum": [
-					"existing_users",
-					"contributors_only",
-					"collaborators_only"
-				],
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/interaction-limits"
-	},
-	getRestrictionsForOrg: {
-		headers: {
-			accept: "application/vnd.github.sombra-preview+json"
-		},
-		method: "GET",
-		params: {
-			org: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/orgs/:org/interaction-limits"
-	},
-	getRestrictionsForRepo: {
-		headers: {
-			accept: "application/vnd.github.sombra-preview+json"
-		},
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/interaction-limits"
-	},
-	removeRestrictionsForOrg: {
-		headers: {
-			accept: "application/vnd.github.sombra-preview+json"
-		},
-		method: "DELETE",
-		params: {
-			org: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/orgs/:org/interaction-limits"
-	},
-	removeRestrictionsForRepo: {
-		headers: {
-			accept: "application/vnd.github.sombra-preview+json"
-		},
-		method: "DELETE",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/interaction-limits"
-	}
-};
-var issues = {
-	addAssignees: {
-		method: "POST",
-		params: {
-			assignees: {
-				type: "string[]"
-			},
-			issue_number: {
-				required: true,
-				type: "integer"
-			},
-			number: {
-				alias: "issue_number",
-				deprecated: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/issues/:issue_number/assignees"
-	},
-	addLabels: {
-		method: "POST",
-		params: {
-			issue_number: {
-				required: true,
-				type: "integer"
-			},
-			labels: {
-				required: true,
-				type: "string[]"
-			},
-			number: {
-				alias: "issue_number",
-				deprecated: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/issues/:issue_number/labels"
-	},
-	checkAssignee: {
-		method: "GET",
-		params: {
-			assignee: {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/assignees/:assignee"
-	},
-	create: {
-		method: "POST",
-		params: {
-			assignee: {
-				type: "string"
-			},
-			assignees: {
-				type: "string[]"
-			},
-			body: {
-				type: "string"
-			},
-			labels: {
-				type: "string[]"
-			},
-			milestone: {
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			title: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/issues"
-	},
-	createComment: {
-		method: "POST",
-		params: {
-			body: {
-				required: true,
-				type: "string"
-			},
-			issue_number: {
-				required: true,
-				type: "integer"
-			},
-			number: {
-				alias: "issue_number",
-				deprecated: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/issues/:issue_number/comments"
-	},
-	createLabel: {
-		method: "POST",
-		params: {
-			color: {
-				required: true,
-				type: "string"
-			},
-			description: {
-				type: "string"
-			},
-			name: {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/labels"
-	},
-	createMilestone: {
-		method: "POST",
-		params: {
-			description: {
-				type: "string"
-			},
-			due_on: {
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			state: {
-				"enum": [
-					"open",
-					"closed"
-				],
-				type: "string"
-			},
-			title: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/milestones"
-	},
-	deleteComment: {
-		method: "DELETE",
-		params: {
-			comment_id: {
-				required: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/issues/comments/:comment_id"
-	},
-	deleteLabel: {
-		method: "DELETE",
-		params: {
-			name: {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/labels/:name"
-	},
-	deleteMilestone: {
-		method: "DELETE",
-		params: {
-			milestone_number: {
-				required: true,
-				type: "integer"
-			},
-			number: {
-				alias: "milestone_number",
-				deprecated: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/milestones/:milestone_number"
-	},
-	get: {
-		method: "GET",
-		params: {
-			issue_number: {
-				required: true,
-				type: "integer"
-			},
-			number: {
-				alias: "issue_number",
-				deprecated: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/issues/:issue_number"
-	},
-	getComment: {
-		method: "GET",
-		params: {
-			comment_id: {
-				required: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/issues/comments/:comment_id"
-	},
-	getEvent: {
-		method: "GET",
-		params: {
-			event_id: {
-				required: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/issues/events/:event_id"
-	},
-	getLabel: {
-		method: "GET",
-		params: {
-			name: {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/labels/:name"
-	},
-	getMilestone: {
-		method: "GET",
-		params: {
-			milestone_number: {
-				required: true,
-				type: "integer"
-			},
-			number: {
-				alias: "milestone_number",
-				deprecated: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/milestones/:milestone_number"
-	},
-	list: {
-		method: "GET",
-		params: {
-			direction: {
-				"enum": [
-					"asc",
-					"desc"
-				],
-				type: "string"
-			},
-			filter: {
-				"enum": [
-					"assigned",
-					"created",
-					"mentioned",
-					"subscribed",
-					"all"
-				],
-				type: "string"
-			},
-			labels: {
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			since: {
-				type: "string"
-			},
-			sort: {
-				"enum": [
-					"created",
-					"updated",
-					"comments"
-				],
-				type: "string"
-			},
-			state: {
-				"enum": [
-					"open",
-					"closed",
-					"all"
-				],
-				type: "string"
-			}
-		},
-		url: "/issues"
-	},
-	listAssignees: {
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/assignees"
-	},
-	listComments: {
-		method: "GET",
-		params: {
-			issue_number: {
-				required: true,
-				type: "integer"
-			},
-			number: {
-				alias: "issue_number",
-				deprecated: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			since: {
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/issues/:issue_number/comments"
-	},
-	listCommentsForRepo: {
-		method: "GET",
-		params: {
-			direction: {
-				"enum": [
-					"asc",
-					"desc"
-				],
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			since: {
-				type: "string"
-			},
-			sort: {
-				"enum": [
-					"created",
-					"updated"
-				],
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/issues/comments"
-	},
-	listEvents: {
-		method: "GET",
-		params: {
-			issue_number: {
-				required: true,
-				type: "integer"
-			},
-			number: {
-				alias: "issue_number",
-				deprecated: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/issues/:issue_number/events"
-	},
-	listEventsForRepo: {
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/issues/events"
-	},
-	listEventsForTimeline: {
-		headers: {
-			accept: "application/vnd.github.mockingbird-preview+json"
-		},
-		method: "GET",
-		params: {
-			issue_number: {
-				required: true,
-				type: "integer"
-			},
-			number: {
-				alias: "issue_number",
-				deprecated: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/issues/:issue_number/timeline"
-	},
-	listForAuthenticatedUser: {
-		method: "GET",
-		params: {
-			direction: {
-				"enum": [
-					"asc",
-					"desc"
-				],
-				type: "string"
-			},
-			filter: {
-				"enum": [
-					"assigned",
-					"created",
-					"mentioned",
-					"subscribed",
-					"all"
-				],
-				type: "string"
-			},
-			labels: {
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			since: {
-				type: "string"
-			},
-			sort: {
-				"enum": [
-					"created",
-					"updated",
-					"comments"
-				],
-				type: "string"
-			},
-			state: {
-				"enum": [
-					"open",
-					"closed",
-					"all"
-				],
-				type: "string"
-			}
-		},
-		url: "/user/issues"
-	},
-	listForOrg: {
-		method: "GET",
-		params: {
-			direction: {
-				"enum": [
-					"asc",
-					"desc"
-				],
-				type: "string"
-			},
-			filter: {
-				"enum": [
-					"assigned",
-					"created",
-					"mentioned",
-					"subscribed",
-					"all"
-				],
-				type: "string"
-			},
-			labels: {
-				type: "string"
-			},
-			org: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			since: {
-				type: "string"
-			},
-			sort: {
-				"enum": [
-					"created",
-					"updated",
-					"comments"
-				],
-				type: "string"
-			},
-			state: {
-				"enum": [
-					"open",
-					"closed",
-					"all"
-				],
-				type: "string"
-			}
-		},
-		url: "/orgs/:org/issues"
-	},
-	listForRepo: {
-		method: "GET",
-		params: {
-			assignee: {
-				type: "string"
-			},
-			creator: {
-				type: "string"
-			},
-			direction: {
-				"enum": [
-					"asc",
-					"desc"
-				],
-				type: "string"
-			},
-			labels: {
-				type: "string"
-			},
-			mentioned: {
-				type: "string"
-			},
-			milestone: {
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			since: {
-				type: "string"
-			},
-			sort: {
-				"enum": [
-					"created",
-					"updated",
-					"comments"
-				],
-				type: "string"
-			},
-			state: {
-				"enum": [
-					"open",
-					"closed",
-					"all"
-				],
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/issues"
-	},
-	listLabelsForMilestone: {
-		method: "GET",
-		params: {
-			milestone_number: {
-				required: true,
-				type: "integer"
-			},
-			number: {
-				alias: "milestone_number",
-				deprecated: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/milestones/:milestone_number/labels"
-	},
-	listLabelsForRepo: {
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/labels"
-	},
-	listLabelsOnIssue: {
-		method: "GET",
-		params: {
-			issue_number: {
-				required: true,
-				type: "integer"
-			},
-			number: {
-				alias: "issue_number",
-				deprecated: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/issues/:issue_number/labels"
-	},
-	listMilestonesForRepo: {
-		method: "GET",
-		params: {
-			direction: {
-				"enum": [
-					"asc",
-					"desc"
-				],
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			sort: {
-				"enum": [
-					"due_on",
-					"completeness"
-				],
-				type: "string"
-			},
-			state: {
-				"enum": [
-					"open",
-					"closed",
-					"all"
-				],
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/milestones"
-	},
-	lock: {
-		method: "PUT",
-		params: {
-			issue_number: {
-				required: true,
-				type: "integer"
-			},
-			lock_reason: {
-				"enum": [
-					"off-topic",
-					"too heated",
-					"resolved",
-					"spam"
-				],
-				type: "string"
-			},
-			number: {
-				alias: "issue_number",
-				deprecated: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/issues/:issue_number/lock"
-	},
-	removeAssignees: {
-		method: "DELETE",
-		params: {
-			assignees: {
-				type: "string[]"
-			},
-			issue_number: {
-				required: true,
-				type: "integer"
-			},
-			number: {
-				alias: "issue_number",
-				deprecated: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/issues/:issue_number/assignees"
-	},
-	removeLabel: {
-		method: "DELETE",
-		params: {
-			issue_number: {
-				required: true,
-				type: "integer"
-			},
-			name: {
-				required: true,
-				type: "string"
-			},
-			number: {
-				alias: "issue_number",
-				deprecated: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/issues/:issue_number/labels/:name"
-	},
-	removeLabels: {
-		method: "DELETE",
-		params: {
-			issue_number: {
-				required: true,
-				type: "integer"
-			},
-			number: {
-				alias: "issue_number",
-				deprecated: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/issues/:issue_number/labels"
-	},
-	replaceLabels: {
-		method: "PUT",
-		params: {
-			issue_number: {
-				required: true,
-				type: "integer"
-			},
-			labels: {
-				type: "string[]"
-			},
-			number: {
-				alias: "issue_number",
-				deprecated: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/issues/:issue_number/labels"
-	},
-	unlock: {
-		method: "DELETE",
-		params: {
-			issue_number: {
-				required: true,
-				type: "integer"
-			},
-			number: {
-				alias: "issue_number",
-				deprecated: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/issues/:issue_number/lock"
-	},
-	update: {
-		method: "PATCH",
-		params: {
-			assignee: {
-				type: "string"
-			},
-			assignees: {
-				type: "string[]"
-			},
-			body: {
-				type: "string"
-			},
-			issue_number: {
-				required: true,
-				type: "integer"
-			},
-			labels: {
-				type: "string[]"
-			},
-			milestone: {
-				allowNull: true,
-				type: "integer"
-			},
-			number: {
-				alias: "issue_number",
-				deprecated: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			state: {
-				"enum": [
-					"open",
-					"closed"
-				],
-				type: "string"
-			},
-			title: {
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/issues/:issue_number"
-	},
-	updateComment: {
-		method: "PATCH",
-		params: {
-			body: {
-				required: true,
-				type: "string"
-			},
-			comment_id: {
-				required: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/issues/comments/:comment_id"
-	},
-	updateLabel: {
-		method: "PATCH",
-		params: {
-			color: {
-				type: "string"
-			},
-			current_name: {
-				required: true,
-				type: "string"
-			},
-			description: {
-				type: "string"
-			},
-			name: {
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/labels/:current_name"
-	},
-	updateMilestone: {
-		method: "PATCH",
-		params: {
-			description: {
-				type: "string"
-			},
-			due_on: {
-				type: "string"
-			},
-			milestone_number: {
-				required: true,
-				type: "integer"
-			},
-			number: {
-				alias: "milestone_number",
-				deprecated: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			state: {
-				"enum": [
-					"open",
-					"closed"
-				],
-				type: "string"
-			},
-			title: {
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/milestones/:milestone_number"
-	}
-};
-var licenses = {
-	get: {
-		method: "GET",
-		params: {
-			license: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/licenses/:license"
-	},
-	getForRepo: {
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/license"
-	},
-	list: {
-		deprecated: "octokit.licenses.list() has been renamed to octokit.licenses.listCommonlyUsed() (2019-03-05)",
-		method: "GET",
-		params: {
-		},
-		url: "/licenses"
-	},
-	listCommonlyUsed: {
-		method: "GET",
-		params: {
-		},
-		url: "/licenses"
-	}
-};
-var markdown = {
-	render: {
-		method: "POST",
-		params: {
-			context: {
-				type: "string"
-			},
-			mode: {
-				"enum": [
-					"markdown",
-					"gfm"
-				],
-				type: "string"
-			},
-			text: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/markdown"
-	},
-	renderRaw: {
-		headers: {
-			"content-type": "text/plain; charset=utf-8"
-		},
-		method: "POST",
-		params: {
-			data: {
-				mapTo: "data",
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/markdown/raw"
-	}
-};
-var meta = {
-	get: {
-		method: "GET",
-		params: {
-		},
-		url: "/meta"
-	}
-};
-var migrations = {
-	cancelImport: {
-		headers: {
-			accept: "application/vnd.github.barred-rock-preview+json"
-		},
-		method: "DELETE",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/import"
-	},
-	deleteArchiveForAuthenticatedUser: {
-		headers: {
-			accept: "application/vnd.github.wyandotte-preview+json"
-		},
-		method: "DELETE",
-		params: {
-			migration_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/user/migrations/:migration_id/archive"
-	},
-	deleteArchiveForOrg: {
-		headers: {
-			accept: "application/vnd.github.wyandotte-preview+json"
-		},
-		method: "DELETE",
-		params: {
-			migration_id: {
-				required: true,
-				type: "integer"
-			},
-			org: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/orgs/:org/migrations/:migration_id/archive"
-	},
-	getArchiveForAuthenticatedUser: {
-		headers: {
-			accept: "application/vnd.github.wyandotte-preview+json"
-		},
-		method: "GET",
-		params: {
-			migration_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/user/migrations/:migration_id/archive"
-	},
-	getArchiveForOrg: {
-		headers: {
-			accept: "application/vnd.github.wyandotte-preview+json"
-		},
-		method: "GET",
-		params: {
-			migration_id: {
-				required: true,
-				type: "integer"
-			},
-			org: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/orgs/:org/migrations/:migration_id/archive"
-	},
-	getCommitAuthors: {
-		headers: {
-			accept: "application/vnd.github.barred-rock-preview+json"
-		},
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			since: {
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/import/authors"
-	},
-	getImportProgress: {
-		headers: {
-			accept: "application/vnd.github.barred-rock-preview+json"
-		},
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/import"
-	},
-	getLargeFiles: {
-		headers: {
-			accept: "application/vnd.github.barred-rock-preview+json"
-		},
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/import/large_files"
-	},
-	getStatusForAuthenticatedUser: {
-		headers: {
-			accept: "application/vnd.github.wyandotte-preview+json"
-		},
-		method: "GET",
-		params: {
-			migration_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/user/migrations/:migration_id"
-	},
-	getStatusForOrg: {
-		headers: {
-			accept: "application/vnd.github.wyandotte-preview+json"
-		},
-		method: "GET",
-		params: {
-			migration_id: {
-				required: true,
-				type: "integer"
-			},
-			org: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/orgs/:org/migrations/:migration_id"
-	},
-	listForAuthenticatedUser: {
-		headers: {
-			accept: "application/vnd.github.wyandotte-preview+json"
-		},
-		method: "GET",
-		params: {
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			}
-		},
-		url: "/user/migrations"
-	},
-	listForOrg: {
-		headers: {
-			accept: "application/vnd.github.wyandotte-preview+json"
-		},
-		method: "GET",
-		params: {
-			org: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			}
-		},
-		url: "/orgs/:org/migrations"
-	},
-	mapCommitAuthor: {
-		headers: {
-			accept: "application/vnd.github.barred-rock-preview+json"
-		},
-		method: "PATCH",
-		params: {
-			author_id: {
-				required: true,
-				type: "integer"
-			},
-			email: {
-				type: "string"
-			},
-			name: {
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/import/authors/:author_id"
-	},
-	setLfsPreference: {
-		headers: {
-			accept: "application/vnd.github.barred-rock-preview+json"
-		},
-		method: "PATCH",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			use_lfs: {
-				"enum": [
-					"opt_in",
-					"opt_out"
-				],
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/import/lfs"
-	},
-	startForAuthenticatedUser: {
-		method: "POST",
-		params: {
-			exclude_attachments: {
-				type: "boolean"
-			},
-			lock_repositories: {
-				type: "boolean"
-			},
-			repositories: {
-				required: true,
-				type: "string[]"
-			}
-		},
-		url: "/user/migrations"
-	},
-	startForOrg: {
-		method: "POST",
-		params: {
-			exclude_attachments: {
-				type: "boolean"
-			},
-			lock_repositories: {
-				type: "boolean"
-			},
-			org: {
-				required: true,
-				type: "string"
-			},
-			repositories: {
-				required: true,
-				type: "string[]"
-			}
-		},
-		url: "/orgs/:org/migrations"
-	},
-	startImport: {
-		headers: {
-			accept: "application/vnd.github.barred-rock-preview+json"
-		},
-		method: "PUT",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			tfvc_project: {
-				type: "string"
-			},
-			vcs: {
-				"enum": [
-					"subversion",
-					"git",
-					"mercurial",
-					"tfvc"
-				],
-				type: "string"
-			},
-			vcs_password: {
-				type: "string"
-			},
-			vcs_url: {
-				required: true,
-				type: "string"
-			},
-			vcs_username: {
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/import"
-	},
-	unlockRepoForAuthenticatedUser: {
-		headers: {
-			accept: "application/vnd.github.wyandotte-preview+json"
-		},
-		method: "DELETE",
-		params: {
-			migration_id: {
-				required: true,
-				type: "integer"
-			},
-			repo_name: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/user/migrations/:migration_id/repos/:repo_name/lock"
-	},
-	unlockRepoForOrg: {
-		headers: {
-			accept: "application/vnd.github.wyandotte-preview+json"
-		},
-		method: "DELETE",
-		params: {
-			migration_id: {
-				required: true,
-				type: "integer"
-			},
-			org: {
-				required: true,
-				type: "string"
-			},
-			repo_name: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/orgs/:org/migrations/:migration_id/repos/:repo_name/lock"
-	},
-	updateImport: {
-		headers: {
-			accept: "application/vnd.github.barred-rock-preview+json"
-		},
-		method: "PATCH",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			vcs_password: {
-				type: "string"
-			},
-			vcs_username: {
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/import"
-	}
-};
-var oauthAuthorizations = {
-	checkAuthorization: {
-		deprecated: "octokit.oauthAuthorizations.checkAuthorization() has been renamed to octokit.apps.checkAuthorization() (2019-11-05)",
-		method: "GET",
-		params: {
-			access_token: {
-				required: true,
-				type: "string"
-			},
-			client_id: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/applications/:client_id/tokens/:access_token"
-	},
-	createAuthorization: {
-		deprecated: "octokit.oauthAuthorizations.createAuthorization() is deprecated, see https://developer.github.com/v3/oauth_authorizations/#create-a-new-authorization",
-		method: "POST",
-		params: {
-			client_id: {
-				type: "string"
-			},
-			client_secret: {
-				type: "string"
-			},
-			fingerprint: {
-				type: "string"
-			},
-			note: {
-				required: true,
-				type: "string"
-			},
-			note_url: {
-				type: "string"
-			},
-			scopes: {
-				type: "string[]"
-			}
-		},
-		url: "/authorizations"
-	},
-	deleteAuthorization: {
-		deprecated: "octokit.oauthAuthorizations.deleteAuthorization() is deprecated, see https://developer.github.com/v3/oauth_authorizations/#delete-an-authorization",
-		method: "DELETE",
-		params: {
-			authorization_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/authorizations/:authorization_id"
-	},
-	deleteGrant: {
-		deprecated: "octokit.oauthAuthorizations.deleteGrant() is deprecated, see https://developer.github.com/v3/oauth_authorizations/#delete-a-grant",
-		method: "DELETE",
-		params: {
-			grant_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/applications/grants/:grant_id"
-	},
-	getAuthorization: {
-		deprecated: "octokit.oauthAuthorizations.getAuthorization() is deprecated, see https://developer.github.com/v3/oauth_authorizations/#get-a-single-authorization",
-		method: "GET",
-		params: {
-			authorization_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/authorizations/:authorization_id"
-	},
-	getGrant: {
-		deprecated: "octokit.oauthAuthorizations.getGrant() is deprecated, see https://developer.github.com/v3/oauth_authorizations/#get-a-single-grant",
-		method: "GET",
-		params: {
-			grant_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/applications/grants/:grant_id"
-	},
-	getOrCreateAuthorizationForApp: {
-		deprecated: "octokit.oauthAuthorizations.getOrCreateAuthorizationForApp() is deprecated, see https://developer.github.com/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app",
-		method: "PUT",
-		params: {
-			client_id: {
-				required: true,
-				type: "string"
-			},
-			client_secret: {
-				required: true,
-				type: "string"
-			},
-			fingerprint: {
-				type: "string"
-			},
-			note: {
-				type: "string"
-			},
-			note_url: {
-				type: "string"
-			},
-			scopes: {
-				type: "string[]"
-			}
-		},
-		url: "/authorizations/clients/:client_id"
-	},
-	getOrCreateAuthorizationForAppAndFingerprint: {
-		deprecated: "octokit.oauthAuthorizations.getOrCreateAuthorizationForAppAndFingerprint() is deprecated, see https://developer.github.com/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app-and-fingerprint",
-		method: "PUT",
-		params: {
-			client_id: {
-				required: true,
-				type: "string"
-			},
-			client_secret: {
-				required: true,
-				type: "string"
-			},
-			fingerprint: {
-				required: true,
-				type: "string"
-			},
-			note: {
-				type: "string"
-			},
-			note_url: {
-				type: "string"
-			},
-			scopes: {
-				type: "string[]"
-			}
-		},
-		url: "/authorizations/clients/:client_id/:fingerprint"
-	},
-	getOrCreateAuthorizationForAppFingerprint: {
-		deprecated: "octokit.oauthAuthorizations.getOrCreateAuthorizationForAppFingerprint() has been renamed to octokit.oauthAuthorizations.getOrCreateAuthorizationForAppAndFingerprint() (2018-12-27)",
-		method: "PUT",
-		params: {
-			client_id: {
-				required: true,
-				type: "string"
-			},
-			client_secret: {
-				required: true,
-				type: "string"
-			},
-			fingerprint: {
-				required: true,
-				type: "string"
-			},
-			note: {
-				type: "string"
-			},
-			note_url: {
-				type: "string"
-			},
-			scopes: {
-				type: "string[]"
-			}
-		},
-		url: "/authorizations/clients/:client_id/:fingerprint"
-	},
-	listAuthorizations: {
-		deprecated: "octokit.oauthAuthorizations.listAuthorizations() is deprecated, see https://developer.github.com/v3/oauth_authorizations/#list-your-authorizations",
-		method: "GET",
-		params: {
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			}
-		},
-		url: "/authorizations"
-	},
-	listGrants: {
-		deprecated: "octokit.oauthAuthorizations.listGrants() is deprecated, see https://developer.github.com/v3/oauth_authorizations/#list-your-grants",
-		method: "GET",
-		params: {
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			}
-		},
-		url: "/applications/grants"
-	},
-	resetAuthorization: {
-		deprecated: "octokit.oauthAuthorizations.resetAuthorization() has been renamed to octokit.apps.resetAuthorization() (2019-11-05)",
-		method: "POST",
-		params: {
-			access_token: {
-				required: true,
-				type: "string"
-			},
-			client_id: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/applications/:client_id/tokens/:access_token"
-	},
-	revokeAuthorizationForApplication: {
-		deprecated: "octokit.oauthAuthorizations.revokeAuthorizationForApplication() has been renamed to octokit.apps.revokeAuthorizationForApplication() (2019-11-05)",
-		method: "DELETE",
-		params: {
-			access_token: {
-				required: true,
-				type: "string"
-			},
-			client_id: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/applications/:client_id/tokens/:access_token"
-	},
-	revokeGrantForApplication: {
-		deprecated: "octokit.oauthAuthorizations.revokeGrantForApplication() has been renamed to octokit.apps.revokeGrantForApplication() (2019-11-05)",
-		method: "DELETE",
-		params: {
-			access_token: {
-				required: true,
-				type: "string"
-			},
-			client_id: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/applications/:client_id/grants/:access_token"
-	},
-	updateAuthorization: {
-		deprecated: "octokit.oauthAuthorizations.updateAuthorization() is deprecated, see https://developer.github.com/v3/oauth_authorizations/#update-an-existing-authorization",
-		method: "PATCH",
-		params: {
-			add_scopes: {
-				type: "string[]"
-			},
-			authorization_id: {
-				required: true,
-				type: "integer"
-			},
-			fingerprint: {
-				type: "string"
-			},
-			note: {
-				type: "string"
-			},
-			note_url: {
-				type: "string"
-			},
-			remove_scopes: {
-				type: "string[]"
-			},
-			scopes: {
-				type: "string[]"
-			}
-		},
-		url: "/authorizations/:authorization_id"
-	}
-};
-var orgs = {
-	addOrUpdateMembership: {
-		method: "PUT",
-		params: {
-			org: {
-				required: true,
-				type: "string"
-			},
-			role: {
-				"enum": [
-					"admin",
-					"member"
-				],
-				type: "string"
-			},
-			username: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/orgs/:org/memberships/:username"
-	},
-	blockUser: {
-		method: "PUT",
-		params: {
-			org: {
-				required: true,
-				type: "string"
-			},
-			username: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/orgs/:org/blocks/:username"
-	},
-	checkBlockedUser: {
-		method: "GET",
-		params: {
-			org: {
-				required: true,
-				type: "string"
-			},
-			username: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/orgs/:org/blocks/:username"
-	},
-	checkMembership: {
-		method: "GET",
-		params: {
-			org: {
-				required: true,
-				type: "string"
-			},
-			username: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/orgs/:org/members/:username"
-	},
-	checkPublicMembership: {
-		method: "GET",
-		params: {
-			org: {
-				required: true,
-				type: "string"
-			},
-			username: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/orgs/:org/public_members/:username"
-	},
-	concealMembership: {
-		method: "DELETE",
-		params: {
-			org: {
-				required: true,
-				type: "string"
-			},
-			username: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/orgs/:org/public_members/:username"
-	},
-	convertMemberToOutsideCollaborator: {
-		method: "PUT",
-		params: {
-			org: {
-				required: true,
-				type: "string"
-			},
-			username: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/orgs/:org/outside_collaborators/:username"
-	},
-	createHook: {
-		method: "POST",
-		params: {
-			active: {
-				type: "boolean"
-			},
-			config: {
-				required: true,
-				type: "object"
-			},
-			"config.content_type": {
-				type: "string"
-			},
-			"config.insecure_ssl": {
-				type: "string"
-			},
-			"config.secret": {
-				type: "string"
-			},
-			"config.url": {
-				required: true,
-				type: "string"
-			},
-			events: {
-				type: "string[]"
-			},
-			name: {
-				required: true,
-				type: "string"
-			},
-			org: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/orgs/:org/hooks"
-	},
-	createInvitation: {
-		method: "POST",
-		params: {
-			email: {
-				type: "string"
-			},
-			invitee_id: {
-				type: "integer"
-			},
-			org: {
-				required: true,
-				type: "string"
-			},
-			role: {
-				"enum": [
-					"admin",
-					"direct_member",
-					"billing_manager"
-				],
-				type: "string"
-			},
-			team_ids: {
-				type: "integer[]"
-			}
-		},
-		url: "/orgs/:org/invitations"
-	},
-	deleteHook: {
-		method: "DELETE",
-		params: {
-			hook_id: {
-				required: true,
-				type: "integer"
-			},
-			org: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/orgs/:org/hooks/:hook_id"
-	},
-	get: {
-		method: "GET",
-		params: {
-			org: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/orgs/:org"
-	},
-	getHook: {
-		method: "GET",
-		params: {
-			hook_id: {
-				required: true,
-				type: "integer"
-			},
-			org: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/orgs/:org/hooks/:hook_id"
-	},
-	getMembership: {
-		method: "GET",
-		params: {
-			org: {
-				required: true,
-				type: "string"
-			},
-			username: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/orgs/:org/memberships/:username"
-	},
-	getMembershipForAuthenticatedUser: {
-		method: "GET",
-		params: {
-			org: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/user/memberships/orgs/:org"
-	},
-	list: {
-		method: "GET",
-		params: {
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			since: {
-				type: "string"
-			}
-		},
-		url: "/organizations"
-	},
-	listBlockedUsers: {
-		method: "GET",
-		params: {
-			org: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/orgs/:org/blocks"
-	},
-	listForAuthenticatedUser: {
-		method: "GET",
-		params: {
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			}
-		},
-		url: "/user/orgs"
-	},
-	listForUser: {
-		method: "GET",
-		params: {
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			username: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/users/:username/orgs"
-	},
-	listHooks: {
-		method: "GET",
-		params: {
-			org: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			}
-		},
-		url: "/orgs/:org/hooks"
-	},
-	listInstallations: {
-		headers: {
-			accept: "application/vnd.github.machine-man-preview+json"
-		},
-		method: "GET",
-		params: {
-			org: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			}
-		},
-		url: "/orgs/:org/installations"
-	},
-	listInvitationTeams: {
-		method: "GET",
-		params: {
-			invitation_id: {
-				required: true,
-				type: "integer"
-			},
-			org: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			}
-		},
-		url: "/orgs/:org/invitations/:invitation_id/teams"
-	},
-	listMembers: {
-		method: "GET",
-		params: {
-			filter: {
-				"enum": [
-					"2fa_disabled",
-					"all"
-				],
-				type: "string"
-			},
-			org: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			role: {
-				"enum": [
-					"all",
-					"admin",
-					"member"
-				],
-				type: "string"
-			}
-		},
-		url: "/orgs/:org/members"
-	},
-	listMemberships: {
-		method: "GET",
-		params: {
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			state: {
-				"enum": [
-					"active",
-					"pending"
-				],
-				type: "string"
-			}
-		},
-		url: "/user/memberships/orgs"
-	},
-	listOutsideCollaborators: {
-		method: "GET",
-		params: {
-			filter: {
-				"enum": [
-					"2fa_disabled",
-					"all"
-				],
-				type: "string"
-			},
-			org: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			}
-		},
-		url: "/orgs/:org/outside_collaborators"
-	},
-	listPendingInvitations: {
-		method: "GET",
-		params: {
-			org: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			}
-		},
-		url: "/orgs/:org/invitations"
-	},
-	listPublicMembers: {
-		method: "GET",
-		params: {
-			org: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			}
-		},
-		url: "/orgs/:org/public_members"
-	},
-	pingHook: {
-		method: "POST",
-		params: {
-			hook_id: {
-				required: true,
-				type: "integer"
-			},
-			org: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/orgs/:org/hooks/:hook_id/pings"
-	},
-	publicizeMembership: {
-		method: "PUT",
-		params: {
-			org: {
-				required: true,
-				type: "string"
-			},
-			username: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/orgs/:org/public_members/:username"
-	},
-	removeMember: {
-		method: "DELETE",
-		params: {
-			org: {
-				required: true,
-				type: "string"
-			},
-			username: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/orgs/:org/members/:username"
-	},
-	removeMembership: {
-		method: "DELETE",
-		params: {
-			org: {
-				required: true,
-				type: "string"
-			},
-			username: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/orgs/:org/memberships/:username"
-	},
-	removeOutsideCollaborator: {
-		method: "DELETE",
-		params: {
-			org: {
-				required: true,
-				type: "string"
-			},
-			username: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/orgs/:org/outside_collaborators/:username"
-	},
-	unblockUser: {
-		method: "DELETE",
-		params: {
-			org: {
-				required: true,
-				type: "string"
-			},
-			username: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/orgs/:org/blocks/:username"
-	},
-	update: {
-		method: "PATCH",
-		params: {
-			billing_email: {
-				type: "string"
-			},
-			company: {
-				type: "string"
-			},
-			default_repository_permission: {
-				"enum": [
-					"read",
-					"write",
-					"admin",
-					"none"
-				],
-				type: "string"
-			},
-			description: {
-				type: "string"
-			},
-			email: {
-				type: "string"
-			},
-			has_organization_projects: {
-				type: "boolean"
-			},
-			has_repository_projects: {
-				type: "boolean"
-			},
-			location: {
-				type: "string"
-			},
-			members_allowed_repository_creation_type: {
-				"enum": [
-					"all",
-					"private",
-					"none"
-				],
-				type: "string"
-			},
-			members_can_create_repositories: {
-				type: "boolean"
-			},
-			name: {
-				type: "string"
-			},
-			org: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/orgs/:org"
-	},
-	updateHook: {
-		method: "PATCH",
-		params: {
-			active: {
-				type: "boolean"
-			},
-			config: {
-				type: "object"
-			},
-			"config.content_type": {
-				type: "string"
-			},
-			"config.insecure_ssl": {
-				type: "string"
-			},
-			"config.secret": {
-				type: "string"
-			},
-			"config.url": {
-				required: true,
-				type: "string"
-			},
-			events: {
-				type: "string[]"
-			},
-			hook_id: {
-				required: true,
-				type: "integer"
-			},
-			org: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/orgs/:org/hooks/:hook_id"
-	},
-	updateMembership: {
-		method: "PATCH",
-		params: {
-			org: {
-				required: true,
-				type: "string"
-			},
-			state: {
-				"enum": [
-					"active"
-				],
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/user/memberships/orgs/:org"
-	}
-};
-var projects = {
-	addCollaborator: {
-		headers: {
-			accept: "application/vnd.github.inertia-preview+json"
-		},
-		method: "PUT",
-		params: {
-			permission: {
-				"enum": [
-					"read",
-					"write",
-					"admin"
-				],
-				type: "string"
-			},
-			project_id: {
-				required: true,
-				type: "integer"
-			},
-			username: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/projects/:project_id/collaborators/:username"
-	},
-	createCard: {
-		headers: {
-			accept: "application/vnd.github.inertia-preview+json"
-		},
-		method: "POST",
-		params: {
-			column_id: {
-				required: true,
-				type: "integer"
-			},
-			content_id: {
-				type: "integer"
-			},
-			content_type: {
-				type: "string"
-			},
-			note: {
-				type: "string"
-			}
-		},
-		url: "/projects/columns/:column_id/cards"
-	},
-	createColumn: {
-		headers: {
-			accept: "application/vnd.github.inertia-preview+json"
-		},
-		method: "POST",
-		params: {
-			name: {
-				required: true,
-				type: "string"
-			},
-			project_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/projects/:project_id/columns"
-	},
-	createForAuthenticatedUser: {
-		headers: {
-			accept: "application/vnd.github.inertia-preview+json"
-		},
-		method: "POST",
-		params: {
-			body: {
-				type: "string"
-			},
-			name: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/user/projects"
-	},
-	createForOrg: {
-		headers: {
-			accept: "application/vnd.github.inertia-preview+json"
-		},
-		method: "POST",
-		params: {
-			body: {
-				type: "string"
-			},
-			name: {
-				required: true,
-				type: "string"
-			},
-			org: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/orgs/:org/projects"
-	},
-	createForRepo: {
-		headers: {
-			accept: "application/vnd.github.inertia-preview+json"
-		},
-		method: "POST",
-		params: {
-			body: {
-				type: "string"
-			},
-			name: {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/projects"
-	},
-	"delete": {
-		headers: {
-			accept: "application/vnd.github.inertia-preview+json"
-		},
-		method: "DELETE",
-		params: {
-			project_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/projects/:project_id"
-	},
-	deleteCard: {
-		headers: {
-			accept: "application/vnd.github.inertia-preview+json"
-		},
-		method: "DELETE",
-		params: {
-			card_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/projects/columns/cards/:card_id"
-	},
-	deleteColumn: {
-		headers: {
-			accept: "application/vnd.github.inertia-preview+json"
-		},
-		method: "DELETE",
-		params: {
-			column_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/projects/columns/:column_id"
-	},
-	get: {
-		headers: {
-			accept: "application/vnd.github.inertia-preview+json"
-		},
-		method: "GET",
-		params: {
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			project_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/projects/:project_id"
-	},
-	getCard: {
-		headers: {
-			accept: "application/vnd.github.inertia-preview+json"
-		},
-		method: "GET",
-		params: {
-			card_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/projects/columns/cards/:card_id"
-	},
-	getColumn: {
-		headers: {
-			accept: "application/vnd.github.inertia-preview+json"
-		},
-		method: "GET",
-		params: {
-			column_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/projects/columns/:column_id"
-	},
-	listCards: {
-		headers: {
-			accept: "application/vnd.github.inertia-preview+json"
-		},
-		method: "GET",
-		params: {
-			archived_state: {
-				"enum": [
-					"all",
-					"archived",
-					"not_archived"
-				],
-				type: "string"
-			},
-			column_id: {
-				required: true,
-				type: "integer"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			}
-		},
-		url: "/projects/columns/:column_id/cards"
-	},
-	listCollaborators: {
-		headers: {
-			accept: "application/vnd.github.inertia-preview+json"
-		},
-		method: "GET",
-		params: {
-			affiliation: {
-				"enum": [
-					"outside",
-					"direct",
-					"all"
-				],
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			project_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/projects/:project_id/collaborators"
-	},
-	listColumns: {
-		headers: {
-			accept: "application/vnd.github.inertia-preview+json"
-		},
-		method: "GET",
-		params: {
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			project_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/projects/:project_id/columns"
-	},
-	listForOrg: {
-		headers: {
-			accept: "application/vnd.github.inertia-preview+json"
-		},
-		method: "GET",
-		params: {
-			org: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			state: {
-				"enum": [
-					"open",
-					"closed",
-					"all"
-				],
-				type: "string"
-			}
-		},
-		url: "/orgs/:org/projects"
-	},
-	listForRepo: {
-		headers: {
-			accept: "application/vnd.github.inertia-preview+json"
-		},
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			state: {
-				"enum": [
-					"open",
-					"closed",
-					"all"
-				],
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/projects"
-	},
-	listForUser: {
-		headers: {
-			accept: "application/vnd.github.inertia-preview+json"
-		},
-		method: "GET",
-		params: {
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			state: {
-				"enum": [
-					"open",
-					"closed",
-					"all"
-				],
-				type: "string"
-			},
-			username: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/users/:username/projects"
-	},
-	moveCard: {
-		headers: {
-			accept: "application/vnd.github.inertia-preview+json"
-		},
-		method: "POST",
-		params: {
-			card_id: {
-				required: true,
-				type: "integer"
-			},
-			column_id: {
-				type: "integer"
-			},
-			position: {
-				required: true,
-				type: "string",
-				validation: "^(top|bottom|after:\\d+)$"
-			}
-		},
-		url: "/projects/columns/cards/:card_id/moves"
-	},
-	moveColumn: {
-		headers: {
-			accept: "application/vnd.github.inertia-preview+json"
-		},
-		method: "POST",
-		params: {
-			column_id: {
-				required: true,
-				type: "integer"
-			},
-			position: {
-				required: true,
-				type: "string",
-				validation: "^(first|last|after:\\d+)$"
-			}
-		},
-		url: "/projects/columns/:column_id/moves"
-	},
-	removeCollaborator: {
-		headers: {
-			accept: "application/vnd.github.inertia-preview+json"
-		},
-		method: "DELETE",
-		params: {
-			project_id: {
-				required: true,
-				type: "integer"
-			},
-			username: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/projects/:project_id/collaborators/:username"
-	},
-	reviewUserPermissionLevel: {
-		headers: {
-			accept: "application/vnd.github.inertia-preview+json"
-		},
-		method: "GET",
-		params: {
-			project_id: {
-				required: true,
-				type: "integer"
-			},
-			username: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/projects/:project_id/collaborators/:username/permission"
-	},
-	update: {
-		headers: {
-			accept: "application/vnd.github.inertia-preview+json"
-		},
-		method: "PATCH",
-		params: {
-			body: {
-				type: "string"
-			},
-			name: {
-				type: "string"
-			},
-			organization_permission: {
-				type: "string"
-			},
-			"private": {
-				type: "boolean"
-			},
-			project_id: {
-				required: true,
-				type: "integer"
-			},
-			state: {
-				"enum": [
-					"open",
-					"closed"
-				],
-				type: "string"
-			}
-		},
-		url: "/projects/:project_id"
-	},
-	updateCard: {
-		headers: {
-			accept: "application/vnd.github.inertia-preview+json"
-		},
-		method: "PATCH",
-		params: {
-			archived: {
-				type: "boolean"
-			},
-			card_id: {
-				required: true,
-				type: "integer"
-			},
-			note: {
-				type: "string"
-			}
-		},
-		url: "/projects/columns/cards/:card_id"
-	},
-	updateColumn: {
-		headers: {
-			accept: "application/vnd.github.inertia-preview+json"
-		},
-		method: "PATCH",
-		params: {
-			column_id: {
-				required: true,
-				type: "integer"
-			},
-			name: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/projects/columns/:column_id"
-	}
-};
-var pulls = {
-	checkIfMerged: {
-		method: "GET",
-		params: {
-			number: {
-				alias: "pull_number",
-				deprecated: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			pull_number: {
-				required: true,
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/pulls/:pull_number/merge"
-	},
-	create: {
-		method: "POST",
-		params: {
-			base: {
-				required: true,
-				type: "string"
-			},
-			body: {
-				type: "string"
-			},
-			draft: {
-				type: "boolean"
-			},
-			head: {
-				required: true,
-				type: "string"
-			},
-			maintainer_can_modify: {
-				type: "boolean"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			title: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/pulls"
-	},
-	createComment: {
-		method: "POST",
-		params: {
-			body: {
-				required: true,
-				type: "string"
-			},
-			commit_id: {
-				required: true,
-				type: "string"
-			},
-			in_reply_to: {
-				deprecated: true,
-				description: "The comment ID to reply to. **Note**: This must be the ID of a top-level comment, not a reply to that comment. Replies to replies are not supported.",
-				type: "integer"
-			},
-			line: {
-				type: "integer"
-			},
-			number: {
-				alias: "pull_number",
-				deprecated: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			path: {
-				required: true,
-				type: "string"
-			},
-			position: {
-				type: "integer"
-			},
-			pull_number: {
-				required: true,
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			side: {
-				"enum": [
-					"LEFT",
-					"RIGHT"
-				],
-				type: "string"
-			},
-			start_line: {
-				type: "integer"
-			},
-			start_side: {
-				"enum": [
-					"LEFT",
-					"RIGHT",
-					"side"
-				],
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/pulls/:pull_number/comments"
-	},
-	createCommentReply: {
-		deprecated: "octokit.pulls.createCommentReply() has been renamed to octokit.pulls.createComment() (2019-09-09)",
-		method: "POST",
-		params: {
-			body: {
-				required: true,
-				type: "string"
-			},
-			commit_id: {
-				required: true,
-				type: "string"
-			},
-			in_reply_to: {
-				deprecated: true,
-				description: "The comment ID to reply to. **Note**: This must be the ID of a top-level comment, not a reply to that comment. Replies to replies are not supported.",
-				type: "integer"
-			},
-			line: {
-				type: "integer"
-			},
-			number: {
-				alias: "pull_number",
-				deprecated: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			path: {
-				required: true,
-				type: "string"
-			},
-			position: {
-				type: "integer"
-			},
-			pull_number: {
-				required: true,
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			side: {
-				"enum": [
-					"LEFT",
-					"RIGHT"
-				],
-				type: "string"
-			},
-			start_line: {
-				type: "integer"
-			},
-			start_side: {
-				"enum": [
-					"LEFT",
-					"RIGHT",
-					"side"
-				],
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/pulls/:pull_number/comments"
-	},
-	createFromIssue: {
-		deprecated: "octokit.pulls.createFromIssue() is deprecated, see https://developer.github.com/v3/pulls/#create-a-pull-request",
-		method: "POST",
-		params: {
-			base: {
-				required: true,
-				type: "string"
-			},
-			draft: {
-				type: "boolean"
-			},
-			head: {
-				required: true,
-				type: "string"
-			},
-			issue: {
-				required: true,
-				type: "integer"
-			},
-			maintainer_can_modify: {
-				type: "boolean"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/pulls"
-	},
-	createReview: {
-		method: "POST",
-		params: {
-			body: {
-				type: "string"
-			},
-			comments: {
-				type: "object[]"
-			},
-			"comments[].body": {
-				required: true,
-				type: "string"
-			},
-			"comments[].path": {
-				required: true,
-				type: "string"
-			},
-			"comments[].position": {
-				required: true,
-				type: "integer"
-			},
-			commit_id: {
-				type: "string"
-			},
-			event: {
-				"enum": [
-					"APPROVE",
-					"REQUEST_CHANGES",
-					"COMMENT"
-				],
-				type: "string"
-			},
-			number: {
-				alias: "pull_number",
-				deprecated: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			pull_number: {
-				required: true,
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/pulls/:pull_number/reviews"
-	},
-	createReviewCommentReply: {
-		method: "POST",
-		params: {
-			body: {
-				required: true,
-				type: "string"
-			},
-			comment_id: {
-				required: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			pull_number: {
-				required: true,
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/pulls/:pull_number/comments/:comment_id/replies"
-	},
-	createReviewRequest: {
-		method: "POST",
-		params: {
-			number: {
-				alias: "pull_number",
-				deprecated: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			pull_number: {
-				required: true,
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			reviewers: {
-				type: "string[]"
-			},
-			team_reviewers: {
-				type: "string[]"
-			}
-		},
-		url: "/repos/:owner/:repo/pulls/:pull_number/requested_reviewers"
-	},
-	deleteComment: {
-		method: "DELETE",
-		params: {
-			comment_id: {
-				required: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/pulls/comments/:comment_id"
-	},
-	deletePendingReview: {
-		method: "DELETE",
-		params: {
-			number: {
-				alias: "pull_number",
-				deprecated: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			pull_number: {
-				required: true,
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			review_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/repos/:owner/:repo/pulls/:pull_number/reviews/:review_id"
-	},
-	deleteReviewRequest: {
-		method: "DELETE",
-		params: {
-			number: {
-				alias: "pull_number",
-				deprecated: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			pull_number: {
-				required: true,
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			reviewers: {
-				type: "string[]"
-			},
-			team_reviewers: {
-				type: "string[]"
-			}
-		},
-		url: "/repos/:owner/:repo/pulls/:pull_number/requested_reviewers"
-	},
-	dismissReview: {
-		method: "PUT",
-		params: {
-			message: {
-				required: true,
-				type: "string"
-			},
-			number: {
-				alias: "pull_number",
-				deprecated: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			pull_number: {
-				required: true,
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			review_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/repos/:owner/:repo/pulls/:pull_number/reviews/:review_id/dismissals"
-	},
-	get: {
-		method: "GET",
-		params: {
-			number: {
-				alias: "pull_number",
-				deprecated: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			pull_number: {
-				required: true,
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/pulls/:pull_number"
-	},
-	getComment: {
-		method: "GET",
-		params: {
-			comment_id: {
-				required: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/pulls/comments/:comment_id"
-	},
-	getCommentsForReview: {
-		method: "GET",
-		params: {
-			number: {
-				alias: "pull_number",
-				deprecated: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			pull_number: {
-				required: true,
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			review_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/repos/:owner/:repo/pulls/:pull_number/reviews/:review_id/comments"
-	},
-	getReview: {
-		method: "GET",
-		params: {
-			number: {
-				alias: "pull_number",
-				deprecated: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			pull_number: {
-				required: true,
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			review_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/repos/:owner/:repo/pulls/:pull_number/reviews/:review_id"
-	},
-	list: {
-		method: "GET",
-		params: {
-			base: {
-				type: "string"
-			},
-			direction: {
-				"enum": [
-					"asc",
-					"desc"
-				],
-				type: "string"
-			},
-			head: {
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			sort: {
-				"enum": [
-					"created",
-					"updated",
-					"popularity",
-					"long-running"
-				],
-				type: "string"
-			},
-			state: {
-				"enum": [
-					"open",
-					"closed",
-					"all"
-				],
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/pulls"
-	},
-	listComments: {
-		method: "GET",
-		params: {
-			direction: {
-				"enum": [
-					"asc",
-					"desc"
-				],
-				type: "string"
-			},
-			number: {
-				alias: "pull_number",
-				deprecated: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			pull_number: {
-				required: true,
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			since: {
-				type: "string"
-			},
-			sort: {
-				"enum": [
-					"created",
-					"updated"
-				],
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/pulls/:pull_number/comments"
-	},
-	listCommentsForRepo: {
-		method: "GET",
-		params: {
-			direction: {
-				"enum": [
-					"asc",
-					"desc"
-				],
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			since: {
-				type: "string"
-			},
-			sort: {
-				"enum": [
-					"created",
-					"updated"
-				],
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/pulls/comments"
-	},
-	listCommits: {
-		method: "GET",
-		params: {
-			number: {
-				alias: "pull_number",
-				deprecated: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			pull_number: {
-				required: true,
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/pulls/:pull_number/commits"
-	},
-	listFiles: {
-		method: "GET",
-		params: {
-			number: {
-				alias: "pull_number",
-				deprecated: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			pull_number: {
-				required: true,
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/pulls/:pull_number/files"
-	},
-	listReviewRequests: {
-		method: "GET",
-		params: {
-			number: {
-				alias: "pull_number",
-				deprecated: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			pull_number: {
-				required: true,
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/pulls/:pull_number/requested_reviewers"
-	},
-	listReviews: {
-		method: "GET",
-		params: {
-			number: {
-				alias: "pull_number",
-				deprecated: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			pull_number: {
-				required: true,
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/pulls/:pull_number/reviews"
-	},
-	merge: {
-		method: "PUT",
-		params: {
-			commit_message: {
-				type: "string"
-			},
-			commit_title: {
-				type: "string"
-			},
-			merge_method: {
-				"enum": [
-					"merge",
-					"squash",
-					"rebase"
-				],
-				type: "string"
-			},
-			number: {
-				alias: "pull_number",
-				deprecated: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			pull_number: {
-				required: true,
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			sha: {
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/pulls/:pull_number/merge"
-	},
-	submitReview: {
-		method: "POST",
-		params: {
-			body: {
-				type: "string"
-			},
-			event: {
-				"enum": [
-					"APPROVE",
-					"REQUEST_CHANGES",
-					"COMMENT"
-				],
-				required: true,
-				type: "string"
-			},
-			number: {
-				alias: "pull_number",
-				deprecated: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			pull_number: {
-				required: true,
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			review_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/repos/:owner/:repo/pulls/:pull_number/reviews/:review_id/events"
-	},
-	update: {
-		method: "PATCH",
-		params: {
-			base: {
-				type: "string"
-			},
-			body: {
-				type: "string"
-			},
-			maintainer_can_modify: {
-				type: "boolean"
-			},
-			number: {
-				alias: "pull_number",
-				deprecated: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			pull_number: {
-				required: true,
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			state: {
-				"enum": [
-					"open",
-					"closed"
-				],
-				type: "string"
-			},
-			title: {
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/pulls/:pull_number"
-	},
-	updateBranch: {
-		headers: {
-			accept: "application/vnd.github.lydian-preview+json"
-		},
-		method: "PUT",
-		params: {
-			expected_head_sha: {
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			pull_number: {
-				required: true,
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/pulls/:pull_number/update-branch"
-	},
-	updateComment: {
-		method: "PATCH",
-		params: {
-			body: {
-				required: true,
-				type: "string"
-			},
-			comment_id: {
-				required: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/pulls/comments/:comment_id"
-	},
-	updateReview: {
-		method: "PUT",
-		params: {
-			body: {
-				required: true,
-				type: "string"
-			},
-			number: {
-				alias: "pull_number",
-				deprecated: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			pull_number: {
-				required: true,
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			review_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/repos/:owner/:repo/pulls/:pull_number/reviews/:review_id"
-	}
-};
-var rateLimit = {
-	get: {
-		method: "GET",
-		params: {
-		},
-		url: "/rate_limit"
-	}
-};
-var reactions = {
-	createForCommitComment: {
-		headers: {
-			accept: "application/vnd.github.squirrel-girl-preview+json"
-		},
-		method: "POST",
-		params: {
-			comment_id: {
-				required: true,
-				type: "integer"
-			},
-			content: {
-				"enum": [
-					"+1",
-					"-1",
-					"laugh",
-					"confused",
-					"heart",
-					"hooray",
-					"rocket",
-					"eyes"
-				],
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/comments/:comment_id/reactions"
-	},
-	createForIssue: {
-		headers: {
-			accept: "application/vnd.github.squirrel-girl-preview+json"
-		},
-		method: "POST",
-		params: {
-			content: {
-				"enum": [
-					"+1",
-					"-1",
-					"laugh",
-					"confused",
-					"heart",
-					"hooray",
-					"rocket",
-					"eyes"
-				],
-				required: true,
-				type: "string"
-			},
-			issue_number: {
-				required: true,
-				type: "integer"
-			},
-			number: {
-				alias: "issue_number",
-				deprecated: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/issues/:issue_number/reactions"
-	},
-	createForIssueComment: {
-		headers: {
-			accept: "application/vnd.github.squirrel-girl-preview+json"
-		},
-		method: "POST",
-		params: {
-			comment_id: {
-				required: true,
-				type: "integer"
-			},
-			content: {
-				"enum": [
-					"+1",
-					"-1",
-					"laugh",
-					"confused",
-					"heart",
-					"hooray",
-					"rocket",
-					"eyes"
-				],
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/issues/comments/:comment_id/reactions"
-	},
-	createForPullRequestReviewComment: {
-		headers: {
-			accept: "application/vnd.github.squirrel-girl-preview+json"
-		},
-		method: "POST",
-		params: {
-			comment_id: {
-				required: true,
-				type: "integer"
-			},
-			content: {
-				"enum": [
-					"+1",
-					"-1",
-					"laugh",
-					"confused",
-					"heart",
-					"hooray",
-					"rocket",
-					"eyes"
-				],
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/pulls/comments/:comment_id/reactions"
-	},
-	createForTeamDiscussion: {
-		headers: {
-			accept: "application/vnd.github.echo-preview+json,application/vnd.github.squirrel-girl-preview+json"
-		},
-		method: "POST",
-		params: {
-			content: {
-				"enum": [
-					"+1",
-					"-1",
-					"laugh",
-					"confused",
-					"heart",
-					"hooray",
-					"rocket",
-					"eyes"
-				],
-				required: true,
-				type: "string"
-			},
-			discussion_number: {
-				required: true,
-				type: "integer"
-			},
-			team_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/teams/:team_id/discussions/:discussion_number/reactions"
-	},
-	createForTeamDiscussionComment: {
-		headers: {
-			accept: "application/vnd.github.echo-preview+json,application/vnd.github.squirrel-girl-preview+json"
-		},
-		method: "POST",
-		params: {
-			comment_number: {
-				required: true,
-				type: "integer"
-			},
-			content: {
-				"enum": [
-					"+1",
-					"-1",
-					"laugh",
-					"confused",
-					"heart",
-					"hooray",
-					"rocket",
-					"eyes"
-				],
-				required: true,
-				type: "string"
-			},
-			discussion_number: {
-				required: true,
-				type: "integer"
-			},
-			team_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/teams/:team_id/discussions/:discussion_number/comments/:comment_number/reactions"
-	},
-	"delete": {
-		headers: {
-			accept: "application/vnd.github.echo-preview+json,application/vnd.github.squirrel-girl-preview+json"
-		},
-		method: "DELETE",
-		params: {
-			reaction_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/reactions/:reaction_id"
-	},
-	listForCommitComment: {
-		headers: {
-			accept: "application/vnd.github.squirrel-girl-preview+json"
-		},
-		method: "GET",
-		params: {
-			comment_id: {
-				required: true,
-				type: "integer"
-			},
-			content: {
-				"enum": [
-					"+1",
-					"-1",
-					"laugh",
-					"confused",
-					"heart",
-					"hooray",
-					"rocket",
-					"eyes"
-				],
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/comments/:comment_id/reactions"
-	},
-	listForIssue: {
-		headers: {
-			accept: "application/vnd.github.squirrel-girl-preview+json"
-		},
-		method: "GET",
-		params: {
-			content: {
-				"enum": [
-					"+1",
-					"-1",
-					"laugh",
-					"confused",
-					"heart",
-					"hooray",
-					"rocket",
-					"eyes"
-				],
-				type: "string"
-			},
-			issue_number: {
-				required: true,
-				type: "integer"
-			},
-			number: {
-				alias: "issue_number",
-				deprecated: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/issues/:issue_number/reactions"
-	},
-	listForIssueComment: {
-		headers: {
-			accept: "application/vnd.github.squirrel-girl-preview+json"
-		},
-		method: "GET",
-		params: {
-			comment_id: {
-				required: true,
-				type: "integer"
-			},
-			content: {
-				"enum": [
-					"+1",
-					"-1",
-					"laugh",
-					"confused",
-					"heart",
-					"hooray",
-					"rocket",
-					"eyes"
-				],
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/issues/comments/:comment_id/reactions"
-	},
-	listForPullRequestReviewComment: {
-		headers: {
-			accept: "application/vnd.github.squirrel-girl-preview+json"
-		},
-		method: "GET",
-		params: {
-			comment_id: {
-				required: true,
-				type: "integer"
-			},
-			content: {
-				"enum": [
-					"+1",
-					"-1",
-					"laugh",
-					"confused",
-					"heart",
-					"hooray",
-					"rocket",
-					"eyes"
-				],
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/pulls/comments/:comment_id/reactions"
-	},
-	listForTeamDiscussion: {
-		headers: {
-			accept: "application/vnd.github.echo-preview+json,application/vnd.github.squirrel-girl-preview+json"
-		},
-		method: "GET",
-		params: {
-			content: {
-				"enum": [
-					"+1",
-					"-1",
-					"laugh",
-					"confused",
-					"heart",
-					"hooray",
-					"rocket",
-					"eyes"
-				],
-				type: "string"
-			},
-			discussion_number: {
-				required: true,
-				type: "integer"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			team_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/teams/:team_id/discussions/:discussion_number/reactions"
-	},
-	listForTeamDiscussionComment: {
-		headers: {
-			accept: "application/vnd.github.echo-preview+json,application/vnd.github.squirrel-girl-preview+json"
-		},
-		method: "GET",
-		params: {
-			comment_number: {
-				required: true,
-				type: "integer"
-			},
-			content: {
-				"enum": [
-					"+1",
-					"-1",
-					"laugh",
-					"confused",
-					"heart",
-					"hooray",
-					"rocket",
-					"eyes"
-				],
-				type: "string"
-			},
-			discussion_number: {
-				required: true,
-				type: "integer"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			team_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/teams/:team_id/discussions/:discussion_number/comments/:comment_number/reactions"
-	}
-};
-var repos = {
-	acceptInvitation: {
-		method: "PATCH",
-		params: {
-			invitation_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/user/repository_invitations/:invitation_id"
-	},
-	addCollaborator: {
-		method: "PUT",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			permission: {
-				"enum": [
-					"pull",
-					"push",
-					"admin"
-				],
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			username: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/collaborators/:username"
-	},
-	addDeployKey: {
-		method: "POST",
-		params: {
-			key: {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			read_only: {
-				type: "boolean"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			title: {
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/keys"
-	},
-	addProtectedBranchAdminEnforcement: {
-		method: "POST",
-		params: {
-			branch: {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/branches/:branch/protection/enforce_admins"
-	},
-	addProtectedBranchAppRestrictions: {
-		method: "POST",
-		params: {
-			apps: {
-				mapTo: "data",
-				required: true,
-				type: "string[]"
-			},
-			branch: {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/branches/:branch/protection/restrictions/apps"
-	},
-	addProtectedBranchRequiredSignatures: {
-		headers: {
-			accept: "application/vnd.github.zzzax-preview+json"
-		},
-		method: "POST",
-		params: {
-			branch: {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/branches/:branch/protection/required_signatures"
-	},
-	addProtectedBranchRequiredStatusChecksContexts: {
-		method: "POST",
-		params: {
-			branch: {
-				required: true,
-				type: "string"
-			},
-			contexts: {
-				mapTo: "data",
-				required: true,
-				type: "string[]"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/branches/:branch/protection/required_status_checks/contexts"
-	},
-	addProtectedBranchTeamRestrictions: {
-		method: "POST",
-		params: {
-			branch: {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			teams: {
-				mapTo: "data",
-				required: true,
-				type: "string[]"
-			}
-		},
-		url: "/repos/:owner/:repo/branches/:branch/protection/restrictions/teams"
-	},
-	addProtectedBranchUserRestrictions: {
-		method: "POST",
-		params: {
-			branch: {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			users: {
-				mapTo: "data",
-				required: true,
-				type: "string[]"
-			}
-		},
-		url: "/repos/:owner/:repo/branches/:branch/protection/restrictions/users"
-	},
-	checkCollaborator: {
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			username: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/collaborators/:username"
-	},
-	checkVulnerabilityAlerts: {
-		headers: {
-			accept: "application/vnd.github.dorian-preview+json"
-		},
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/vulnerability-alerts"
-	},
-	compareCommits: {
-		method: "GET",
-		params: {
-			base: {
-				required: true,
-				type: "string"
-			},
-			head: {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/compare/:base...:head"
-	},
-	createCommitComment: {
-		method: "POST",
-		params: {
-			body: {
-				required: true,
-				type: "string"
-			},
-			commit_sha: {
-				required: true,
-				type: "string"
-			},
-			line: {
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			path: {
-				type: "string"
-			},
-			position: {
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			sha: {
-				alias: "commit_sha",
-				deprecated: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/commits/:commit_sha/comments"
-	},
-	createDeployment: {
-		method: "POST",
-		params: {
-			auto_merge: {
-				type: "boolean"
-			},
-			description: {
-				type: "string"
-			},
-			environment: {
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			payload: {
-				type: "string"
-			},
-			production_environment: {
-				type: "boolean"
-			},
-			ref: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			required_contexts: {
-				type: "string[]"
-			},
-			task: {
-				type: "string"
-			},
-			transient_environment: {
-				type: "boolean"
-			}
-		},
-		url: "/repos/:owner/:repo/deployments"
-	},
-	createDeploymentStatus: {
-		method: "POST",
-		params: {
-			auto_inactive: {
-				type: "boolean"
-			},
-			deployment_id: {
-				required: true,
-				type: "integer"
-			},
-			description: {
-				type: "string"
-			},
-			environment: {
-				"enum": [
-					"production",
-					"staging",
-					"qa"
-				],
-				type: "string"
-			},
-			environment_url: {
-				type: "string"
-			},
-			log_url: {
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			state: {
-				"enum": [
-					"error",
-					"failure",
-					"inactive",
-					"in_progress",
-					"queued",
-					"pending",
-					"success"
-				],
-				required: true,
-				type: "string"
-			},
-			target_url: {
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/deployments/:deployment_id/statuses"
-	},
-	createDispatchEvent: {
-		headers: {
-			accept: "application/vnd.github.everest-preview+json"
-		},
-		method: "POST",
-		params: {
-			client_payload: {
-				type: "object"
-			},
-			event_type: {
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/dispatches"
-	},
-	createFile: {
-		deprecated: "octokit.repos.createFile() has been renamed to octokit.repos.createOrUpdateFile() (2019-06-07)",
-		method: "PUT",
-		params: {
-			author: {
-				type: "object"
-			},
-			"author.email": {
-				required: true,
-				type: "string"
-			},
-			"author.name": {
-				required: true,
-				type: "string"
-			},
-			branch: {
-				type: "string"
-			},
-			committer: {
-				type: "object"
-			},
-			"committer.email": {
-				required: true,
-				type: "string"
-			},
-			"committer.name": {
-				required: true,
-				type: "string"
-			},
-			content: {
-				required: true,
-				type: "string"
-			},
-			message: {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			path: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			sha: {
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/contents/:path"
-	},
-	createForAuthenticatedUser: {
-		method: "POST",
-		params: {
-			allow_merge_commit: {
-				type: "boolean"
-			},
-			allow_rebase_merge: {
-				type: "boolean"
-			},
-			allow_squash_merge: {
-				type: "boolean"
-			},
-			auto_init: {
-				type: "boolean"
-			},
-			description: {
-				type: "string"
-			},
-			gitignore_template: {
-				type: "string"
-			},
-			has_issues: {
-				type: "boolean"
-			},
-			has_projects: {
-				type: "boolean"
-			},
-			has_wiki: {
-				type: "boolean"
-			},
-			homepage: {
-				type: "string"
-			},
-			is_template: {
-				type: "boolean"
-			},
-			license_template: {
-				type: "string"
-			},
-			name: {
-				required: true,
-				type: "string"
-			},
-			"private": {
-				type: "boolean"
-			},
-			team_id: {
-				type: "integer"
-			}
-		},
-		url: "/user/repos"
-	},
-	createFork: {
-		method: "POST",
-		params: {
-			organization: {
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/forks"
-	},
-	createHook: {
-		method: "POST",
-		params: {
-			active: {
-				type: "boolean"
-			},
-			config: {
-				required: true,
-				type: "object"
-			},
-			"config.content_type": {
-				type: "string"
-			},
-			"config.insecure_ssl": {
-				type: "string"
-			},
-			"config.secret": {
-				type: "string"
-			},
-			"config.url": {
-				required: true,
-				type: "string"
-			},
-			events: {
-				type: "string[]"
-			},
-			name: {
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/hooks"
-	},
-	createInOrg: {
-		method: "POST",
-		params: {
-			allow_merge_commit: {
-				type: "boolean"
-			},
-			allow_rebase_merge: {
-				type: "boolean"
-			},
-			allow_squash_merge: {
-				type: "boolean"
-			},
-			auto_init: {
-				type: "boolean"
-			},
-			description: {
-				type: "string"
-			},
-			gitignore_template: {
-				type: "string"
-			},
-			has_issues: {
-				type: "boolean"
-			},
-			has_projects: {
-				type: "boolean"
-			},
-			has_wiki: {
-				type: "boolean"
-			},
-			homepage: {
-				type: "string"
-			},
-			is_template: {
-				type: "boolean"
-			},
-			license_template: {
-				type: "string"
-			},
-			name: {
-				required: true,
-				type: "string"
-			},
-			org: {
-				required: true,
-				type: "string"
-			},
-			"private": {
-				type: "boolean"
-			},
-			team_id: {
-				type: "integer"
-			}
-		},
-		url: "/orgs/:org/repos"
-	},
-	createOrUpdateFile: {
-		method: "PUT",
-		params: {
-			author: {
-				type: "object"
-			},
-			"author.email": {
-				required: true,
-				type: "string"
-			},
-			"author.name": {
-				required: true,
-				type: "string"
-			},
-			branch: {
-				type: "string"
-			},
-			committer: {
-				type: "object"
-			},
-			"committer.email": {
-				required: true,
-				type: "string"
-			},
-			"committer.name": {
-				required: true,
-				type: "string"
-			},
-			content: {
-				required: true,
-				type: "string"
-			},
-			message: {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			path: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			sha: {
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/contents/:path"
-	},
-	createRelease: {
-		method: "POST",
-		params: {
-			body: {
-				type: "string"
-			},
-			draft: {
-				type: "boolean"
-			},
-			name: {
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			prerelease: {
-				type: "boolean"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			tag_name: {
-				required: true,
-				type: "string"
-			},
-			target_commitish: {
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/releases"
-	},
-	createStatus: {
-		method: "POST",
-		params: {
-			context: {
-				type: "string"
-			},
-			description: {
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			sha: {
-				required: true,
-				type: "string"
-			},
-			state: {
-				"enum": [
-					"error",
-					"failure",
-					"pending",
-					"success"
-				],
-				required: true,
-				type: "string"
-			},
-			target_url: {
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/statuses/:sha"
-	},
-	createUsingTemplate: {
-		headers: {
-			accept: "application/vnd.github.baptiste-preview+json"
-		},
-		method: "POST",
-		params: {
-			description: {
-				type: "string"
-			},
-			name: {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				type: "string"
-			},
-			"private": {
-				type: "boolean"
-			},
-			template_owner: {
-				required: true,
-				type: "string"
-			},
-			template_repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:template_owner/:template_repo/generate"
-	},
-	declineInvitation: {
-		method: "DELETE",
-		params: {
-			invitation_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/user/repository_invitations/:invitation_id"
-	},
-	"delete": {
-		method: "DELETE",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo"
-	},
-	deleteCommitComment: {
-		method: "DELETE",
-		params: {
-			comment_id: {
-				required: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/comments/:comment_id"
-	},
-	deleteDownload: {
-		method: "DELETE",
-		params: {
-			download_id: {
-				required: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/downloads/:download_id"
-	},
-	deleteFile: {
-		method: "DELETE",
-		params: {
-			author: {
-				type: "object"
-			},
-			"author.email": {
-				type: "string"
-			},
-			"author.name": {
-				type: "string"
-			},
-			branch: {
-				type: "string"
-			},
-			committer: {
-				type: "object"
-			},
-			"committer.email": {
-				type: "string"
-			},
-			"committer.name": {
-				type: "string"
-			},
-			message: {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			path: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			sha: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/contents/:path"
-	},
-	deleteHook: {
-		method: "DELETE",
-		params: {
-			hook_id: {
-				required: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/hooks/:hook_id"
-	},
-	deleteInvitation: {
-		method: "DELETE",
-		params: {
-			invitation_id: {
-				required: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/invitations/:invitation_id"
-	},
-	deleteRelease: {
-		method: "DELETE",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			release_id: {
-				required: true,
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/releases/:release_id"
-	},
-	deleteReleaseAsset: {
-		method: "DELETE",
-		params: {
-			asset_id: {
-				required: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/releases/assets/:asset_id"
-	},
-	disableAutomatedSecurityFixes: {
-		headers: {
-			accept: "application/vnd.github.london-preview+json"
-		},
-		method: "DELETE",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/automated-security-fixes"
-	},
-	disablePagesSite: {
-		headers: {
-			accept: "application/vnd.github.switcheroo-preview+json"
-		},
-		method: "DELETE",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/pages"
-	},
-	disableVulnerabilityAlerts: {
-		headers: {
-			accept: "application/vnd.github.dorian-preview+json"
-		},
-		method: "DELETE",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/vulnerability-alerts"
-	},
-	enableAutomatedSecurityFixes: {
-		headers: {
-			accept: "application/vnd.github.london-preview+json"
-		},
-		method: "PUT",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/automated-security-fixes"
-	},
-	enablePagesSite: {
-		headers: {
-			accept: "application/vnd.github.switcheroo-preview+json"
-		},
-		method: "POST",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			source: {
-				type: "object"
-			},
-			"source.branch": {
-				"enum": [
-					"master",
-					"gh-pages"
-				],
-				type: "string"
-			},
-			"source.path": {
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/pages"
-	},
-	enableVulnerabilityAlerts: {
-		headers: {
-			accept: "application/vnd.github.dorian-preview+json"
-		},
-		method: "PUT",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/vulnerability-alerts"
-	},
-	get: {
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo"
-	},
-	getAppsWithAccessToProtectedBranch: {
-		method: "GET",
-		params: {
-			branch: {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/branches/:branch/protection/restrictions/apps"
-	},
-	getArchiveLink: {
-		method: "GET",
-		params: {
-			archive_format: {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			ref: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/:archive_format/:ref"
-	},
-	getBranch: {
-		method: "GET",
-		params: {
-			branch: {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/branches/:branch"
-	},
-	getBranchProtection: {
-		method: "GET",
-		params: {
-			branch: {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/branches/:branch/protection"
-	},
-	getClones: {
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			per: {
-				"enum": [
-					"day",
-					"week"
-				],
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/traffic/clones"
-	},
-	getCodeFrequencyStats: {
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/stats/code_frequency"
-	},
-	getCollaboratorPermissionLevel: {
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			username: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/collaborators/:username/permission"
-	},
-	getCombinedStatusForRef: {
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			ref: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/commits/:ref/status"
-	},
-	getCommit: {
-		method: "GET",
-		params: {
-			commit_sha: {
-				alias: "ref",
-				deprecated: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			ref: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			sha: {
-				alias: "ref",
-				deprecated: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/commits/:ref"
-	},
-	getCommitActivityStats: {
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/stats/commit_activity"
-	},
-	getCommitComment: {
-		method: "GET",
-		params: {
-			comment_id: {
-				required: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/comments/:comment_id"
-	},
-	getCommitRefSha: {
-		deprecated: "octokit.repos.getCommitRefSha() is deprecated, see https://developer.github.com/v3/repos/commits/#get-a-single-commit",
-		headers: {
-			accept: "application/vnd.github.v3.sha"
-		},
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			ref: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/commits/:ref"
-	},
-	getContents: {
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			path: {
-				required: true,
-				type: "string"
-			},
-			ref: {
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/contents/:path"
-	},
-	getContributorsStats: {
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/stats/contributors"
-	},
-	getDeployKey: {
-		method: "GET",
-		params: {
-			key_id: {
-				required: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/keys/:key_id"
-	},
-	getDeployment: {
-		method: "GET",
-		params: {
-			deployment_id: {
-				required: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/deployments/:deployment_id"
-	},
-	getDeploymentStatus: {
-		method: "GET",
-		params: {
-			deployment_id: {
-				required: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			status_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/repos/:owner/:repo/deployments/:deployment_id/statuses/:status_id"
-	},
-	getDownload: {
-		method: "GET",
-		params: {
-			download_id: {
-				required: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/downloads/:download_id"
-	},
-	getHook: {
-		method: "GET",
-		params: {
-			hook_id: {
-				required: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/hooks/:hook_id"
-	},
-	getLatestPagesBuild: {
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/pages/builds/latest"
-	},
-	getLatestRelease: {
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/releases/latest"
-	},
-	getPages: {
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/pages"
-	},
-	getPagesBuild: {
-		method: "GET",
-		params: {
-			build_id: {
-				required: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/pages/builds/:build_id"
-	},
-	getParticipationStats: {
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/stats/participation"
-	},
-	getProtectedBranchAdminEnforcement: {
-		method: "GET",
-		params: {
-			branch: {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/branches/:branch/protection/enforce_admins"
-	},
-	getProtectedBranchPullRequestReviewEnforcement: {
-		method: "GET",
-		params: {
-			branch: {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/branches/:branch/protection/required_pull_request_reviews"
-	},
-	getProtectedBranchRequiredSignatures: {
-		headers: {
-			accept: "application/vnd.github.zzzax-preview+json"
-		},
-		method: "GET",
-		params: {
-			branch: {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/branches/:branch/protection/required_signatures"
-	},
-	getProtectedBranchRequiredStatusChecks: {
-		method: "GET",
-		params: {
-			branch: {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/branches/:branch/protection/required_status_checks"
-	},
-	getProtectedBranchRestrictions: {
-		method: "GET",
-		params: {
-			branch: {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/branches/:branch/protection/restrictions"
-	},
-	getPunchCardStats: {
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/stats/punch_card"
-	},
-	getReadme: {
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			ref: {
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/readme"
-	},
-	getRelease: {
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			release_id: {
-				required: true,
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/releases/:release_id"
-	},
-	getReleaseAsset: {
-		method: "GET",
-		params: {
-			asset_id: {
-				required: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/releases/assets/:asset_id"
-	},
-	getReleaseByTag: {
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			tag: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/releases/tags/:tag"
-	},
-	getTeamsWithAccessToProtectedBranch: {
-		method: "GET",
-		params: {
-			branch: {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/branches/:branch/protection/restrictions/teams"
-	},
-	getTopPaths: {
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/traffic/popular/paths"
-	},
-	getTopReferrers: {
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/traffic/popular/referrers"
-	},
-	getUsersWithAccessToProtectedBranch: {
-		method: "GET",
-		params: {
-			branch: {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/branches/:branch/protection/restrictions/users"
-	},
-	getViews: {
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			per: {
-				"enum": [
-					"day",
-					"week"
-				],
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/traffic/views"
-	},
-	list: {
-		method: "GET",
-		params: {
-			affiliation: {
-				type: "string"
-			},
-			direction: {
-				"enum": [
-					"asc",
-					"desc"
-				],
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			sort: {
-				"enum": [
-					"created",
-					"updated",
-					"pushed",
-					"full_name"
-				],
-				type: "string"
-			},
-			type: {
-				"enum": [
-					"all",
-					"owner",
-					"public",
-					"private",
-					"member"
-				],
-				type: "string"
-			},
-			visibility: {
-				"enum": [
-					"all",
-					"public",
-					"private"
-				],
-				type: "string"
-			}
-		},
-		url: "/user/repos"
-	},
-	listAppsWithAccessToProtectedBranch: {
-		deprecated: "octokit.repos.listAppsWithAccessToProtectedBranch() has been renamed to octokit.repos.getAppsWithAccessToProtectedBranch() (2019-09-13)",
-		method: "GET",
-		params: {
-			branch: {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/branches/:branch/protection/restrictions/apps"
-	},
-	listAssetsForRelease: {
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			release_id: {
-				required: true,
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/releases/:release_id/assets"
-	},
-	listBranches: {
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			"protected": {
-				type: "boolean"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/branches"
-	},
-	listBranchesForHeadCommit: {
-		headers: {
-			accept: "application/vnd.github.groot-preview+json"
-		},
-		method: "GET",
-		params: {
-			commit_sha: {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/commits/:commit_sha/branches-where-head"
-	},
-	listCollaborators: {
-		method: "GET",
-		params: {
-			affiliation: {
-				"enum": [
-					"outside",
-					"direct",
-					"all"
-				],
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/collaborators"
-	},
-	listCommentsForCommit: {
-		method: "GET",
-		params: {
-			commit_sha: {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			ref: {
-				alias: "commit_sha",
-				deprecated: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/commits/:commit_sha/comments"
-	},
-	listCommitComments: {
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/comments"
-	},
-	listCommits: {
-		method: "GET",
-		params: {
-			author: {
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			path: {
-				type: "string"
-			},
-			per_page: {
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			sha: {
-				type: "string"
-			},
-			since: {
-				type: "string"
-			},
-			until: {
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/commits"
-	},
-	listContributors: {
-		method: "GET",
-		params: {
-			anon: {
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/contributors"
-	},
-	listDeployKeys: {
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/keys"
-	},
-	listDeploymentStatuses: {
-		method: "GET",
-		params: {
-			deployment_id: {
-				required: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/deployments/:deployment_id/statuses"
-	},
-	listDeployments: {
-		method: "GET",
-		params: {
-			environment: {
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			ref: {
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			sha: {
-				type: "string"
-			},
-			task: {
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/deployments"
-	},
-	listDownloads: {
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/downloads"
-	},
-	listForOrg: {
-		method: "GET",
-		params: {
-			direction: {
-				"enum": [
-					"asc",
-					"desc"
-				],
-				type: "string"
-			},
-			org: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			sort: {
-				"enum": [
-					"created",
-					"updated",
-					"pushed",
-					"full_name"
-				],
-				type: "string"
-			},
-			type: {
-				"enum": [
-					"all",
-					"public",
-					"private",
-					"forks",
-					"sources",
-					"member"
-				],
-				type: "string"
-			}
-		},
-		url: "/orgs/:org/repos"
-	},
-	listForUser: {
-		method: "GET",
-		params: {
-			direction: {
-				"enum": [
-					"asc",
-					"desc"
-				],
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			sort: {
-				"enum": [
-					"created",
-					"updated",
-					"pushed",
-					"full_name"
-				],
-				type: "string"
-			},
-			type: {
-				"enum": [
-					"all",
-					"owner",
-					"member"
-				],
-				type: "string"
-			},
-			username: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/users/:username/repos"
-	},
-	listForks: {
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			sort: {
-				"enum": [
-					"newest",
-					"oldest",
-					"stargazers"
-				],
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/forks"
-	},
-	listHooks: {
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/hooks"
-	},
-	listInvitations: {
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/invitations"
-	},
-	listInvitationsForAuthenticatedUser: {
-		method: "GET",
-		params: {
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			}
-		},
-		url: "/user/repository_invitations"
-	},
-	listLanguages: {
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/languages"
-	},
-	listPagesBuilds: {
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/pages/builds"
-	},
-	listProtectedBranchRequiredStatusChecksContexts: {
-		method: "GET",
-		params: {
-			branch: {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/branches/:branch/protection/required_status_checks/contexts"
-	},
-	listProtectedBranchTeamRestrictions: {
-		deprecated: "octokit.repos.listProtectedBranchTeamRestrictions() has been renamed to octokit.repos.getTeamsWithAccessToProtectedBranch() (2019-09-09)",
-		method: "GET",
-		params: {
-			branch: {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/branches/:branch/protection/restrictions/teams"
-	},
-	listProtectedBranchUserRestrictions: {
-		deprecated: "octokit.repos.listProtectedBranchUserRestrictions() has been renamed to octokit.repos.getUsersWithAccessToProtectedBranch() (2019-09-09)",
-		method: "GET",
-		params: {
-			branch: {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/branches/:branch/protection/restrictions/users"
-	},
-	listPublic: {
-		method: "GET",
-		params: {
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			since: {
-				type: "string"
-			}
-		},
-		url: "/repositories"
-	},
-	listPullRequestsAssociatedWithCommit: {
-		headers: {
-			accept: "application/vnd.github.groot-preview+json"
-		},
-		method: "GET",
-		params: {
-			commit_sha: {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/commits/:commit_sha/pulls"
-	},
-	listReleases: {
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/releases"
-	},
-	listStatusesForRef: {
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			ref: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/commits/:ref/statuses"
-	},
-	listTags: {
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/tags"
-	},
-	listTeams: {
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/teams"
-	},
-	listTeamsWithAccessToProtectedBranch: {
-		deprecated: "octokit.repos.listTeamsWithAccessToProtectedBranch() has been renamed to octokit.repos.getTeamsWithAccessToProtectedBranch() (2019-09-13)",
-		method: "GET",
-		params: {
-			branch: {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/branches/:branch/protection/restrictions/teams"
-	},
-	listTopics: {
-		headers: {
-			accept: "application/vnd.github.mercy-preview+json"
-		},
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/topics"
-	},
-	listUsersWithAccessToProtectedBranch: {
-		deprecated: "octokit.repos.listUsersWithAccessToProtectedBranch() has been renamed to octokit.repos.getUsersWithAccessToProtectedBranch() (2019-09-13)",
-		method: "GET",
-		params: {
-			branch: {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/branches/:branch/protection/restrictions/users"
-	},
-	merge: {
-		method: "POST",
-		params: {
-			base: {
-				required: true,
-				type: "string"
-			},
-			commit_message: {
-				type: "string"
-			},
-			head: {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/merges"
-	},
-	pingHook: {
-		method: "POST",
-		params: {
-			hook_id: {
-				required: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/hooks/:hook_id/pings"
-	},
-	removeBranchProtection: {
-		method: "DELETE",
-		params: {
-			branch: {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/branches/:branch/protection"
-	},
-	removeCollaborator: {
-		method: "DELETE",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			username: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/collaborators/:username"
-	},
-	removeDeployKey: {
-		method: "DELETE",
-		params: {
-			key_id: {
-				required: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/keys/:key_id"
-	},
-	removeProtectedBranchAdminEnforcement: {
-		method: "DELETE",
-		params: {
-			branch: {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/branches/:branch/protection/enforce_admins"
-	},
-	removeProtectedBranchAppRestrictions: {
-		method: "DELETE",
-		params: {
-			apps: {
-				mapTo: "data",
-				required: true,
-				type: "string[]"
-			},
-			branch: {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/branches/:branch/protection/restrictions/apps"
-	},
-	removeProtectedBranchPullRequestReviewEnforcement: {
-		method: "DELETE",
-		params: {
-			branch: {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/branches/:branch/protection/required_pull_request_reviews"
-	},
-	removeProtectedBranchRequiredSignatures: {
-		headers: {
-			accept: "application/vnd.github.zzzax-preview+json"
-		},
-		method: "DELETE",
-		params: {
-			branch: {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/branches/:branch/protection/required_signatures"
-	},
-	removeProtectedBranchRequiredStatusChecks: {
-		method: "DELETE",
-		params: {
-			branch: {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/branches/:branch/protection/required_status_checks"
-	},
-	removeProtectedBranchRequiredStatusChecksContexts: {
-		method: "DELETE",
-		params: {
-			branch: {
-				required: true,
-				type: "string"
-			},
-			contexts: {
-				mapTo: "data",
-				required: true,
-				type: "string[]"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/branches/:branch/protection/required_status_checks/contexts"
-	},
-	removeProtectedBranchRestrictions: {
-		method: "DELETE",
-		params: {
-			branch: {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/branches/:branch/protection/restrictions"
-	},
-	removeProtectedBranchTeamRestrictions: {
-		method: "DELETE",
-		params: {
-			branch: {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			teams: {
-				mapTo: "data",
-				required: true,
-				type: "string[]"
-			}
-		},
-		url: "/repos/:owner/:repo/branches/:branch/protection/restrictions/teams"
-	},
-	removeProtectedBranchUserRestrictions: {
-		method: "DELETE",
-		params: {
-			branch: {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			users: {
-				mapTo: "data",
-				required: true,
-				type: "string[]"
-			}
-		},
-		url: "/repos/:owner/:repo/branches/:branch/protection/restrictions/users"
-	},
-	replaceProtectedBranchAppRestrictions: {
-		method: "PUT",
-		params: {
-			apps: {
-				mapTo: "data",
-				required: true,
-				type: "string[]"
-			},
-			branch: {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/branches/:branch/protection/restrictions/apps"
-	},
-	replaceProtectedBranchRequiredStatusChecksContexts: {
-		method: "PUT",
-		params: {
-			branch: {
-				required: true,
-				type: "string"
-			},
-			contexts: {
-				mapTo: "data",
-				required: true,
-				type: "string[]"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/branches/:branch/protection/required_status_checks/contexts"
-	},
-	replaceProtectedBranchTeamRestrictions: {
-		method: "PUT",
-		params: {
-			branch: {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			teams: {
-				mapTo: "data",
-				required: true,
-				type: "string[]"
-			}
-		},
-		url: "/repos/:owner/:repo/branches/:branch/protection/restrictions/teams"
-	},
-	replaceProtectedBranchUserRestrictions: {
-		method: "PUT",
-		params: {
-			branch: {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			users: {
-				mapTo: "data",
-				required: true,
-				type: "string[]"
-			}
-		},
-		url: "/repos/:owner/:repo/branches/:branch/protection/restrictions/users"
-	},
-	replaceTopics: {
-		headers: {
-			accept: "application/vnd.github.mercy-preview+json"
-		},
-		method: "PUT",
-		params: {
-			names: {
-				required: true,
-				type: "string[]"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/topics"
-	},
-	requestPageBuild: {
-		method: "POST",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/pages/builds"
-	},
-	retrieveCommunityProfileMetrics: {
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/community/profile"
-	},
-	testPushHook: {
-		method: "POST",
-		params: {
-			hook_id: {
-				required: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/hooks/:hook_id/tests"
-	},
-	transfer: {
-		headers: {
-			accept: "application/vnd.github.nightshade-preview+json"
-		},
-		method: "POST",
-		params: {
-			new_owner: {
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			team_ids: {
-				type: "integer[]"
-			}
-		},
-		url: "/repos/:owner/:repo/transfer"
-	},
-	update: {
-		method: "PATCH",
-		params: {
-			allow_merge_commit: {
-				type: "boolean"
-			},
-			allow_rebase_merge: {
-				type: "boolean"
-			},
-			allow_squash_merge: {
-				type: "boolean"
-			},
-			archived: {
-				type: "boolean"
-			},
-			default_branch: {
-				type: "string"
-			},
-			description: {
-				type: "string"
-			},
-			has_issues: {
-				type: "boolean"
-			},
-			has_projects: {
-				type: "boolean"
-			},
-			has_wiki: {
-				type: "boolean"
-			},
-			homepage: {
-				type: "string"
-			},
-			is_template: {
-				type: "boolean"
-			},
-			name: {
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			"private": {
-				type: "boolean"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo"
-	},
-	updateBranchProtection: {
-		method: "PUT",
-		params: {
-			branch: {
-				required: true,
-				type: "string"
-			},
-			enforce_admins: {
-				allowNull: true,
-				required: true,
-				type: "boolean"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			required_pull_request_reviews: {
-				allowNull: true,
-				required: true,
-				type: "object"
-			},
-			"required_pull_request_reviews.dismiss_stale_reviews": {
-				type: "boolean"
-			},
-			"required_pull_request_reviews.dismissal_restrictions": {
-				type: "object"
-			},
-			"required_pull_request_reviews.dismissal_restrictions.teams": {
-				type: "string[]"
-			},
-			"required_pull_request_reviews.dismissal_restrictions.users": {
-				type: "string[]"
-			},
-			"required_pull_request_reviews.require_code_owner_reviews": {
-				type: "boolean"
-			},
-			"required_pull_request_reviews.required_approving_review_count": {
-				type: "integer"
-			},
-			required_status_checks: {
-				allowNull: true,
-				required: true,
-				type: "object"
-			},
-			"required_status_checks.contexts": {
-				required: true,
-				type: "string[]"
-			},
-			"required_status_checks.strict": {
-				required: true,
-				type: "boolean"
-			},
-			restrictions: {
-				allowNull: true,
-				required: true,
-				type: "object"
-			},
-			"restrictions.apps": {
-				type: "string[]"
-			},
-			"restrictions.teams": {
-				required: true,
-				type: "string[]"
-			},
-			"restrictions.users": {
-				required: true,
-				type: "string[]"
-			}
-		},
-		url: "/repos/:owner/:repo/branches/:branch/protection"
-	},
-	updateCommitComment: {
-		method: "PATCH",
-		params: {
-			body: {
-				required: true,
-				type: "string"
-			},
-			comment_id: {
-				required: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/comments/:comment_id"
-	},
-	updateFile: {
-		deprecated: "octokit.repos.updateFile() has been renamed to octokit.repos.createOrUpdateFile() (2019-06-07)",
-		method: "PUT",
-		params: {
-			author: {
-				type: "object"
-			},
-			"author.email": {
-				required: true,
-				type: "string"
-			},
-			"author.name": {
-				required: true,
-				type: "string"
-			},
-			branch: {
-				type: "string"
-			},
-			committer: {
-				type: "object"
-			},
-			"committer.email": {
-				required: true,
-				type: "string"
-			},
-			"committer.name": {
-				required: true,
-				type: "string"
-			},
-			content: {
-				required: true,
-				type: "string"
-			},
-			message: {
-				required: true,
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			path: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			sha: {
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/contents/:path"
-	},
-	updateHook: {
-		method: "PATCH",
-		params: {
-			active: {
-				type: "boolean"
-			},
-			add_events: {
-				type: "string[]"
-			},
-			config: {
-				type: "object"
-			},
-			"config.content_type": {
-				type: "string"
-			},
-			"config.insecure_ssl": {
-				type: "string"
-			},
-			"config.secret": {
-				type: "string"
-			},
-			"config.url": {
-				required: true,
-				type: "string"
-			},
-			events: {
-				type: "string[]"
-			},
-			hook_id: {
-				required: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			remove_events: {
-				type: "string[]"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/hooks/:hook_id"
-	},
-	updateInformationAboutPagesSite: {
-		method: "PUT",
-		params: {
-			cname: {
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			source: {
-				"enum": [
-					"\"gh-pages\"",
-					"\"master\"",
-					"\"master /docs\""
-				],
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/pages"
-	},
-	updateInvitation: {
-		method: "PATCH",
-		params: {
-			invitation_id: {
-				required: true,
-				type: "integer"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			permissions: {
-				"enum": [
-					"read",
-					"write",
-					"admin"
-				],
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/invitations/:invitation_id"
-	},
-	updateProtectedBranchPullRequestReviewEnforcement: {
-		method: "PATCH",
-		params: {
-			branch: {
-				required: true,
-				type: "string"
-			},
-			dismiss_stale_reviews: {
-				type: "boolean"
-			},
-			dismissal_restrictions: {
-				type: "object"
-			},
-			"dismissal_restrictions.teams": {
-				type: "string[]"
-			},
-			"dismissal_restrictions.users": {
-				type: "string[]"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			require_code_owner_reviews: {
-				type: "boolean"
-			},
-			required_approving_review_count: {
-				type: "integer"
-			}
-		},
-		url: "/repos/:owner/:repo/branches/:branch/protection/required_pull_request_reviews"
-	},
-	updateProtectedBranchRequiredStatusChecks: {
-		method: "PATCH",
-		params: {
-			branch: {
-				required: true,
-				type: "string"
-			},
-			contexts: {
-				type: "string[]"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			strict: {
-				type: "boolean"
-			}
-		},
-		url: "/repos/:owner/:repo/branches/:branch/protection/required_status_checks"
-	},
-	updateRelease: {
-		method: "PATCH",
-		params: {
-			body: {
-				type: "string"
-			},
-			draft: {
-				type: "boolean"
-			},
-			name: {
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			prerelease: {
-				type: "boolean"
-			},
-			release_id: {
-				required: true,
-				type: "integer"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			tag_name: {
-				type: "string"
-			},
-			target_commitish: {
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/releases/:release_id"
-	},
-	updateReleaseAsset: {
-		method: "PATCH",
-		params: {
-			asset_id: {
-				required: true,
-				type: "integer"
-			},
-			label: {
-				type: "string"
-			},
-			name: {
-				type: "string"
-			},
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/repos/:owner/:repo/releases/assets/:asset_id"
-	},
-	uploadReleaseAsset: {
-		method: "POST",
-		params: {
-			file: {
-				mapTo: "data",
-				required: true,
-				type: "string | object"
-			},
-			headers: {
-				required: true,
-				type: "object"
-			},
-			"headers.content-length": {
-				required: true,
-				type: "integer"
-			},
-			"headers.content-type": {
-				required: true,
-				type: "string"
-			},
-			label: {
-				type: "string"
-			},
-			name: {
-				required: true,
-				type: "string"
-			},
-			url: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: ":url"
-	}
-};
-var search = {
-	code: {
-		method: "GET",
-		params: {
-			order: {
-				"enum": [
-					"desc",
-					"asc"
-				],
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			q: {
-				required: true,
-				type: "string"
-			},
-			sort: {
-				"enum": [
-					"indexed"
-				],
-				type: "string"
-			}
-		},
-		url: "/search/code"
-	},
-	commits: {
-		headers: {
-			accept: "application/vnd.github.cloak-preview+json"
-		},
-		method: "GET",
-		params: {
-			order: {
-				"enum": [
-					"desc",
-					"asc"
-				],
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			q: {
-				required: true,
-				type: "string"
-			},
-			sort: {
-				"enum": [
-					"author-date",
-					"committer-date"
-				],
-				type: "string"
-			}
-		},
-		url: "/search/commits"
-	},
-	issues: {
-		deprecated: "octokit.search.issues() has been renamed to octokit.search.issuesAndPullRequests() (2018-12-27)",
-		method: "GET",
-		params: {
-			order: {
-				"enum": [
-					"desc",
-					"asc"
-				],
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			q: {
-				required: true,
-				type: "string"
-			},
-			sort: {
-				"enum": [
-					"comments",
-					"reactions",
-					"reactions-+1",
-					"reactions--1",
-					"reactions-smile",
-					"reactions-thinking_face",
-					"reactions-heart",
-					"reactions-tada",
-					"interactions",
-					"created",
-					"updated"
-				],
-				type: "string"
-			}
-		},
-		url: "/search/issues"
-	},
-	issuesAndPullRequests: {
-		method: "GET",
-		params: {
-			order: {
-				"enum": [
-					"desc",
-					"asc"
-				],
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			q: {
-				required: true,
-				type: "string"
-			},
-			sort: {
-				"enum": [
-					"comments",
-					"reactions",
-					"reactions-+1",
-					"reactions--1",
-					"reactions-smile",
-					"reactions-thinking_face",
-					"reactions-heart",
-					"reactions-tada",
-					"interactions",
-					"created",
-					"updated"
-				],
-				type: "string"
-			}
-		},
-		url: "/search/issues"
-	},
-	labels: {
-		method: "GET",
-		params: {
-			order: {
-				"enum": [
-					"desc",
-					"asc"
-				],
-				type: "string"
-			},
-			q: {
-				required: true,
-				type: "string"
-			},
-			repository_id: {
-				required: true,
-				type: "integer"
-			},
-			sort: {
-				"enum": [
-					"created",
-					"updated"
-				],
-				type: "string"
-			}
-		},
-		url: "/search/labels"
-	},
-	repos: {
-		method: "GET",
-		params: {
-			order: {
-				"enum": [
-					"desc",
-					"asc"
-				],
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			q: {
-				required: true,
-				type: "string"
-			},
-			sort: {
-				"enum": [
-					"stars",
-					"forks",
-					"help-wanted-issues",
-					"updated"
-				],
-				type: "string"
-			}
-		},
-		url: "/search/repositories"
-	},
-	topics: {
-		method: "GET",
-		params: {
-			q: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/search/topics"
-	},
-	users: {
-		method: "GET",
-		params: {
-			order: {
-				"enum": [
-					"desc",
-					"asc"
-				],
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			q: {
-				required: true,
-				type: "string"
-			},
-			sort: {
-				"enum": [
-					"followers",
-					"repositories",
-					"joined"
-				],
-				type: "string"
-			}
-		},
-		url: "/search/users"
-	}
-};
-var teams = {
-	addMember: {
-		deprecated: "octokit.teams.addMember() is deprecated, see https://developer.github.com/v3/teams/members/#add-team-member",
-		method: "PUT",
-		params: {
-			team_id: {
-				required: true,
-				type: "integer"
-			},
-			username: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/teams/:team_id/members/:username"
-	},
-	addOrUpdateMembership: {
-		method: "PUT",
-		params: {
-			role: {
-				"enum": [
-					"member",
-					"maintainer"
-				],
-				type: "string"
-			},
-			team_id: {
-				required: true,
-				type: "integer"
-			},
-			username: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/teams/:team_id/memberships/:username"
-	},
-	addOrUpdateProject: {
-		headers: {
-			accept: "application/vnd.github.inertia-preview+json"
-		},
-		method: "PUT",
-		params: {
-			permission: {
-				"enum": [
-					"read",
-					"write",
-					"admin"
-				],
-				type: "string"
-			},
-			project_id: {
-				required: true,
-				type: "integer"
-			},
-			team_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/teams/:team_id/projects/:project_id"
-	},
-	addOrUpdateRepo: {
-		method: "PUT",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			permission: {
-				"enum": [
-					"pull",
-					"push",
-					"admin"
-				],
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			team_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/teams/:team_id/repos/:owner/:repo"
-	},
-	checkManagesRepo: {
-		method: "GET",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			team_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/teams/:team_id/repos/:owner/:repo"
-	},
-	create: {
-		method: "POST",
-		params: {
-			description: {
-				type: "string"
-			},
-			maintainers: {
-				type: "string[]"
-			},
-			name: {
-				required: true,
-				type: "string"
-			},
-			org: {
-				required: true,
-				type: "string"
-			},
-			parent_team_id: {
-				type: "integer"
-			},
-			permission: {
-				"enum": [
-					"pull",
-					"push",
-					"admin"
-				],
-				type: "string"
-			},
-			privacy: {
-				"enum": [
-					"secret",
-					"closed"
-				],
-				type: "string"
-			},
-			repo_names: {
-				type: "string[]"
-			}
-		},
-		url: "/orgs/:org/teams"
-	},
-	createDiscussion: {
-		headers: {
-			accept: "application/vnd.github.echo-preview+json"
-		},
-		method: "POST",
-		params: {
-			body: {
-				required: true,
-				type: "string"
-			},
-			"private": {
-				type: "boolean"
-			},
-			team_id: {
-				required: true,
-				type: "integer"
-			},
-			title: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/teams/:team_id/discussions"
-	},
-	createDiscussionComment: {
-		headers: {
-			accept: "application/vnd.github.echo-preview+json"
-		},
-		method: "POST",
-		params: {
-			body: {
-				required: true,
-				type: "string"
-			},
-			discussion_number: {
-				required: true,
-				type: "integer"
-			},
-			team_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/teams/:team_id/discussions/:discussion_number/comments"
-	},
-	"delete": {
-		method: "DELETE",
-		params: {
-			team_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/teams/:team_id"
-	},
-	deleteDiscussion: {
-		headers: {
-			accept: "application/vnd.github.echo-preview+json"
-		},
-		method: "DELETE",
-		params: {
-			discussion_number: {
-				required: true,
-				type: "integer"
-			},
-			team_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/teams/:team_id/discussions/:discussion_number"
-	},
-	deleteDiscussionComment: {
-		headers: {
-			accept: "application/vnd.github.echo-preview+json"
-		},
-		method: "DELETE",
-		params: {
-			comment_number: {
-				required: true,
-				type: "integer"
-			},
-			discussion_number: {
-				required: true,
-				type: "integer"
-			},
-			team_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/teams/:team_id/discussions/:discussion_number/comments/:comment_number"
-	},
-	get: {
-		method: "GET",
-		params: {
-			team_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/teams/:team_id"
-	},
-	getByName: {
-		method: "GET",
-		params: {
-			org: {
-				required: true,
-				type: "string"
-			},
-			team_slug: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/orgs/:org/teams/:team_slug"
-	},
-	getDiscussion: {
-		headers: {
-			accept: "application/vnd.github.echo-preview+json"
-		},
-		method: "GET",
-		params: {
-			discussion_number: {
-				required: true,
-				type: "integer"
-			},
-			team_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/teams/:team_id/discussions/:discussion_number"
-	},
-	getDiscussionComment: {
-		headers: {
-			accept: "application/vnd.github.echo-preview+json"
-		},
-		method: "GET",
-		params: {
-			comment_number: {
-				required: true,
-				type: "integer"
-			},
-			discussion_number: {
-				required: true,
-				type: "integer"
-			},
-			team_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/teams/:team_id/discussions/:discussion_number/comments/:comment_number"
-	},
-	getMember: {
-		deprecated: "octokit.teams.getMember() is deprecated, see https://developer.github.com/v3/teams/members/#get-team-member",
-		method: "GET",
-		params: {
-			team_id: {
-				required: true,
-				type: "integer"
-			},
-			username: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/teams/:team_id/members/:username"
-	},
-	getMembership: {
-		method: "GET",
-		params: {
-			team_id: {
-				required: true,
-				type: "integer"
-			},
-			username: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/teams/:team_id/memberships/:username"
-	},
-	list: {
-		method: "GET",
-		params: {
-			org: {
-				required: true,
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			}
-		},
-		url: "/orgs/:org/teams"
-	},
-	listChild: {
-		headers: {
-			accept: "application/vnd.github.hellcat-preview+json"
-		},
-		method: "GET",
-		params: {
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			team_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/teams/:team_id/teams"
-	},
-	listDiscussionComments: {
-		headers: {
-			accept: "application/vnd.github.echo-preview+json"
-		},
-		method: "GET",
-		params: {
-			direction: {
-				"enum": [
-					"asc",
-					"desc"
-				],
-				type: "string"
-			},
-			discussion_number: {
-				required: true,
-				type: "integer"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			team_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/teams/:team_id/discussions/:discussion_number/comments"
-	},
-	listDiscussions: {
-		headers: {
-			accept: "application/vnd.github.echo-preview+json"
-		},
-		method: "GET",
-		params: {
-			direction: {
-				"enum": [
-					"asc",
-					"desc"
-				],
-				type: "string"
-			},
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			team_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/teams/:team_id/discussions"
-	},
-	listForAuthenticatedUser: {
-		method: "GET",
-		params: {
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			}
-		},
-		url: "/user/teams"
-	},
-	listMembers: {
-		method: "GET",
-		params: {
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			role: {
-				"enum": [
-					"member",
-					"maintainer",
-					"all"
-				],
-				type: "string"
-			},
-			team_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/teams/:team_id/members"
-	},
-	listPendingInvitations: {
-		method: "GET",
-		params: {
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			team_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/teams/:team_id/invitations"
-	},
-	listProjects: {
-		headers: {
-			accept: "application/vnd.github.inertia-preview+json"
-		},
-		method: "GET",
-		params: {
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			team_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/teams/:team_id/projects"
-	},
-	listRepos: {
-		method: "GET",
-		params: {
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			team_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/teams/:team_id/repos"
-	},
-	removeMember: {
-		deprecated: "octokit.teams.removeMember() is deprecated, see https://developer.github.com/v3/teams/members/#remove-team-member",
-		method: "DELETE",
-		params: {
-			team_id: {
-				required: true,
-				type: "integer"
-			},
-			username: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/teams/:team_id/members/:username"
-	},
-	removeMembership: {
-		method: "DELETE",
-		params: {
-			team_id: {
-				required: true,
-				type: "integer"
-			},
-			username: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/teams/:team_id/memberships/:username"
-	},
-	removeProject: {
-		method: "DELETE",
-		params: {
-			project_id: {
-				required: true,
-				type: "integer"
-			},
-			team_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/teams/:team_id/projects/:project_id"
-	},
-	removeRepo: {
-		method: "DELETE",
-		params: {
-			owner: {
-				required: true,
-				type: "string"
-			},
-			repo: {
-				required: true,
-				type: "string"
-			},
-			team_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/teams/:team_id/repos/:owner/:repo"
-	},
-	reviewProject: {
-		headers: {
-			accept: "application/vnd.github.inertia-preview+json"
-		},
-		method: "GET",
-		params: {
-			project_id: {
-				required: true,
-				type: "integer"
-			},
-			team_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/teams/:team_id/projects/:project_id"
-	},
-	update: {
-		method: "PATCH",
-		params: {
-			description: {
-				type: "string"
-			},
-			name: {
-				required: true,
-				type: "string"
-			},
-			parent_team_id: {
-				type: "integer"
-			},
-			permission: {
-				"enum": [
-					"pull",
-					"push",
-					"admin"
-				],
-				type: "string"
-			},
-			privacy: {
-				"enum": [
-					"secret",
-					"closed"
-				],
-				type: "string"
-			},
-			team_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/teams/:team_id"
-	},
-	updateDiscussion: {
-		headers: {
-			accept: "application/vnd.github.echo-preview+json"
-		},
-		method: "PATCH",
-		params: {
-			body: {
-				type: "string"
-			},
-			discussion_number: {
-				required: true,
-				type: "integer"
-			},
-			team_id: {
-				required: true,
-				type: "integer"
-			},
-			title: {
-				type: "string"
-			}
-		},
-		url: "/teams/:team_id/discussions/:discussion_number"
-	},
-	updateDiscussionComment: {
-		headers: {
-			accept: "application/vnd.github.echo-preview+json"
-		},
-		method: "PATCH",
-		params: {
-			body: {
-				required: true,
-				type: "string"
-			},
-			comment_number: {
-				required: true,
-				type: "integer"
-			},
-			discussion_number: {
-				required: true,
-				type: "integer"
-			},
-			team_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/teams/:team_id/discussions/:discussion_number/comments/:comment_number"
-	}
-};
-var users = {
-	addEmails: {
-		method: "POST",
-		params: {
-			emails: {
-				required: true,
-				type: "string[]"
-			}
-		},
-		url: "/user/emails"
-	},
-	block: {
-		method: "PUT",
-		params: {
-			username: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/user/blocks/:username"
-	},
-	checkBlocked: {
-		method: "GET",
-		params: {
-			username: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/user/blocks/:username"
-	},
-	checkFollowing: {
-		method: "GET",
-		params: {
-			username: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/user/following/:username"
-	},
-	checkFollowingForUser: {
-		method: "GET",
-		params: {
-			target_user: {
-				required: true,
-				type: "string"
-			},
-			username: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/users/:username/following/:target_user"
-	},
-	createGpgKey: {
-		method: "POST",
-		params: {
-			armored_public_key: {
-				type: "string"
-			}
-		},
-		url: "/user/gpg_keys"
-	},
-	createPublicKey: {
-		method: "POST",
-		params: {
-			key: {
-				type: "string"
-			},
-			title: {
-				type: "string"
-			}
-		},
-		url: "/user/keys"
-	},
-	deleteEmails: {
-		method: "DELETE",
-		params: {
-			emails: {
-				required: true,
-				type: "string[]"
-			}
-		},
-		url: "/user/emails"
-	},
-	deleteGpgKey: {
-		method: "DELETE",
-		params: {
-			gpg_key_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/user/gpg_keys/:gpg_key_id"
-	},
-	deletePublicKey: {
-		method: "DELETE",
-		params: {
-			key_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/user/keys/:key_id"
-	},
-	follow: {
-		method: "PUT",
-		params: {
-			username: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/user/following/:username"
-	},
-	getAuthenticated: {
-		method: "GET",
-		params: {
-		},
-		url: "/user"
-	},
-	getByUsername: {
-		method: "GET",
-		params: {
-			username: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/users/:username"
-	},
-	getContextForUser: {
-		headers: {
-			accept: "application/vnd.github.hagar-preview+json"
-		},
-		method: "GET",
-		params: {
-			subject_id: {
-				type: "string"
-			},
-			subject_type: {
-				"enum": [
-					"organization",
-					"repository",
-					"issue",
-					"pull_request"
-				],
-				type: "string"
-			},
-			username: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/users/:username/hovercard"
-	},
-	getGpgKey: {
-		method: "GET",
-		params: {
-			gpg_key_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/user/gpg_keys/:gpg_key_id"
-	},
-	getPublicKey: {
-		method: "GET",
-		params: {
-			key_id: {
-				required: true,
-				type: "integer"
-			}
-		},
-		url: "/user/keys/:key_id"
-	},
-	list: {
-		method: "GET",
-		params: {
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			since: {
-				type: "string"
-			}
-		},
-		url: "/users"
-	},
-	listBlocked: {
-		method: "GET",
-		params: {
-		},
-		url: "/user/blocks"
-	},
-	listEmails: {
-		method: "GET",
-		params: {
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			}
-		},
-		url: "/user/emails"
-	},
-	listFollowersForAuthenticatedUser: {
-		method: "GET",
-		params: {
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			}
-		},
-		url: "/user/followers"
-	},
-	listFollowersForUser: {
-		method: "GET",
-		params: {
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			username: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/users/:username/followers"
-	},
-	listFollowingForAuthenticatedUser: {
-		method: "GET",
-		params: {
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			}
-		},
-		url: "/user/following"
-	},
-	listFollowingForUser: {
-		method: "GET",
-		params: {
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			username: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/users/:username/following"
-	},
-	listGpgKeys: {
-		method: "GET",
-		params: {
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			}
-		},
-		url: "/user/gpg_keys"
-	},
-	listGpgKeysForUser: {
-		method: "GET",
-		params: {
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			username: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/users/:username/gpg_keys"
-	},
-	listPublicEmails: {
-		method: "GET",
-		params: {
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			}
-		},
-		url: "/user/public_emails"
-	},
-	listPublicKeys: {
-		method: "GET",
-		params: {
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			}
-		},
-		url: "/user/keys"
-	},
-	listPublicKeysForUser: {
-		method: "GET",
-		params: {
-			page: {
-				type: "integer"
-			},
-			per_page: {
-				type: "integer"
-			},
-			username: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/users/:username/keys"
-	},
-	togglePrimaryEmailVisibility: {
-		method: "PATCH",
-		params: {
-			email: {
-				required: true,
-				type: "string"
-			},
-			visibility: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/user/email/visibility"
-	},
-	unblock: {
-		method: "DELETE",
-		params: {
-			username: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/user/blocks/:username"
-	},
-	unfollow: {
-		method: "DELETE",
-		params: {
-			username: {
-				required: true,
-				type: "string"
-			}
-		},
-		url: "/user/following/:username"
-	},
-	updateAuthenticated: {
-		method: "PATCH",
-		params: {
-			bio: {
-				type: "string"
-			},
-			blog: {
-				type: "string"
-			},
-			company: {
-				type: "string"
-			},
-			email: {
-				type: "string"
-			},
-			hireable: {
-				type: "boolean"
-			},
-			location: {
-				type: "string"
-			},
-			name: {
-				type: "string"
-			}
-		},
-		url: "/user"
-	}
-};
-var routes = {
-	activity: activity,
-	apps: apps,
-	checks: checks,
-	codesOfConduct: codesOfConduct,
-	emojis: emojis,
-	gists: gists,
-	git: git,
-	gitignore: gitignore,
-	interactions: interactions,
-	issues: issues,
-	licenses: licenses,
-	markdown: markdown,
-	meta: meta,
-	migrations: migrations,
-	oauthAuthorizations: oauthAuthorizations,
-	orgs: orgs,
-	projects: projects,
-	pulls: pulls,
-	rateLimit: rateLimit,
-	reactions: reactions,
-	repos: repos,
-	search: search,
-	teams: teams,
-	users: users
-};
-
-var routes$1 = /*#__PURE__*/Object.freeze({
-	__proto__: null,
-	activity: activity,
-	apps: apps,
-	checks: checks,
-	codesOfConduct: codesOfConduct,
-	emojis: emojis,
-	gists: gists,
-	git: git,
-	gitignore: gitignore,
-	interactions: interactions,
-	issues: issues,
-	licenses: licenses,
-	markdown: markdown,
-	meta: meta,
-	migrations: migrations,
-	oauthAuthorizations: oauthAuthorizations,
-	orgs: orgs,
-	projects: projects,
-	pulls: pulls,
-	rateLimit: rateLimit,
-	reactions: reactions,
-	repos: repos,
-	search: search,
-	teams: teams,
-	users: users,
-	'default': routes
-});
-
-var ROUTES = getCjsExportFromNamespace(routes$1);
-
-var restApiEndpoints = octokitRestApiEndpoints;
-
-
-
-function octokitRestApiEndpoints(octokit) {
-  // Aliasing scopes for backward compatibility
-  // See https://github.com/octokit/rest.js/pull/1134
-  ROUTES.gitdata = ROUTES.git;
-  ROUTES.authorization = ROUTES.oauthAuthorizations;
-  ROUTES.pullRequests = ROUTES.pulls;
-
-  octokit.registerEndpoints(ROUTES);
-}
-
-/**
- * lodash (Custom Build) <https://lodash.com/>
- * Build: `lodash modularize exports="npm" -o ./`
- * Copyright jQuery Foundation and other contributors <https://jquery.org/>
- * Released under MIT license <https://lodash.com/license>
- * Based on Underscore.js 1.8.3 <http://underscorejs.org/LICENSE>
- * Copyright Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
- */
-
-/** Used as the `TypeError` message for "Functions" methods. */
-var FUNC_ERROR_TEXT = 'Expected a function';
-
-/** Used to stand-in for `undefined` hash values. */
-var HASH_UNDEFINED$1 = '__lodash_hash_undefined__';
-
-/** Used as references for various `Number` constants. */
-var INFINITY$1 = 1 / 0;
-
-/** `Object#toString` result references. */
-var funcTag$1 = '[object Function]',
-    genTag$1 = '[object GeneratorFunction]',
-    symbolTag = '[object Symbol]';
-
-/** Used to match property names within property paths. */
-var reIsDeepProp = /\.|\[(?:[^[\]]*|(["'])(?:(?!\1)[^\\]|\\.)*?\1)\]/,
-    reIsPlainProp = /^\w*$/,
-    reLeadingDot = /^\./,
-    rePropName = /[^.[\]]+|\[(?:(-?\d+(?:\.\d+)?)|(["'])((?:(?!\2)[^\\]|\\.)*?)\2)\]|(?=(?:\.|\[\])(?:\.|\[\]|$))/g;
-
-/**
- * Used to match `RegExp`
- * [syntax characters](http://ecma-international.org/ecma-262/7.0/#sec-patterns).
- */
-var reRegExpChar$1 = /[\\^$.*+?()[\]{}|]/g;
-
-/** Used to match backslashes in property paths. */
-var reEscapeChar = /\\(\\)?/g;
-
-/** Used to detect host constructors (Safari). */
-var reIsHostCtor$1 = /^\[object .+?Constructor\]$/;
-
-/** Detect free variable `global` from Node.js. */
-var freeGlobal$1 = typeof commonjsGlobal == 'object' && commonjsGlobal && commonjsGlobal.Object === Object && commonjsGlobal;
-
-/** Detect free variable `self`. */
-var freeSelf$1 = typeof self == 'object' && self && self.Object === Object && self;
-
-/** Used as a reference to the global object. */
-var root$1 = freeGlobal$1 || freeSelf$1 || Function('return this')();
-
-/**
- * Gets the value at `key` of `object`.
- *
- * @private
- * @param {Object} [object] The object to query.
- * @param {string} key The key of the property to get.
- * @returns {*} Returns the property value.
- */
-function getValue$1(object, key) {
-  return object == null ? undefined : object[key];
-}
-
-/**
- * Checks if `value` is a host object in IE < 9.
- *
- * @private
- * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is a host object, else `false`.
- */
-function isHostObject$1(value) {
-  // Many host objects are `Object` objects that can coerce to strings
-  // despite having improperly defined `toString` methods.
-  var result = false;
-  if (value != null && typeof value.toString != 'function') {
-    try {
-      result = !!(value + '');
-    } catch (e) {}
-  }
-  return result;
-}
-
-/** Used for built-in method references. */
-var arrayProto$1 = Array.prototype,
-    funcProto$1 = Function.prototype,
-    objectProto$1 = Object.prototype;
-
-/** Used to detect overreaching core-js shims. */
-var coreJsData$1 = root$1['__core-js_shared__'];
-
-/** Used to detect methods masquerading as native. */
-var maskSrcKey$1 = (function() {
-  var uid = /[^.]+$/.exec(coreJsData$1 && coreJsData$1.keys && coreJsData$1.keys.IE_PROTO || '');
-  return uid ? ('Symbol(src)_1.' + uid) : '';
-}());
-
-/** Used to resolve the decompiled source of functions. */
-var funcToString$1 = funcProto$1.toString;
-
-/** Used to check objects for own properties. */
-var hasOwnProperty$1 = objectProto$1.hasOwnProperty;
-
-/**
- * Used to resolve the
- * [`toStringTag`](http://ecma-international.org/ecma-262/7.0/#sec-object.prototype.tostring)
- * of values.
- */
-var objectToString$1 = objectProto$1.toString;
-
-/** Used to detect if a method is native. */
-var reIsNative$1 = RegExp('^' +
-  funcToString$1.call(hasOwnProperty$1).replace(reRegExpChar$1, '\\$&')
-  .replace(/hasOwnProperty|(function).*?(?=\\\()| for .+?(?=\\\])/g, '$1.*?') + '$'
-);
-
-/** Built-in value references. */
-var Symbol$1 = root$1.Symbol,
-    splice$1 = arrayProto$1.splice;
-
-/* Built-in method references that are verified to be native. */
-var Map$2 = getNative$1(root$1, 'Map'),
-    nativeCreate$1 = getNative$1(Object, 'create');
-
-/** Used to convert symbols to primitives and strings. */
-var symbolProto = Symbol$1 ? Symbol$1.prototype : undefined,
-    symbolToString = symbolProto ? symbolProto.toString : undefined;
-
-/**
- * Creates a hash object.
- *
- * @private
- * @constructor
- * @param {Array} [entries] The key-value pairs to cache.
- */
-function Hash$1(entries) {
-  var index = -1,
-      length = entries ? entries.length : 0;
-
-  this.clear();
-  while (++index < length) {
-    var entry = entries[index];
-    this.set(entry[0], entry[1]);
-  }
-}
-
-/**
- * Removes all key-value entries from the hash.
- *
- * @private
- * @name clear
- * @memberOf Hash
- */
-function hashClear$1() {
-  this.__data__ = nativeCreate$1 ? nativeCreate$1(null) : {};
-}
-
-/**
- * Removes `key` and its value from the hash.
- *
- * @private
- * @name delete
- * @memberOf Hash
- * @param {Object} hash The hash to modify.
- * @param {string} key The key of the value to remove.
- * @returns {boolean} Returns `true` if the entry was removed, else `false`.
- */
-function hashDelete$1(key) {
-  return this.has(key) && delete this.__data__[key];
-}
-
-/**
- * Gets the hash value for `key`.
- *
- * @private
- * @name get
- * @memberOf Hash
- * @param {string} key The key of the value to get.
- * @returns {*} Returns the entry value.
- */
-function hashGet$1(key) {
-  var data = this.__data__;
-  if (nativeCreate$1) {
-    var result = data[key];
-    return result === HASH_UNDEFINED$1 ? undefined : result;
-  }
-  return hasOwnProperty$1.call(data, key) ? data[key] : undefined;
-}
-
-/**
- * Checks if a hash value for `key` exists.
- *
- * @private
- * @name has
- * @memberOf Hash
- * @param {string} key The key of the entry to check.
- * @returns {boolean} Returns `true` if an entry for `key` exists, else `false`.
- */
-function hashHas$1(key) {
-  var data = this.__data__;
-  return nativeCreate$1 ? data[key] !== undefined : hasOwnProperty$1.call(data, key);
-}
-
-/**
- * Sets the hash `key` to `value`.
- *
- * @private
- * @name set
- * @memberOf Hash
- * @param {string} key The key of the value to set.
- * @param {*} value The value to set.
- * @returns {Object} Returns the hash instance.
- */
-function hashSet$1(key, value) {
-  var data = this.__data__;
-  data[key] = (nativeCreate$1 && value === undefined) ? HASH_UNDEFINED$1 : value;
-  return this;
-}
-
-// Add methods to `Hash`.
-Hash$1.prototype.clear = hashClear$1;
-Hash$1.prototype['delete'] = hashDelete$1;
-Hash$1.prototype.get = hashGet$1;
-Hash$1.prototype.has = hashHas$1;
-Hash$1.prototype.set = hashSet$1;
-
-/**
- * Creates an list cache object.
- *
- * @private
- * @constructor
- * @param {Array} [entries] The key-value pairs to cache.
- */
-function ListCache$1(entries) {
-  var index = -1,
-      length = entries ? entries.length : 0;
-
-  this.clear();
-  while (++index < length) {
-    var entry = entries[index];
-    this.set(entry[0], entry[1]);
-  }
-}
-
-/**
- * Removes all key-value entries from the list cache.
- *
- * @private
- * @name clear
- * @memberOf ListCache
- */
-function listCacheClear$1() {
-  this.__data__ = [];
-}
-
-/**
- * Removes `key` and its value from the list cache.
- *
- * @private
- * @name delete
- * @memberOf ListCache
- * @param {string} key The key of the value to remove.
- * @returns {boolean} Returns `true` if the entry was removed, else `false`.
- */
-function listCacheDelete$1(key) {
-  var data = this.__data__,
-      index = assocIndexOf$1(data, key);
-
-  if (index < 0) {
-    return false;
-  }
-  var lastIndex = data.length - 1;
-  if (index == lastIndex) {
-    data.pop();
-  } else {
-    splice$1.call(data, index, 1);
-  }
-  return true;
-}
-
-/**
- * Gets the list cache value for `key`.
- *
- * @private
- * @name get
- * @memberOf ListCache
- * @param {string} key The key of the value to get.
- * @returns {*} Returns the entry value.
- */
-function listCacheGet$1(key) {
-  var data = this.__data__,
-      index = assocIndexOf$1(data, key);
-
-  return index < 0 ? undefined : data[index][1];
-}
-
-/**
- * Checks if a list cache value for `key` exists.
- *
- * @private
- * @name has
- * @memberOf ListCache
- * @param {string} key The key of the entry to check.
- * @returns {boolean} Returns `true` if an entry for `key` exists, else `false`.
- */
-function listCacheHas$1(key) {
-  return assocIndexOf$1(this.__data__, key) > -1;
-}
-
-/**
- * Sets the list cache `key` to `value`.
- *
- * @private
- * @name set
- * @memberOf ListCache
- * @param {string} key The key of the value to set.
- * @param {*} value The value to set.
- * @returns {Object} Returns the list cache instance.
- */
-function listCacheSet$1(key, value) {
-  var data = this.__data__,
-      index = assocIndexOf$1(data, key);
-
-  if (index < 0) {
-    data.push([key, value]);
-  } else {
-    data[index][1] = value;
-  }
-  return this;
-}
-
-// Add methods to `ListCache`.
-ListCache$1.prototype.clear = listCacheClear$1;
-ListCache$1.prototype['delete'] = listCacheDelete$1;
-ListCache$1.prototype.get = listCacheGet$1;
-ListCache$1.prototype.has = listCacheHas$1;
-ListCache$1.prototype.set = listCacheSet$1;
-
-/**
- * Creates a map cache object to store key-value pairs.
- *
- * @private
- * @constructor
- * @param {Array} [entries] The key-value pairs to cache.
- */
-function MapCache$1(entries) {
-  var index = -1,
-      length = entries ? entries.length : 0;
-
-  this.clear();
-  while (++index < length) {
-    var entry = entries[index];
-    this.set(entry[0], entry[1]);
-  }
-}
-
-/**
- * Removes all key-value entries from the map.
- *
- * @private
- * @name clear
- * @memberOf MapCache
- */
-function mapCacheClear$1() {
-  this.__data__ = {
-    'hash': new Hash$1,
-    'map': new (Map$2 || ListCache$1),
-    'string': new Hash$1
-  };
-}
-
-/**
- * Removes `key` and its value from the map.
- *
- * @private
- * @name delete
- * @memberOf MapCache
- * @param {string} key The key of the value to remove.
- * @returns {boolean} Returns `true` if the entry was removed, else `false`.
- */
-function mapCacheDelete$1(key) {
-  return getMapData$1(this, key)['delete'](key);
-}
-
-/**
- * Gets the map value for `key`.
- *
- * @private
- * @name get
- * @memberOf MapCache
- * @param {string} key The key of the value to get.
- * @returns {*} Returns the entry value.
- */
-function mapCacheGet$1(key) {
-  return getMapData$1(this, key).get(key);
-}
-
-/**
- * Checks if a map value for `key` exists.
- *
- * @private
- * @name has
- * @memberOf MapCache
- * @param {string} key The key of the entry to check.
- * @returns {boolean} Returns `true` if an entry for `key` exists, else `false`.
- */
-function mapCacheHas$1(key) {
-  return getMapData$1(this, key).has(key);
-}
-
-/**
- * Sets the map `key` to `value`.
- *
- * @private
- * @name set
- * @memberOf MapCache
- * @param {string} key The key of the value to set.
- * @param {*} value The value to set.
- * @returns {Object} Returns the map cache instance.
- */
-function mapCacheSet$1(key, value) {
-  getMapData$1(this, key).set(key, value);
-  return this;
-}
-
-// Add methods to `MapCache`.
-MapCache$1.prototype.clear = mapCacheClear$1;
-MapCache$1.prototype['delete'] = mapCacheDelete$1;
-MapCache$1.prototype.get = mapCacheGet$1;
-MapCache$1.prototype.has = mapCacheHas$1;
-MapCache$1.prototype.set = mapCacheSet$1;
-
-/**
- * Gets the index at which the `key` is found in `array` of key-value pairs.
- *
- * @private
- * @param {Array} array The array to inspect.
- * @param {*} key The key to search for.
- * @returns {number} Returns the index of the matched value, else `-1`.
- */
-function assocIndexOf$1(array, key) {
-  var length = array.length;
-  while (length--) {
-    if (eq$1(array[length][0], key)) {
-      return length;
-    }
-  }
-  return -1;
-}
-
-/**
- * The base implementation of `_.get` without support for default values.
- *
- * @private
- * @param {Object} object The object to query.
- * @param {Array|string} path The path of the property to get.
- * @returns {*} Returns the resolved value.
- */
-function baseGet(object, path) {
-  path = isKey(path, object) ? [path] : castPath(path);
-
-  var index = 0,
-      length = path.length;
-
-  while (object != null && index < length) {
-    object = object[toKey(path[index++])];
-  }
-  return (index && index == length) ? object : undefined;
-}
-
-/**
- * The base implementation of `_.isNative` without bad shim checks.
- *
- * @private
- * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is a native function,
- *  else `false`.
- */
-function baseIsNative$1(value) {
-  if (!isObject$3(value) || isMasked$1(value)) {
-    return false;
-  }
-  var pattern = (isFunction$1(value) || isHostObject$1(value)) ? reIsNative$1 : reIsHostCtor$1;
-  return pattern.test(toSource$1(value));
-}
-
-/**
- * The base implementation of `_.toString` which doesn't convert nullish
- * values to empty strings.
- *
- * @private
- * @param {*} value The value to process.
- * @returns {string} Returns the string.
- */
-function baseToString(value) {
-  // Exit early for strings to avoid a performance hit in some environments.
-  if (typeof value == 'string') {
-    return value;
-  }
-  if (isSymbol(value)) {
-    return symbolToString ? symbolToString.call(value) : '';
-  }
-  var result = (value + '');
-  return (result == '0' && (1 / value) == -INFINITY$1) ? '-0' : result;
-}
-
-/**
- * Casts `value` to a path array if it's not one.
- *
- * @private
- * @param {*} value The value to inspect.
- * @returns {Array} Returns the cast property path array.
- */
-function castPath(value) {
-  return isArray(value) ? value : stringToPath(value);
-}
-
-/**
- * Gets the data for `map`.
- *
- * @private
- * @param {Object} map The map to query.
- * @param {string} key The reference key.
- * @returns {*} Returns the map data.
- */
-function getMapData$1(map, key) {
-  var data = map.__data__;
-  return isKeyable$1(key)
-    ? data[typeof key == 'string' ? 'string' : 'hash']
-    : data.map;
-}
-
-/**
- * Gets the native function at `key` of `object`.
- *
- * @private
- * @param {Object} object The object to query.
- * @param {string} key The key of the method to get.
- * @returns {*} Returns the function if it's native, else `undefined`.
- */
-function getNative$1(object, key) {
-  var value = getValue$1(object, key);
-  return baseIsNative$1(value) ? value : undefined;
-}
-
-/**
- * Checks if `value` is a property name and not a property path.
- *
- * @private
- * @param {*} value The value to check.
- * @param {Object} [object] The object to query keys on.
- * @returns {boolean} Returns `true` if `value` is a property name, else `false`.
- */
-function isKey(value, object) {
-  if (isArray(value)) {
-    return false;
-  }
-  var type = typeof value;
-  if (type == 'number' || type == 'symbol' || type == 'boolean' ||
-      value == null || isSymbol(value)) {
-    return true;
-  }
-  return reIsPlainProp.test(value) || !reIsDeepProp.test(value) ||
-    (object != null && value in Object(object));
-}
-
-/**
- * Checks if `value` is suitable for use as unique object key.
- *
- * @private
- * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is suitable, else `false`.
- */
-function isKeyable$1(value) {
-  var type = typeof value;
-  return (type == 'string' || type == 'number' || type == 'symbol' || type == 'boolean')
-    ? (value !== '__proto__')
-    : (value === null);
-}
-
-/**
- * Checks if `func` has its source masked.
- *
- * @private
- * @param {Function} func The function to check.
- * @returns {boolean} Returns `true` if `func` is masked, else `false`.
- */
-function isMasked$1(func) {
-  return !!maskSrcKey$1 && (maskSrcKey$1 in func);
-}
-
-/**
- * Converts `string` to a property path array.
- *
- * @private
- * @param {string} string The string to convert.
- * @returns {Array} Returns the property path array.
- */
-var stringToPath = memoize(function(string) {
-  string = toString(string);
-
-  var result = [];
-  if (reLeadingDot.test(string)) {
-    result.push('');
-  }
-  string.replace(rePropName, function(match, number, quote, string) {
-    result.push(quote ? string.replace(reEscapeChar, '$1') : (number || match));
-  });
-  return result;
+const composePaginateRest = Object.assign(paginate, {
+  iterator
 });
 
 /**
- * Converts `value` to a string key if it's not a string or symbol.
- *
- * @private
- * @param {*} value The value to inspect.
- * @returns {string|symbol} Returns the key.
- */
-function toKey(value) {
-  if (typeof value == 'string' || isSymbol(value)) {
-    return value;
-  }
-  var result = (value + '');
-  return (result == '0' && (1 / value) == -INFINITY$1) ? '-0' : result;
-}
-
-/**
- * Converts `func` to its source code.
- *
- * @private
- * @param {Function} func The function to process.
- * @returns {string} Returns the source code.
- */
-function toSource$1(func) {
-  if (func != null) {
-    try {
-      return funcToString$1.call(func);
-    } catch (e) {}
-    try {
-      return (func + '');
-    } catch (e) {}
-  }
-  return '';
-}
-
-/**
- * Creates a function that memoizes the result of `func`. If `resolver` is
- * provided, it determines the cache key for storing the result based on the
- * arguments provided to the memoized function. By default, the first argument
- * provided to the memoized function is used as the map cache key. The `func`
- * is invoked with the `this` binding of the memoized function.
- *
- * **Note:** The cache is exposed as the `cache` property on the memoized
- * function. Its creation may be customized by replacing the `_.memoize.Cache`
- * constructor with one whose instances implement the
- * [`Map`](http://ecma-international.org/ecma-262/7.0/#sec-properties-of-the-map-prototype-object)
- * method interface of `delete`, `get`, `has`, and `set`.
- *
- * @static
- * @memberOf _
- * @since 0.1.0
- * @category Function
- * @param {Function} func The function to have its output memoized.
- * @param {Function} [resolver] The function to resolve the cache key.
- * @returns {Function} Returns the new memoized function.
- * @example
- *
- * var object = { 'a': 1, 'b': 2 };
- * var other = { 'c': 3, 'd': 4 };
- *
- * var values = _.memoize(_.values);
- * values(object);
- * // => [1, 2]
- *
- * values(other);
- * // => [3, 4]
- *
- * object.a = 2;
- * values(object);
- * // => [1, 2]
- *
- * // Modify the result cache.
- * values.cache.set(object, ['a', 'b']);
- * values(object);
- * // => ['a', 'b']
- *
- * // Replace `_.memoize.Cache`.
- * _.memoize.Cache = WeakMap;
- */
-function memoize(func, resolver) {
-  if (typeof func != 'function' || (resolver && typeof resolver != 'function')) {
-    throw new TypeError(FUNC_ERROR_TEXT);
-  }
-  var memoized = function() {
-    var args = arguments,
-        key = resolver ? resolver.apply(this, args) : args[0],
-        cache = memoized.cache;
-
-    if (cache.has(key)) {
-      return cache.get(key);
-    }
-    var result = func.apply(this, args);
-    memoized.cache = cache.set(key, result);
-    return result;
-  };
-  memoized.cache = new (memoize.Cache || MapCache$1);
-  return memoized;
-}
-
-// Assign cache to `_.memoize`.
-memoize.Cache = MapCache$1;
-
-/**
- * Performs a
- * [`SameValueZero`](http://ecma-international.org/ecma-262/7.0/#sec-samevaluezero)
- * comparison between two values to determine if they are equivalent.
- *
- * @static
- * @memberOf _
- * @since 4.0.0
- * @category Lang
- * @param {*} value The value to compare.
- * @param {*} other The other value to compare.
- * @returns {boolean} Returns `true` if the values are equivalent, else `false`.
- * @example
- *
- * var object = { 'a': 1 };
- * var other = { 'a': 1 };
- *
- * _.eq(object, object);
- * // => true
- *
- * _.eq(object, other);
- * // => false
- *
- * _.eq('a', 'a');
- * // => true
- *
- * _.eq('a', Object('a'));
- * // => false
- *
- * _.eq(NaN, NaN);
- * // => true
- */
-function eq$1(value, other) {
-  return value === other || (value !== value && other !== other);
-}
-
-/**
- * Checks if `value` is classified as an `Array` object.
- *
- * @static
- * @memberOf _
- * @since 0.1.0
- * @category Lang
- * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is an array, else `false`.
- * @example
- *
- * _.isArray([1, 2, 3]);
- * // => true
- *
- * _.isArray(document.body.children);
- * // => false
- *
- * _.isArray('abc');
- * // => false
- *
- * _.isArray(_.noop);
- * // => false
- */
-var isArray = Array.isArray;
-
-/**
- * Checks if `value` is classified as a `Function` object.
- *
- * @static
- * @memberOf _
- * @since 0.1.0
- * @category Lang
- * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is a function, else `false`.
- * @example
- *
- * _.isFunction(_);
- * // => true
- *
- * _.isFunction(/abc/);
- * // => false
- */
-function isFunction$1(value) {
-  // The use of `Object#toString` avoids issues with the `typeof` operator
-  // in Safari 8-9 which returns 'object' for typed array and other constructors.
-  var tag = isObject$3(value) ? objectToString$1.call(value) : '';
-  return tag == funcTag$1 || tag == genTag$1;
-}
-
-/**
- * Checks if `value` is the
- * [language type](http://www.ecma-international.org/ecma-262/7.0/#sec-ecmascript-language-types)
- * of `Object`. (e.g. arrays, functions, objects, regexes, `new Number(0)`, and `new String('')`)
- *
- * @static
- * @memberOf _
- * @since 0.1.0
- * @category Lang
- * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is an object, else `false`.
- * @example
- *
- * _.isObject({});
- * // => true
- *
- * _.isObject([1, 2, 3]);
- * // => true
- *
- * _.isObject(_.noop);
- * // => true
- *
- * _.isObject(null);
- * // => false
- */
-function isObject$3(value) {
-  var type = typeof value;
-  return !!value && (type == 'object' || type == 'function');
-}
-
-/**
- * Checks if `value` is object-like. A value is object-like if it's not `null`
- * and has a `typeof` result of "object".
- *
- * @static
- * @memberOf _
- * @since 4.0.0
- * @category Lang
- * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is object-like, else `false`.
- * @example
- *
- * _.isObjectLike({});
- * // => true
- *
- * _.isObjectLike([1, 2, 3]);
- * // => true
- *
- * _.isObjectLike(_.noop);
- * // => false
- *
- * _.isObjectLike(null);
- * // => false
- */
-function isObjectLike(value) {
-  return !!value && typeof value == 'object';
-}
-
-/**
- * Checks if `value` is classified as a `Symbol` primitive or object.
- *
- * @static
- * @memberOf _
- * @since 4.0.0
- * @category Lang
- * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is a symbol, else `false`.
- * @example
- *
- * _.isSymbol(Symbol.iterator);
- * // => true
- *
- * _.isSymbol('abc');
- * // => false
- */
-function isSymbol(value) {
-  return typeof value == 'symbol' ||
-    (isObjectLike(value) && objectToString$1.call(value) == symbolTag);
-}
-
-/**
- * Converts `value` to a string. An empty string is returned for `null`
- * and `undefined` values. The sign of `-0` is preserved.
- *
- * @static
- * @memberOf _
- * @since 4.0.0
- * @category Lang
- * @param {*} value The value to process.
- * @returns {string} Returns the string.
- * @example
- *
- * _.toString(null);
- * // => ''
- *
- * _.toString(-0);
- * // => '-0'
- *
- * _.toString([1, 2, 3]);
- * // => '1,2,3'
- */
-function toString(value) {
-  return value == null ? '' : baseToString(value);
-}
-
-/**
- * Gets the value at `path` of `object`. If the resolved value is
- * `undefined`, the `defaultValue` is returned in its place.
- *
- * @static
- * @memberOf _
- * @since 3.7.0
- * @category Object
- * @param {Object} object The object to query.
- * @param {Array|string} path The path of the property to get.
- * @param {*} [defaultValue] The value returned for `undefined` resolved values.
- * @returns {*} Returns the resolved value.
- * @example
- *
- * var object = { 'a': [{ 'b': { 'c': 3 } }] };
- *
- * _.get(object, 'a[0].b.c');
- * // => 3
- *
- * _.get(object, ['a', '0', 'b', 'c']);
- * // => 3
- *
- * _.get(object, 'a.b.c', 'default');
- * // => 'default'
- */
-function get(object, path, defaultValue) {
-  var result = object == null ? undefined : baseGet(object, path);
-  return result === undefined ? defaultValue : result;
-}
-
-var lodash_get = get;
-
-/**
- * lodash (Custom Build) <https://lodash.com/>
- * Build: `lodash modularize exports="npm" -o ./`
- * Copyright jQuery Foundation and other contributors <https://jquery.org/>
- * Released under MIT license <https://lodash.com/license>
- * Based on Underscore.js 1.8.3 <http://underscorejs.org/LICENSE>
- * Copyright Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
+ * @param octokit Octokit instance
+ * @param options Options passed to Octokit constructor
  */
 
-/** Used as the `TypeError` message for "Functions" methods. */
-var FUNC_ERROR_TEXT$1 = 'Expected a function';
-
-/** Used to stand-in for `undefined` hash values. */
-var HASH_UNDEFINED$2 = '__lodash_hash_undefined__';
-
-/** Used as references for various `Number` constants. */
-var INFINITY$2 = 1 / 0,
-    MAX_SAFE_INTEGER = 9007199254740991;
-
-/** `Object#toString` result references. */
-var funcTag$2 = '[object Function]',
-    genTag$2 = '[object GeneratorFunction]',
-    symbolTag$1 = '[object Symbol]';
-
-/** Used to match property names within property paths. */
-var reIsDeepProp$1 = /\.|\[(?:[^[\]]*|(["'])(?:(?!\1)[^\\]|\\.)*?\1)\]/,
-    reIsPlainProp$1 = /^\w*$/,
-    reLeadingDot$1 = /^\./,
-    rePropName$1 = /[^.[\]]+|\[(?:(-?\d+(?:\.\d+)?)|(["'])((?:(?!\2)[^\\]|\\.)*?)\2)\]|(?=(?:\.|\[\])(?:\.|\[\]|$))/g;
-
-/**
- * Used to match `RegExp`
- * [syntax characters](http://ecma-international.org/ecma-262/7.0/#sec-patterns).
- */
-var reRegExpChar$2 = /[\\^$.*+?()[\]{}|]/g;
-
-/** Used to match backslashes in property paths. */
-var reEscapeChar$1 = /\\(\\)?/g;
-
-/** Used to detect host constructors (Safari). */
-var reIsHostCtor$2 = /^\[object .+?Constructor\]$/;
-
-/** Used to detect unsigned integer values. */
-var reIsUint = /^(?:0|[1-9]\d*)$/;
-
-/** Detect free variable `global` from Node.js. */
-var freeGlobal$2 = typeof commonjsGlobal == 'object' && commonjsGlobal && commonjsGlobal.Object === Object && commonjsGlobal;
-
-/** Detect free variable `self`. */
-var freeSelf$2 = typeof self == 'object' && self && self.Object === Object && self;
-
-/** Used as a reference to the global object. */
-var root$2 = freeGlobal$2 || freeSelf$2 || Function('return this')();
-
-/**
- * Gets the value at `key` of `object`.
- *
- * @private
- * @param {Object} [object] The object to query.
- * @param {string} key The key of the property to get.
- * @returns {*} Returns the property value.
- */
-function getValue$2(object, key) {
-  return object == null ? undefined : object[key];
-}
-
-/**
- * Checks if `value` is a host object in IE < 9.
- *
- * @private
- * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is a host object, else `false`.
- */
-function isHostObject$2(value) {
-  // Many host objects are `Object` objects that can coerce to strings
-  // despite having improperly defined `toString` methods.
-  var result = false;
-  if (value != null && typeof value.toString != 'function') {
-    try {
-      result = !!(value + '');
-    } catch (e) {}
-  }
-  return result;
-}
-
-/** Used for built-in method references. */
-var arrayProto$2 = Array.prototype,
-    funcProto$2 = Function.prototype,
-    objectProto$2 = Object.prototype;
-
-/** Used to detect overreaching core-js shims. */
-var coreJsData$2 = root$2['__core-js_shared__'];
-
-/** Used to detect methods masquerading as native. */
-var maskSrcKey$2 = (function() {
-  var uid = /[^.]+$/.exec(coreJsData$2 && coreJsData$2.keys && coreJsData$2.keys.IE_PROTO || '');
-  return uid ? ('Symbol(src)_1.' + uid) : '';
-}());
-
-/** Used to resolve the decompiled source of functions. */
-var funcToString$2 = funcProto$2.toString;
-
-/** Used to check objects for own properties. */
-var hasOwnProperty$2 = objectProto$2.hasOwnProperty;
-
-/**
- * Used to resolve the
- * [`toStringTag`](http://ecma-international.org/ecma-262/7.0/#sec-object.prototype.tostring)
- * of values.
- */
-var objectToString$2 = objectProto$2.toString;
-
-/** Used to detect if a method is native. */
-var reIsNative$2 = RegExp('^' +
-  funcToString$2.call(hasOwnProperty$2).replace(reRegExpChar$2, '\\$&')
-  .replace(/hasOwnProperty|(function).*?(?=\\\()| for .+?(?=\\\])/g, '$1.*?') + '$'
-);
-
-/** Built-in value references. */
-var Symbol$2 = root$2.Symbol,
-    splice$2 = arrayProto$2.splice;
-
-/* Built-in method references that are verified to be native. */
-var Map$3 = getNative$2(root$2, 'Map'),
-    nativeCreate$2 = getNative$2(Object, 'create');
-
-/** Used to convert symbols to primitives and strings. */
-var symbolProto$1 = Symbol$2 ? Symbol$2.prototype : undefined,
-    symbolToString$1 = symbolProto$1 ? symbolProto$1.toString : undefined;
-
-/**
- * Creates a hash object.
- *
- * @private
- * @constructor
- * @param {Array} [entries] The key-value pairs to cache.
- */
-function Hash$2(entries) {
-  var index = -1,
-      length = entries ? entries.length : 0;
-
-  this.clear();
-  while (++index < length) {
-    var entry = entries[index];
-    this.set(entry[0], entry[1]);
-  }
-}
-
-/**
- * Removes all key-value entries from the hash.
- *
- * @private
- * @name clear
- * @memberOf Hash
- */
-function hashClear$2() {
-  this.__data__ = nativeCreate$2 ? nativeCreate$2(null) : {};
-}
-
-/**
- * Removes `key` and its value from the hash.
- *
- * @private
- * @name delete
- * @memberOf Hash
- * @param {Object} hash The hash to modify.
- * @param {string} key The key of the value to remove.
- * @returns {boolean} Returns `true` if the entry was removed, else `false`.
- */
-function hashDelete$2(key) {
-  return this.has(key) && delete this.__data__[key];
-}
-
-/**
- * Gets the hash value for `key`.
- *
- * @private
- * @name get
- * @memberOf Hash
- * @param {string} key The key of the value to get.
- * @returns {*} Returns the entry value.
- */
-function hashGet$2(key) {
-  var data = this.__data__;
-  if (nativeCreate$2) {
-    var result = data[key];
-    return result === HASH_UNDEFINED$2 ? undefined : result;
-  }
-  return hasOwnProperty$2.call(data, key) ? data[key] : undefined;
-}
-
-/**
- * Checks if a hash value for `key` exists.
- *
- * @private
- * @name has
- * @memberOf Hash
- * @param {string} key The key of the entry to check.
- * @returns {boolean} Returns `true` if an entry for `key` exists, else `false`.
- */
-function hashHas$2(key) {
-  var data = this.__data__;
-  return nativeCreate$2 ? data[key] !== undefined : hasOwnProperty$2.call(data, key);
-}
-
-/**
- * Sets the hash `key` to `value`.
- *
- * @private
- * @name set
- * @memberOf Hash
- * @param {string} key The key of the value to set.
- * @param {*} value The value to set.
- * @returns {Object} Returns the hash instance.
- */
-function hashSet$2(key, value) {
-  var data = this.__data__;
-  data[key] = (nativeCreate$2 && value === undefined) ? HASH_UNDEFINED$2 : value;
-  return this;
-}
-
-// Add methods to `Hash`.
-Hash$2.prototype.clear = hashClear$2;
-Hash$2.prototype['delete'] = hashDelete$2;
-Hash$2.prototype.get = hashGet$2;
-Hash$2.prototype.has = hashHas$2;
-Hash$2.prototype.set = hashSet$2;
-
-/**
- * Creates an list cache object.
- *
- * @private
- * @constructor
- * @param {Array} [entries] The key-value pairs to cache.
- */
-function ListCache$2(entries) {
-  var index = -1,
-      length = entries ? entries.length : 0;
-
-  this.clear();
-  while (++index < length) {
-    var entry = entries[index];
-    this.set(entry[0], entry[1]);
-  }
-}
-
-/**
- * Removes all key-value entries from the list cache.
- *
- * @private
- * @name clear
- * @memberOf ListCache
- */
-function listCacheClear$2() {
-  this.__data__ = [];
-}
-
-/**
- * Removes `key` and its value from the list cache.
- *
- * @private
- * @name delete
- * @memberOf ListCache
- * @param {string} key The key of the value to remove.
- * @returns {boolean} Returns `true` if the entry was removed, else `false`.
- */
-function listCacheDelete$2(key) {
-  var data = this.__data__,
-      index = assocIndexOf$2(data, key);
-
-  if (index < 0) {
-    return false;
-  }
-  var lastIndex = data.length - 1;
-  if (index == lastIndex) {
-    data.pop();
-  } else {
-    splice$2.call(data, index, 1);
-  }
-  return true;
-}
-
-/**
- * Gets the list cache value for `key`.
- *
- * @private
- * @name get
- * @memberOf ListCache
- * @param {string} key The key of the value to get.
- * @returns {*} Returns the entry value.
- */
-function listCacheGet$2(key) {
-  var data = this.__data__,
-      index = assocIndexOf$2(data, key);
-
-  return index < 0 ? undefined : data[index][1];
-}
-
-/**
- * Checks if a list cache value for `key` exists.
- *
- * @private
- * @name has
- * @memberOf ListCache
- * @param {string} key The key of the entry to check.
- * @returns {boolean} Returns `true` if an entry for `key` exists, else `false`.
- */
-function listCacheHas$2(key) {
-  return assocIndexOf$2(this.__data__, key) > -1;
-}
-
-/**
- * Sets the list cache `key` to `value`.
- *
- * @private
- * @name set
- * @memberOf ListCache
- * @param {string} key The key of the value to set.
- * @param {*} value The value to set.
- * @returns {Object} Returns the list cache instance.
- */
-function listCacheSet$2(key, value) {
-  var data = this.__data__,
-      index = assocIndexOf$2(data, key);
-
-  if (index < 0) {
-    data.push([key, value]);
-  } else {
-    data[index][1] = value;
-  }
-  return this;
-}
-
-// Add methods to `ListCache`.
-ListCache$2.prototype.clear = listCacheClear$2;
-ListCache$2.prototype['delete'] = listCacheDelete$2;
-ListCache$2.prototype.get = listCacheGet$2;
-ListCache$2.prototype.has = listCacheHas$2;
-ListCache$2.prototype.set = listCacheSet$2;
-
-/**
- * Creates a map cache object to store key-value pairs.
- *
- * @private
- * @constructor
- * @param {Array} [entries] The key-value pairs to cache.
- */
-function MapCache$2(entries) {
-  var index = -1,
-      length = entries ? entries.length : 0;
-
-  this.clear();
-  while (++index < length) {
-    var entry = entries[index];
-    this.set(entry[0], entry[1]);
-  }
-}
-
-/**
- * Removes all key-value entries from the map.
- *
- * @private
- * @name clear
- * @memberOf MapCache
- */
-function mapCacheClear$2() {
-  this.__data__ = {
-    'hash': new Hash$2,
-    'map': new (Map$3 || ListCache$2),
-    'string': new Hash$2
+function paginateRest(octokit) {
+  return {
+    paginate: Object.assign(paginate.bind(null, octokit), {
+      iterator: iterator.bind(null, octokit)
+    })
   };
 }
+paginateRest.VERSION = VERSION;
 
-/**
- * Removes `key` and its value from the map.
- *
- * @private
- * @name delete
- * @memberOf MapCache
- * @param {string} key The key of the value to remove.
- * @returns {boolean} Returns `true` if the entry was removed, else `false`.
- */
-function mapCacheDelete$2(key) {
-  return getMapData$2(this, key)['delete'](key);
-}
-
-/**
- * Gets the map value for `key`.
- *
- * @private
- * @name get
- * @memberOf MapCache
- * @param {string} key The key of the value to get.
- * @returns {*} Returns the entry value.
- */
-function mapCacheGet$2(key) {
-  return getMapData$2(this, key).get(key);
-}
-
-/**
- * Checks if a map value for `key` exists.
- *
- * @private
- * @name has
- * @memberOf MapCache
- * @param {string} key The key of the entry to check.
- * @returns {boolean} Returns `true` if an entry for `key` exists, else `false`.
- */
-function mapCacheHas$2(key) {
-  return getMapData$2(this, key).has(key);
-}
-
-/**
- * Sets the map `key` to `value`.
- *
- * @private
- * @name set
- * @memberOf MapCache
- * @param {string} key The key of the value to set.
- * @param {*} value The value to set.
- * @returns {Object} Returns the map cache instance.
- */
-function mapCacheSet$2(key, value) {
-  getMapData$2(this, key).set(key, value);
-  return this;
-}
-
-// Add methods to `MapCache`.
-MapCache$2.prototype.clear = mapCacheClear$2;
-MapCache$2.prototype['delete'] = mapCacheDelete$2;
-MapCache$2.prototype.get = mapCacheGet$2;
-MapCache$2.prototype.has = mapCacheHas$2;
-MapCache$2.prototype.set = mapCacheSet$2;
-
-/**
- * Assigns `value` to `key` of `object` if the existing value is not equivalent
- * using [`SameValueZero`](http://ecma-international.org/ecma-262/7.0/#sec-samevaluezero)
- * for equality comparisons.
- *
- * @private
- * @param {Object} object The object to modify.
- * @param {string} key The key of the property to assign.
- * @param {*} value The value to assign.
- */
-function assignValue(object, key, value) {
-  var objValue = object[key];
-  if (!(hasOwnProperty$2.call(object, key) && eq$2(objValue, value)) ||
-      (value === undefined && !(key in object))) {
-    object[key] = value;
-  }
-}
-
-/**
- * Gets the index at which the `key` is found in `array` of key-value pairs.
- *
- * @private
- * @param {Array} array The array to inspect.
- * @param {*} key The key to search for.
- * @returns {number} Returns the index of the matched value, else `-1`.
- */
-function assocIndexOf$2(array, key) {
-  var length = array.length;
-  while (length--) {
-    if (eq$2(array[length][0], key)) {
-      return length;
-    }
-  }
-  return -1;
-}
-
-/**
- * The base implementation of `_.isNative` without bad shim checks.
- *
- * @private
- * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is a native function,
- *  else `false`.
- */
-function baseIsNative$2(value) {
-  if (!isObject$4(value) || isMasked$2(value)) {
-    return false;
-  }
-  var pattern = (isFunction$2(value) || isHostObject$2(value)) ? reIsNative$2 : reIsHostCtor$2;
-  return pattern.test(toSource$2(value));
-}
-
-/**
- * The base implementation of `_.set`.
- *
- * @private
- * @param {Object} object The object to modify.
- * @param {Array|string} path The path of the property to set.
- * @param {*} value The value to set.
- * @param {Function} [customizer] The function to customize path creation.
- * @returns {Object} Returns `object`.
- */
-function baseSet(object, path, value, customizer) {
-  if (!isObject$4(object)) {
-    return object;
-  }
-  path = isKey$1(path, object) ? [path] : castPath$1(path);
-
-  var index = -1,
-      length = path.length,
-      lastIndex = length - 1,
-      nested = object;
-
-  while (nested != null && ++index < length) {
-    var key = toKey$1(path[index]),
-        newValue = value;
-
-    if (index != lastIndex) {
-      var objValue = nested[key];
-      newValue = customizer ? customizer(objValue, key, nested) : undefined;
-      if (newValue === undefined) {
-        newValue = isObject$4(objValue)
-          ? objValue
-          : (isIndex(path[index + 1]) ? [] : {});
-      }
-    }
-    assignValue(nested, key, newValue);
-    nested = nested[key];
-  }
-  return object;
-}
-
-/**
- * The base implementation of `_.toString` which doesn't convert nullish
- * values to empty strings.
- *
- * @private
- * @param {*} value The value to process.
- * @returns {string} Returns the string.
- */
-function baseToString$1(value) {
-  // Exit early for strings to avoid a performance hit in some environments.
-  if (typeof value == 'string') {
-    return value;
-  }
-  if (isSymbol$1(value)) {
-    return symbolToString$1 ? symbolToString$1.call(value) : '';
-  }
-  var result = (value + '');
-  return (result == '0' && (1 / value) == -INFINITY$2) ? '-0' : result;
-}
-
-/**
- * Casts `value` to a path array if it's not one.
- *
- * @private
- * @param {*} value The value to inspect.
- * @returns {Array} Returns the cast property path array.
- */
-function castPath$1(value) {
-  return isArray$1(value) ? value : stringToPath$1(value);
-}
-
-/**
- * Gets the data for `map`.
- *
- * @private
- * @param {Object} map The map to query.
- * @param {string} key The reference key.
- * @returns {*} Returns the map data.
- */
-function getMapData$2(map, key) {
-  var data = map.__data__;
-  return isKeyable$2(key)
-    ? data[typeof key == 'string' ? 'string' : 'hash']
-    : data.map;
-}
-
-/**
- * Gets the native function at `key` of `object`.
- *
- * @private
- * @param {Object} object The object to query.
- * @param {string} key The key of the method to get.
- * @returns {*} Returns the function if it's native, else `undefined`.
- */
-function getNative$2(object, key) {
-  var value = getValue$2(object, key);
-  return baseIsNative$2(value) ? value : undefined;
-}
-
-/**
- * Checks if `value` is a valid array-like index.
- *
- * @private
- * @param {*} value The value to check.
- * @param {number} [length=MAX_SAFE_INTEGER] The upper bounds of a valid index.
- * @returns {boolean} Returns `true` if `value` is a valid index, else `false`.
- */
-function isIndex(value, length) {
-  length = length == null ? MAX_SAFE_INTEGER : length;
-  return !!length &&
-    (typeof value == 'number' || reIsUint.test(value)) &&
-    (value > -1 && value % 1 == 0 && value < length);
-}
-
-/**
- * Checks if `value` is a property name and not a property path.
- *
- * @private
- * @param {*} value The value to check.
- * @param {Object} [object] The object to query keys on.
- * @returns {boolean} Returns `true` if `value` is a property name, else `false`.
- */
-function isKey$1(value, object) {
-  if (isArray$1(value)) {
-    return false;
-  }
-  var type = typeof value;
-  if (type == 'number' || type == 'symbol' || type == 'boolean' ||
-      value == null || isSymbol$1(value)) {
-    return true;
-  }
-  return reIsPlainProp$1.test(value) || !reIsDeepProp$1.test(value) ||
-    (object != null && value in Object(object));
-}
-
-/**
- * Checks if `value` is suitable for use as unique object key.
- *
- * @private
- * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is suitable, else `false`.
- */
-function isKeyable$2(value) {
-  var type = typeof value;
-  return (type == 'string' || type == 'number' || type == 'symbol' || type == 'boolean')
-    ? (value !== '__proto__')
-    : (value === null);
-}
-
-/**
- * Checks if `func` has its source masked.
- *
- * @private
- * @param {Function} func The function to check.
- * @returns {boolean} Returns `true` if `func` is masked, else `false`.
- */
-function isMasked$2(func) {
-  return !!maskSrcKey$2 && (maskSrcKey$2 in func);
-}
-
-/**
- * Converts `string` to a property path array.
- *
- * @private
- * @param {string} string The string to convert.
- * @returns {Array} Returns the property path array.
- */
-var stringToPath$1 = memoize$1(function(string) {
-  string = toString$1(string);
-
-  var result = [];
-  if (reLeadingDot$1.test(string)) {
-    result.push('');
-  }
-  string.replace(rePropName$1, function(match, number, quote, string) {
-    result.push(quote ? string.replace(reEscapeChar$1, '$1') : (number || match));
-  });
-  return result;
-});
-
-/**
- * Converts `value` to a string key if it's not a string or symbol.
- *
- * @private
- * @param {*} value The value to inspect.
- * @returns {string|symbol} Returns the key.
- */
-function toKey$1(value) {
-  if (typeof value == 'string' || isSymbol$1(value)) {
-    return value;
-  }
-  var result = (value + '');
-  return (result == '0' && (1 / value) == -INFINITY$2) ? '-0' : result;
-}
-
-/**
- * Converts `func` to its source code.
- *
- * @private
- * @param {Function} func The function to process.
- * @returns {string} Returns the source code.
- */
-function toSource$2(func) {
-  if (func != null) {
-    try {
-      return funcToString$2.call(func);
-    } catch (e) {}
-    try {
-      return (func + '');
-    } catch (e) {}
-  }
-  return '';
-}
-
-/**
- * Creates a function that memoizes the result of `func`. If `resolver` is
- * provided, it determines the cache key for storing the result based on the
- * arguments provided to the memoized function. By default, the first argument
- * provided to the memoized function is used as the map cache key. The `func`
- * is invoked with the `this` binding of the memoized function.
- *
- * **Note:** The cache is exposed as the `cache` property on the memoized
- * function. Its creation may be customized by replacing the `_.memoize.Cache`
- * constructor with one whose instances implement the
- * [`Map`](http://ecma-international.org/ecma-262/7.0/#sec-properties-of-the-map-prototype-object)
- * method interface of `delete`, `get`, `has`, and `set`.
- *
- * @static
- * @memberOf _
- * @since 0.1.0
- * @category Function
- * @param {Function} func The function to have its output memoized.
- * @param {Function} [resolver] The function to resolve the cache key.
- * @returns {Function} Returns the new memoized function.
- * @example
- *
- * var object = { 'a': 1, 'b': 2 };
- * var other = { 'c': 3, 'd': 4 };
- *
- * var values = _.memoize(_.values);
- * values(object);
- * // => [1, 2]
- *
- * values(other);
- * // => [3, 4]
- *
- * object.a = 2;
- * values(object);
- * // => [1, 2]
- *
- * // Modify the result cache.
- * values.cache.set(object, ['a', 'b']);
- * values(object);
- * // => ['a', 'b']
- *
- * // Replace `_.memoize.Cache`.
- * _.memoize.Cache = WeakMap;
- */
-function memoize$1(func, resolver) {
-  if (typeof func != 'function' || (resolver && typeof resolver != 'function')) {
-    throw new TypeError(FUNC_ERROR_TEXT$1);
-  }
-  var memoized = function() {
-    var args = arguments,
-        key = resolver ? resolver.apply(this, args) : args[0],
-        cache = memoized.cache;
-
-    if (cache.has(key)) {
-      return cache.get(key);
-    }
-    var result = func.apply(this, args);
-    memoized.cache = cache.set(key, result);
-    return result;
-  };
-  memoized.cache = new (memoize$1.Cache || MapCache$2);
-  return memoized;
-}
-
-// Assign cache to `_.memoize`.
-memoize$1.Cache = MapCache$2;
-
-/**
- * Performs a
- * [`SameValueZero`](http://ecma-international.org/ecma-262/7.0/#sec-samevaluezero)
- * comparison between two values to determine if they are equivalent.
- *
- * @static
- * @memberOf _
- * @since 4.0.0
- * @category Lang
- * @param {*} value The value to compare.
- * @param {*} other The other value to compare.
- * @returns {boolean} Returns `true` if the values are equivalent, else `false`.
- * @example
- *
- * var object = { 'a': 1 };
- * var other = { 'a': 1 };
- *
- * _.eq(object, object);
- * // => true
- *
- * _.eq(object, other);
- * // => false
- *
- * _.eq('a', 'a');
- * // => true
- *
- * _.eq('a', Object('a'));
- * // => false
- *
- * _.eq(NaN, NaN);
- * // => true
- */
-function eq$2(value, other) {
-  return value === other || (value !== value && other !== other);
-}
-
-/**
- * Checks if `value` is classified as an `Array` object.
- *
- * @static
- * @memberOf _
- * @since 0.1.0
- * @category Lang
- * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is an array, else `false`.
- * @example
- *
- * _.isArray([1, 2, 3]);
- * // => true
- *
- * _.isArray(document.body.children);
- * // => false
- *
- * _.isArray('abc');
- * // => false
- *
- * _.isArray(_.noop);
- * // => false
- */
-var isArray$1 = Array.isArray;
-
-/**
- * Checks if `value` is classified as a `Function` object.
- *
- * @static
- * @memberOf _
- * @since 0.1.0
- * @category Lang
- * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is a function, else `false`.
- * @example
- *
- * _.isFunction(_);
- * // => true
- *
- * _.isFunction(/abc/);
- * // => false
- */
-function isFunction$2(value) {
-  // The use of `Object#toString` avoids issues with the `typeof` operator
-  // in Safari 8-9 which returns 'object' for typed array and other constructors.
-  var tag = isObject$4(value) ? objectToString$2.call(value) : '';
-  return tag == funcTag$2 || tag == genTag$2;
-}
-
-/**
- * Checks if `value` is the
- * [language type](http://www.ecma-international.org/ecma-262/7.0/#sec-ecmascript-language-types)
- * of `Object`. (e.g. arrays, functions, objects, regexes, `new Number(0)`, and `new String('')`)
- *
- * @static
- * @memberOf _
- * @since 0.1.0
- * @category Lang
- * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is an object, else `false`.
- * @example
- *
- * _.isObject({});
- * // => true
- *
- * _.isObject([1, 2, 3]);
- * // => true
- *
- * _.isObject(_.noop);
- * // => true
- *
- * _.isObject(null);
- * // => false
- */
-function isObject$4(value) {
-  var type = typeof value;
-  return !!value && (type == 'object' || type == 'function');
-}
-
-/**
- * Checks if `value` is object-like. A value is object-like if it's not `null`
- * and has a `typeof` result of "object".
- *
- * @static
- * @memberOf _
- * @since 4.0.0
- * @category Lang
- * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is object-like, else `false`.
- * @example
- *
- * _.isObjectLike({});
- * // => true
- *
- * _.isObjectLike([1, 2, 3]);
- * // => true
- *
- * _.isObjectLike(_.noop);
- * // => false
- *
- * _.isObjectLike(null);
- * // => false
- */
-function isObjectLike$1(value) {
-  return !!value && typeof value == 'object';
-}
-
-/**
- * Checks if `value` is classified as a `Symbol` primitive or object.
- *
- * @static
- * @memberOf _
- * @since 4.0.0
- * @category Lang
- * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is a symbol, else `false`.
- * @example
- *
- * _.isSymbol(Symbol.iterator);
- * // => true
- *
- * _.isSymbol('abc');
- * // => false
- */
-function isSymbol$1(value) {
-  return typeof value == 'symbol' ||
-    (isObjectLike$1(value) && objectToString$2.call(value) == symbolTag$1);
-}
-
-/**
- * Converts `value` to a string. An empty string is returned for `null`
- * and `undefined` values. The sign of `-0` is preserved.
- *
- * @static
- * @memberOf _
- * @since 4.0.0
- * @category Lang
- * @param {*} value The value to process.
- * @returns {string} Returns the string.
- * @example
- *
- * _.toString(null);
- * // => ''
- *
- * _.toString(-0);
- * // => '-0'
- *
- * _.toString([1, 2, 3]);
- * // => '1,2,3'
- */
-function toString$1(value) {
-  return value == null ? '' : baseToString$1(value);
-}
-
-/**
- * Sets the value at `path` of `object`. If a portion of `path` doesn't exist,
- * it's created. Arrays are created for missing index properties while objects
- * are created for all other missing properties. Use `_.setWith` to customize
- * `path` creation.
- *
- * **Note:** This method mutates `object`.
- *
- * @static
- * @memberOf _
- * @since 3.7.0
- * @category Object
- * @param {Object} object The object to modify.
- * @param {Array|string} path The path of the property to set.
- * @param {*} value The value to set.
- * @returns {Object} Returns `object`.
- * @example
- *
- * var object = { 'a': [{ 'b': { 'c': 3 } }] };
- *
- * _.set(object, 'a[0].b.c', 4);
- * console.log(object.a[0].b.c);
- * // => 4
- *
- * _.set(object, ['x', '0', 'y', 'z'], 5);
- * console.log(object.x[0].y.z);
- * // => 5
- */
-function set(object, path, value) {
-  return object == null ? object : baseSet(object, path, value);
-}
-
-var lodash_set = set;
-
-var validate_1 = validate$1;
-
-const { RequestError: RequestError$2 } = distNode$3;
-
-
-
-function validate$1(octokit, options) {
-  if (!options.request.validate) {
-    return;
-  }
-  const { validate: params } = options.request;
-
-  Object.keys(params).forEach(parameterName => {
-    const parameter = lodash_get(params, parameterName);
-
-    const expectedType = parameter.type;
-    let parentParameterName;
-    let parentValue;
-    let parentParamIsPresent = true;
-    let parentParameterIsArray = false;
-
-    if (/\./.test(parameterName)) {
-      parentParameterName = parameterName.replace(/\.[^.]+$/, "");
-      parentParameterIsArray = parentParameterName.slice(-2) === "[]";
-      if (parentParameterIsArray) {
-        parentParameterName = parentParameterName.slice(0, -2);
-      }
-      parentValue = lodash_get(options, parentParameterName);
-      parentParamIsPresent =
-        parentParameterName === "headers" ||
-        (typeof parentValue === "object" && parentValue !== null);
-    }
-
-    const values = parentParameterIsArray
-      ? (lodash_get(options, parentParameterName) || []).map(
-          value => value[parameterName.split(/\./).pop()]
-        )
-      : [lodash_get(options, parameterName)];
-
-    values.forEach((value, i) => {
-      const valueIsPresent = typeof value !== "undefined";
-      const valueIsNull = value === null;
-      const currentParameterName = parentParameterIsArray
-        ? parameterName.replace(/\[\]/, `[${i}]`)
-        : parameterName;
-
-      if (!parameter.required && !valueIsPresent) {
-        return;
-      }
-
-      // if the parent parameter is of type object but allows null
-      // then the child parameters can be ignored
-      if (!parentParamIsPresent) {
-        return;
-      }
-
-      if (parameter.allowNull && valueIsNull) {
-        return;
-      }
-
-      if (!parameter.allowNull && valueIsNull) {
-        throw new RequestError$2(
-          `'${currentParameterName}' cannot be null`,
-          400,
-          {
-            request: options
-          }
-        );
-      }
-
-      if (parameter.required && !valueIsPresent) {
-        throw new RequestError$2(
-          `Empty value for parameter '${currentParameterName}': ${JSON.stringify(
-            value
-          )}`,
-          400,
-          {
-            request: options
-          }
-        );
-      }
-
-      // parse to integer before checking for enum
-      // so that string "1" will match enum with number 1
-      if (expectedType === "integer") {
-        const unparsedValue = value;
-        value = parseInt(value, 10);
-        if (isNaN(value)) {
-          throw new RequestError$2(
-            `Invalid value for parameter '${currentParameterName}': ${JSON.stringify(
-              unparsedValue
-            )} is NaN`,
-            400,
-            {
-              request: options
-            }
-          );
-        }
-      }
-
-      if (parameter.enum && parameter.enum.indexOf(String(value)) === -1) {
-        throw new RequestError$2(
-          `Invalid value for parameter '${currentParameterName}': ${JSON.stringify(
-            value
-          )}`,
-          400,
-          {
-            request: options
-          }
-        );
-      }
-
-      if (parameter.validation) {
-        const regex = new RegExp(parameter.validation);
-        if (!regex.test(value)) {
-          throw new RequestError$2(
-            `Invalid value for parameter '${currentParameterName}': ${JSON.stringify(
-              value
-            )}`,
-            400,
-            {
-              request: options
-            }
-          );
-        }
-      }
-
-      if (expectedType === "object" && typeof value === "string") {
-        try {
-          value = JSON.parse(value);
-        } catch (exception) {
-          throw new RequestError$2(
-            `JSON parse error of value for parameter '${currentParameterName}': ${JSON.stringify(
-              value
-            )}`,
-            400,
-            {
-              request: options
-            }
-          );
-        }
-      }
-
-      lodash_set(options, parameter.mapTo || currentParameterName, value);
-    });
-  });
-
-  return options;
-}
-
-var validate_1$1 = octokitValidate;
-
-
-
-function octokitValidate(octokit) {
-  octokit.hook.before("request", validate_1.bind(null, octokit));
-}
-
-var deprecate_1 = deprecate;
-
-const loggedMessages = {};
-
-function deprecate (message) {
-  if (loggedMessages[message]) {
-    return
-  }
-
-  console.warn(`DEPRECATED (@octokit/rest): ${message}`);
-  loggedMessages[message] = 1;
-}
-
-var getPageLinks_1 = getPageLinks;
-
-function getPageLinks (link) {
-  link = link.link || link.headers.link || '';
-
-  const links = {};
-
-  // link format:
-  // '<https://api.github.com/users/aseemk/followers?page=2>; rel="next", <https://api.github.com/users/aseemk/followers?page=2>; rel="last"'
-  link.replace(/<([^>]*)>;\s*rel="([\w]*)"/g, (m, uri, type) => {
-    links[type] = uri;
-  });
-
-  return links
-}
-
-var httpError = class HttpError extends Error {
-  constructor (message, code, headers) {
-    super(message);
-
-    // Maintains proper stack trace (only available on V8)
-    /* istanbul ignore next */
-    if (Error.captureStackTrace) {
-      Error.captureStackTrace(this, this.constructor);
-    }
-
-    this.name = 'HttpError';
-    this.code = code;
-    this.headers = headers;
-  }
-};
-
-var getPage_1 = getPage;
-
-
-
-
-
-function getPage (octokit, link, which, headers) {
-  deprecate_1(`octokit.get${which.charAt(0).toUpperCase() + which.slice(1)}Page() – You can use octokit.paginate or async iterators instead: https://github.com/octokit/rest.js#pagination.`);
-  const url = getPageLinks_1(link)[which];
-
-  if (!url) {
-    const urlError = new httpError(`No ${which} page found`, 404);
-    return Promise.reject(urlError)
-  }
-
-  const requestOptions = {
-    url,
-    headers: applyAcceptHeader(link, headers)
-  };
-
-  const promise = octokit.request(requestOptions);
-
-  return promise
-}
-
-function applyAcceptHeader (res, headers) {
-  const previous = res.headers && res.headers['x-github-media-type'];
-
-  if (!previous || (headers && headers.accept)) {
-    return headers
-  }
-  headers = headers || {};
-  headers.accept = 'application/vnd.' + previous
-    .replace('; param=', '.')
-    .replace('; format=', '+');
-
-  return headers
-}
-
-var getFirstPage_1 = getFirstPage;
-
-
-
-function getFirstPage (octokit, link, headers) {
-  return getPage_1(octokit, link, 'first', headers)
-}
-
-var getLastPage_1 = getLastPage;
-
-
-
-function getLastPage (octokit, link, headers) {
-  return getPage_1(octokit, link, 'last', headers)
-}
-
-var getNextPage_1 = getNextPage;
-
-
-
-function getNextPage (octokit, link, headers) {
-  return getPage_1(octokit, link, 'next', headers)
-}
-
-var getPreviousPage_1 = getPreviousPage;
-
-
-
-function getPreviousPage (octokit, link, headers) {
-  return getPage_1(octokit, link, 'prev', headers)
-}
-
-var hasFirstPage_1 = hasFirstPage;
-
-
-
-
-function hasFirstPage (link) {
-  deprecate_1(`octokit.hasFirstPage() – You can use octokit.paginate or async iterators instead: https://github.com/octokit/rest.js#pagination.`);
-  return getPageLinks_1(link).first
-}
-
-var hasLastPage_1 = hasLastPage;
-
-
-
-
-function hasLastPage (link) {
-  deprecate_1(`octokit.hasLastPage() – You can use octokit.paginate or async iterators instead: https://github.com/octokit/rest.js#pagination.`);
-  return getPageLinks_1(link).last
-}
-
-var hasNextPage_1 = hasNextPage;
-
-
-
-
-function hasNextPage (link) {
-  deprecate_1(`octokit.hasNextPage() – You can use octokit.paginate or async iterators instead: https://github.com/octokit/rest.js#pagination.`);
-  return getPageLinks_1(link).next
-}
-
-var hasPreviousPage_1 = hasPreviousPage;
-
-
-
-
-function hasPreviousPage (link) {
-  deprecate_1(`octokit.hasPreviousPage() – You can use octokit.paginate or async iterators instead: https://github.com/octokit/rest.js#pagination.`);
-  return getPageLinks_1(link).prev
-}
-
-var octokitPaginationMethods = paginationMethodsPlugin;
-
-function paginationMethodsPlugin (octokit) {
-  octokit.getFirstPage = getFirstPage_1.bind(null, octokit);
-  octokit.getLastPage = getLastPage_1.bind(null, octokit);
-  octokit.getNextPage = getNextPage_1.bind(null, octokit);
-  octokit.getPreviousPage = getPreviousPage_1.bind(null, octokit);
-  octokit.hasFirstPage = hasFirstPage_1;
-  octokit.hasLastPage = hasLastPage_1;
-  octokit.hasNextPage = hasNextPage_1;
-  octokit.hasPreviousPage = hasPreviousPage_1;
-}
-
-const CORE_PLUGINS = [
-  log,
-  authenticationDeprecated, // deprecated: remove in v17
-  authentication,
-  pagination,
-  registerEndpoints_1$1,
-  restApiEndpoints,
-  validate_1$1,
-
-  octokitPaginationMethods // deprecated: remove in v17
-];
-
-var rest = core$3.plugin(CORE_PLUGINS);
-
-var context = createCommonjsModule(function (module, exports) {
-Object.defineProperty(exports, "__esModule", { value: true });
-
-
-class Context {
-    /**
-     * Hydrate the context from the environment
-     */
-    constructor() {
-        this.payload = {};
-        if (process.env.GITHUB_EVENT_PATH) {
-            if (fs__default.existsSync(process.env.GITHUB_EVENT_PATH)) {
-                this.payload = JSON.parse(fs__default.readFileSync(process.env.GITHUB_EVENT_PATH, { encoding: 'utf8' }));
-            }
-            else {
-                process.stdout.write(`GITHUB_EVENT_PATH ${process.env.GITHUB_EVENT_PATH} does not exist${os.EOL}`);
-            }
-        }
-        this.eventName = process.env.GITHUB_EVENT_NAME;
-        this.sha = process.env.GITHUB_SHA;
-        this.ref = process.env.GITHUB_REF;
-        this.workflow = process.env.GITHUB_WORKFLOW;
-        this.action = process.env.GITHUB_ACTION;
-        this.actor = process.env.GITHUB_ACTOR;
-    }
-    get issue() {
-        const payload = this.payload;
-        return Object.assign(Object.assign({}, this.repo), { number: (payload.issue || payload.pullRequest || payload).number });
-    }
-    get repo() {
-        if (process.env.GITHUB_REPOSITORY) {
-            const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
-            return { owner, repo };
-        }
-        if (this.payload.repository) {
-            return {
-                owner: this.payload.repository.owner.login,
-                repo: this.payload.repository.name
-            };
-        }
-        throw new Error("context.repo requires a GITHUB_REPOSITORY environment variable like 'owner/repo'");
-    }
-}
-exports.Context = Context;
+exports.composePaginateRest = composePaginateRest;
+exports.paginateRest = paginateRest;
 
 });
 
-unwrapExports(context);
-var context_1 = context.Context;
+unwrapExports(distNode$9);
+var distNode_1$9 = distNode$9.composePaginateRest;
+var distNode_2$1 = distNode$9.paginateRest;
 
-var github = createCommonjsModule(function (module, exports) {
-var __importDefault = (commonjsGlobal && commonjsGlobal.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
+var utils$1 = createCommonjsModule(function (module, exports) {
+var __createBinding = (commonjsGlobal && commonjsGlobal.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (commonjsGlobal && commonjsGlobal.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
 var __importStar = (commonjsGlobal && commonjsGlobal.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
-    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
-    result["default"] = mod;
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
     return result;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-// Originally pulled from https://github.com/JasonEtco/actions-toolkit/blob/master/src/github.ts
-
-const rest_1 = __importDefault(rest);
+exports.getOctokitOptions = exports.GitHub = exports.context = void 0;
 const Context = __importStar(context);
-// We need this in order to extend Octokit
-rest_1.default.prototype = new rest_1.default();
+const Utils = __importStar(utils);
+// octokit + plugins
+
+
+
 exports.context = new Context.Context();
-class GitHub extends rest_1.default {
-    constructor(token, opts = {}) {
-        super(Object.assign(Object.assign({}, opts), { auth: `token ${token}` }));
-        this.graphql = graphql$1.defaults({
-            headers: { authorization: `token ${token}` }
-        });
+const baseUrl = Utils.getApiBaseUrl();
+const defaults = {
+    baseUrl,
+    request: {
+        agent: Utils.getProxyAgent(baseUrl)
     }
+};
+exports.GitHub = distNode$7.Octokit.plugin(distNode$8.restEndpointMethods, distNode$9.paginateRest).defaults(defaults);
+/**
+ * Convience function to correctly format Octokit Options to pass into the constructor.
+ *
+ * @param     token    the repo PAT or GITHUB_TOKEN
+ * @param     options  other options to set
+ */
+function getOctokitOptions(token, options) {
+    const opts = Object.assign({}, options || {}); // Shallow clone - don't mutate the object provided by the caller
+    // Auth
+    const auth = Utils.getAuthString(token, opts);
+    if (auth) {
+        opts.auth = auth;
+    }
+    return opts;
 }
-exports.GitHub = GitHub;
+exports.getOctokitOptions = getOctokitOptions;
+
+});
+
+unwrapExports(utils$1);
+var utils_1$1 = utils$1.getOctokitOptions;
+var utils_2$1 = utils$1.GitHub;
+var utils_3$1 = utils$1.context;
+
+var github = createCommonjsModule(function (module, exports) {
+var __createBinding = (commonjsGlobal && commonjsGlobal.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (commonjsGlobal && commonjsGlobal.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (commonjsGlobal && commonjsGlobal.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getOctokit = exports.context = void 0;
+const Context = __importStar(context);
+
+exports.context = new Context.Context();
+/**
+ * Returns a hydrated octokit ready to use for GitHub Actions
+ *
+ * @param     token    the repo PAT or GITHUB_TOKEN
+ * @param     options  other options to set
+ */
+function getOctokit(token, options) {
+    return new utils$1.GitHub(utils$1.getOctokitOptions(token, options));
+}
+exports.getOctokit = getOctokit;
 
 });
 
 var github$1 = unwrapExports(github);
-var github_1 = github.context;
-var github_2 = github.GitHub;
+var github_1 = github.getOctokit;
+var github_2 = github.context;
 
 /*
 Copyright (c) 2012, Yahoo! Inc. All rights reserved.
@@ -22718,7 +5744,7 @@ var walkFile = function(str, cb) {
     }
 };
 
-var parse$1 = function(file, cb) {
+var parse = function(file, cb) {
     exists(file, function(x) {
         if (!x) {
             return walkFile(file, cb);
@@ -22731,12 +5757,12 @@ var parse$1 = function(file, cb) {
 };
 
 
-var lib$1 = parse$1;
+var lib$1 = parse;
 var source = walkFile;
 lib$1.source = source;
 
 // Parse lcov string into lcov data
-function parse$2(data) {
+function parse$1(data) {
 	return new Promise(function(resolve, reject) {
 		lib$1(data, function(err, res) {
 			if (err) {
@@ -23028,7 +6054,7 @@ const walkSync = (dir, filelist = []) => {
 	return filelist;
 };
 
-async function main$1() {
+async function main() {
 	const { context = {} } = github$1 || {};
 
 	const token = core$1.getInput("github-token");
@@ -23055,7 +6081,7 @@ async function main$1() {
 	for (const file of lcovArray) {
 		if (file.path.includes(".info")) {
 			const raw = await fs.promises.readFile(file.path, "utf8");
-			const data = await parse$2(raw);
+			const data = await parse$1(raw);
 			lcovArrayWithRaw.push({
 				packageName: file.name,
 				lcov: data,
@@ -23071,8 +6097,8 @@ async function main$1() {
 		base: context.payload.pull_request.base.ref,
 	};
 
-	const lcov = await parse$2(raw);
-	const baselcov = baseRaw && (await parse$2(baseRaw));
+	const lcov = await parse$1(raw);
+	const baselcov = baseRaw && (await parse$1(baseRaw));
 
 	const client = github$1.getOctokit(token);
 
@@ -23080,11 +6106,11 @@ async function main$1() {
 		client,
 		context,
 		prNumber: context.payload.pull_request.number,
-		body: diff(lcov, baselcov, options),
+		body: diff(lcov, lcovArrayWithRaw, baselcov, options),
 	});
 }
 
-main$1().catch(function(err) {
+main().catch(function(err) {
 	console.log(err);
 	core$1.setFailed(err.message);
 });

--- a/dist/main.js
+++ b/dist/main.js
@@ -22922,6 +22922,14 @@ async function main$1() {
 	const lcovFile = core$1.getInput("lcov-file") || "./coverage/lcov.info";
 	const baseFile = core$1.getInput("lcov-base");
 
+	// Add base path for monorepo
+	const monorepoBasePath = core$1.getInput("monorepo-base-path") || "./packages";
+
+	for await (const dirent of monorepoBasePath) {
+    console.log(dirent.name);
+  }
+
+
 	const raw = await fs.promises.readFile(lcovFile, "utf-8").catch(err => null);
 	if (!raw) {
 		console.log(`No coverage report found at '${lcovFile}', exiting...`);

--- a/dist/main.js
+++ b/dist/main.js
@@ -5,7 +5,7 @@ function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'defau
 var fs = require('fs');
 var fs__default = _interopDefault(fs);
 var os = _interopDefault(require('os'));
-var path$1 = _interopDefault(require('path'));
+var path = _interopDefault(require('path'));
 var child_process = _interopDefault(require('child_process'));
 var Stream = _interopDefault(require('stream'));
 var assert = _interopDefault(require('assert'));
@@ -157,7 +157,7 @@ exports.setSecret = setSecret;
  */
 function addPath(inputPath) {
     command.issueCommand('add-path', {}, inputPath);
-    process.env['PATH'] = `${inputPath}${path$1.delimiter}${process.env['PATH']}`;
+    process.env['PATH'] = `${inputPath}${path.delimiter}${process.env['PATH']}`;
 }
 exports.addPath = addPath;
 /**
@@ -622,7 +622,7 @@ function which (cmd, opt, cb) {
     if (pathPart.charAt(0) === '"' && pathPart.slice(-1) === '"')
       pathPart = pathPart.slice(1, -1);
 
-    var p = path$1.join(pathPart, cmd);
+    var p = path.join(pathPart, cmd);
     if (!pathPart && (/^\.[\\\/]/).test(cmd)) {
       p = cmd.slice(0, 2) + p;
     }
@@ -656,7 +656,7 @@ function whichSync (cmd, opt) {
     if (pathPart.charAt(0) === '"' && pathPart.slice(-1) === '"')
       pathPart = pathPart.slice(1, -1);
 
-    var p = path$1.join(pathPart, cmd);
+    var p = path.join(pathPart, cmd);
     if (!pathPart && /^\.[\\\/]/.test(cmd)) {
       p = cmd.slice(0, 2) + p;
     }
@@ -718,7 +718,7 @@ function resolveCommandAttempt(parsed, withoutPathExt) {
     try {
         resolved = which_1.sync(parsed.command, {
             path: (parsed.options.env || process.env)[pathKey$1],
-            pathExt: withoutPathExt ? path$1.delimiter : undefined,
+            pathExt: withoutPathExt ? path.delimiter : undefined,
         });
     } catch (e) {
         /* Empty */
@@ -729,7 +729,7 @@ function resolveCommandAttempt(parsed, withoutPathExt) {
     // If we successfully resolved, ensure that an absolute path is returned
     // Note that when a custom `cwd` was used, we need to resolve to an absolute path based on it
     if (resolved) {
-        resolved = path$1.resolve(hasCustomCwd ? parsed.options.cwd : '', resolved);
+        resolved = path.resolve(hasCustomCwd ? parsed.options.cwd : '', resolved);
     }
 
     return resolved;
@@ -2407,7 +2407,7 @@ function parseNonShell(parsed) {
 
         // Normalize posix paths into OS compatible paths (e.g.: foo/bar -> foo\bar)
         // This is necessary otherwise it will always fail with ENOENT in those cases
-        parsed.command = path$1.normalize(parsed.command);
+        parsed.command = path.normalize(parsed.command);
 
         // Escape command & arguments
         parsed.command = _escape.command(parsed.command);
@@ -2602,19 +2602,19 @@ module.exports = opts => {
 	}, opts);
 
 	let prev;
-	let pth = path$1.resolve(opts.cwd);
+	let pth = path.resolve(opts.cwd);
 	const ret = [];
 
 	while (prev !== pth) {
-		ret.push(path$1.join(pth, 'node_modules/.bin'));
+		ret.push(path.join(pth, 'node_modules/.bin'));
 		prev = pth;
-		pth = path$1.resolve(pth, '..');
+		pth = path.resolve(pth, '..');
 	}
 
 	// ensure the running `node` binary is used
-	ret.push(path$1.dirname(process.execPath));
+	ret.push(path.dirname(process.execPath));
 
-	return ret.concat(opts.path).join(path$1.delimiter);
+	return ret.concat(opts.path).join(path.delimiter);
 };
 
 module.exports.env = opts => {
@@ -3387,7 +3387,7 @@ function handleArgs(cmd, args, opts) {
 		opts.cleanup = false;
 	}
 
-	if (process.platform === 'win32' && path$1.basename(parsed.command) === 'cmd.exe') {
+	if (process.platform === 'win32' && path.basename(parsed.command) === 'cmd.exe') {
 		// #116
 		parsed.args.unshift('/q');
 	}
@@ -22617,7 +22617,7 @@ http://yuilibrary.com/license/
 
 
 /* istanbul ignore next */
-var exists = fs__default.exists || path$1.exists;
+var exists = fs__default.exists || path.exists;
 
 var walkFile = function(str, cb) {
     var data = [], item;

--- a/dist/main.js
+++ b/dist/main.js
@@ -6153,8 +6153,6 @@ async function main() {
 		console.log(`No coverage report found at '${baseFile}', ignoring...`);
 	}
 
-	console.log("monorepoBasePath", monorepoBasePath);
-
 	let lcovArray = monorepoBasePath ? getLcovFiles(monorepoBasePath) : [];
 	let lcovBaseArray = monorepoBasePath
 		? getLcovBaseFiles(monorepoBasePath)

--- a/dist/main.js
+++ b/dist/main.js
@@ -4,8 +4,8 @@ function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'defau
 
 var fs = require('fs');
 var fs__default = _interopDefault(fs);
-var os = _interopDefault(require('os'));
 var path = _interopDefault(require('path'));
+var os = _interopDefault(require('os'));
 var child_process = _interopDefault(require('child_process'));
 var Stream = _interopDefault(require('stream'));
 var assert = _interopDefault(require('assert'));
@@ -22916,6 +22916,23 @@ function diff(lcov, before, options) {
 	);
 }
 
+const getAllFiles = function(dirPath, arrayOfFiles) {
+  let files = fs__default.readdirSync(dirPath);
+  arrayOfFiles = arrayOfFiles || [];
+
+  files.forEach(function(file) {
+    if (fs__default.statSync(dirPath + "/" + file).isDirectory()) {
+      arrayOfFiles = getAllFiles(dirPath + "/" + file, arrayOfFiles);
+    } else {
+      if( file.includes('.info')){
+        arrayOfFiles.push(path.join(path.resolve(), dirPath, "/", file));
+      }
+    }
+  });
+
+  return arrayOfFiles
+};
+
 async function main$1() {
 	const token = core$1.getInput("github-token");
 	const lcovFile = core$1.getInput("lcov-file") || "./coverage/lcov.info";
@@ -22924,15 +22941,15 @@ async function main$1() {
 	// Add base path for monorepo
 	const monorepoBasePath = core$1.getInput("monorepo-base-path") || "./packages";
 
-	let dirCont = await fs.promises.readdir(monorepoBasePath);
-	let files = dirCont.filter( function( elm ) {return elm.match(/.*\.(info)/ig);});
-  for (const file of files) {
-    console.log(file);
-  }
+	const lcovArray = getAllFiles(monorepoBasePath);
+
+	let raw = "";
+	lcovArray.forEach(function(lcovFile) {
+		raw += fs__default.readFileSync(lcovFile, "utf-8");
+	});
 
 
-
-	const raw = await fs.promises.readFile(lcovFile, "utf-8").catch(err => null);
+	//const raw = await promises.readFile(lcovFile, "utf-8").catch(err => null)
 	if (!raw) {
 		console.log(`No coverage report found at '${lcovFile}', exiting...`);
 		return;

--- a/dist/main.js
+++ b/dist/main.js
@@ -6188,7 +6188,11 @@ async function main() {
 		prNumber: context.payload.pull_request.number,
 		body: !lcovArrayForMonorepo.length
 			? diff(lcov, baselcov, options)
-			: diffForMonorepo(lcovArrayForMonorepo, lcovBaseArrayForMonorepo.options),
+			: diffForMonorepo(
+					lcovArrayForMonorepo,
+					lcovBaseArrayForMonorepo,
+					options,
+			  ),
 	});
 }
 

--- a/dist/main.js
+++ b/dist/main.js
@@ -22924,7 +22924,7 @@ async function main$1() {
 	// Add base path for monorepo
 	const monorepoBasePath = core$1.getInput("monorepo-base-path") || "./packages";
 
-	const dir = await fs.promises.promises.opendir(monorepoBasePath);
+	const dir = await fs.promises.opendir(monorepoBasePath);
 	for await (const dirent of dir) {
     console.log(dirent.name);
   }

--- a/dist/main.js
+++ b/dist/main.js
@@ -5967,7 +5967,7 @@ function comment(lcov, before, options) {
 	const pdiffHtml = before ? th(arrow, " ", plus, pdiff.toFixed(2), "%") : "";
 
 	return fragment(
-		`Coverage after merging ${b(options.head)} into ${b(options.base)}`,
+		`Coverage after merging ${b(options.head)} into ${b(options.base)} <p></p>`,
 		table(tbody(tr(th(percentage(lcov).toFixed(2), "%"), pdiffHtml))),
 		"\n\n",
 		details(summary("Coverage Report"), tabulate(lcov, options)),

--- a/dist/main.js
+++ b/dist/main.js
@@ -22882,21 +22882,18 @@ function uncovered(file, options) {
 }
 
 function comment(lcov, lcovArrayWithRaw, options) {
-	const tableHTML = lcovArrayWithRaw.map(lcovObj => {
+	const HTML = lcovArrayWithRaw.map(lcovObj => {
 		return `${lcovObj.packageName} - ${table(
 			tbody(tr(th(percentage(lcovObj.lcov).toFixed(2), "%"))),
-		)} \n\n`;
-	});
-
-	const detailsHTML = lcovArrayWithRaw.map(lcovObj => {
-		return details(summary("Coverage Report"), tabulate(lcovObj.lcov, options));
+		)} \n\n ${details(
+			summary("Coverage Report"),
+			tabulate(lcovObj.lcov, options),
+		)}`;
 	});
 
 	return fragment(
 		`Coverage after merging ${b(options.head)} into ${b(options.base)}`,
-		tableHTML.join(""),
-		"\n\n",
-		detailsHTML.join(""),
+		HTML.join(""),
 	);
 }
 

--- a/dist/main.js
+++ b/dist/main.js
@@ -22881,8 +22881,7 @@ function uncovered(file, options) {
 		.join(", ");
 }
 
-function comment(lcov, lcovArrayWithRaw, options) {
-	console.log("lcovArrayWithRaw", lcovArrayWithRaw);
+function comment(lcov, options) {
 	return fragment(
 		`Coverage after merging ${b(options.head)} into ${b(options.base)}`,
 		table(tbody(tr(th(percentage(lcov).toFixed(2), "%")))),
@@ -22893,7 +22892,8 @@ function comment(lcov, lcovArrayWithRaw, options) {
 
 function diff(lcov, lcovArrayWithRaw, before, options) {
 	if (!before) {
-		return comment(lcov, lcovArrayWithRaw, options);
+		console.log("lcovArrayWithRaw", lcovArrayWithRaw);
+		return comment(lcov, options);
 	}
 
 	const pbefore = percentage(before);

--- a/dist/main.js
+++ b/dist/main.js
@@ -6138,7 +6138,7 @@ async function main() {
 
     let lcovArray = monorepoBasePath ? getLcovFiles(monorepoBasePath) : [];
     let lcovBaseArray = monorepoBasePath
-        ? getLcovFiles(monorepoBasePath, "lcov-base.info")
+        ? getLcovFiles(monorepoBasePath, [], "lcov-base.info")
         : [];
 
     const lcovArrayForMonorepo = [];

--- a/dist/main.js
+++ b/dist/main.js
@@ -6094,36 +6094,15 @@ var github_1$1 = github$2.upsertComment;
  * @function getLcovFiles
  * @param  {string} dir Dir path string.
  * @return {string[{<package_name>: <path_to_lcov_file>}]} Array with lcove file names with package names as key.
+ * @param {string} lcovFileName  path string  for lcov file for PR or base lcov file.
  */
-const getLcovFiles = (dir, filelist = []) => {
+const getLcovFiles = (dir, filelist = [], lcovFileName = "lcov.info") => {
     fs__default.readdirSync(dir).forEach(file => {
         filelist = fs__default.statSync(path.join(dir, file)).isDirectory()
             ? getLcovFiles(path.join(dir, file), filelist)
             : filelist
                   .filter(file => {
-                      return file.path.includes("lcov.info");
-                  })
-                  .concat({
-                      name: dir.split("/")[1],
-                      path: path.join(dir, file),
-                  });
-    });
-    return filelist;
-};
-
-/**
- * Find all files inside a dir, recursively for base branch.
- * @function getLcovBaseFiles
- * @param  {string} dir Dir path string.
- * @return {string[{<package_name>: <path_to_lcov_file>}]} Array with lcove file names with package names as key.
- */
-const getLcovBaseFiles = (dir, filelist = []) => {
-    fs__default.readdirSync(dir).forEach(file => {
-        filelist = fs__default.statSync(path.join(dir, file)).isDirectory()
-            ? getLcovBaseFiles(path.join(dir, file), filelist)
-            : filelist
-                  .filter(file => {
-                      return file.path.includes("lcov-base.info");
+                      return file.path.includes(lcovFileName);
                   })
                   .concat({
                       name: dir.split("/")[1],
@@ -6159,7 +6138,7 @@ async function main() {
 
     let lcovArray = monorepoBasePath ? getLcovFiles(monorepoBasePath) : [];
     let lcovBaseArray = monorepoBasePath
-        ? getLcovBaseFiles(monorepoBasePath)
+        ? getLcovFiles(monorepoBasePath, "lcov-base.info")
         : [];
 
     const lcovArrayForMonorepo = [];

--- a/dist/main.js
+++ b/dist/main.js
@@ -6139,7 +6139,9 @@ async function main() {
 	// Add base path for monorepo
 	const monorepoBasePath = core$1.getInput("monorepo-base-path");
 
-	const raw = await fs.promises.readFile(lcovFile, "utf-8").catch(err => null);
+	const raw =
+		!monorepoBasePath &&
+		(await fs.promises.readFile(lcovFile, "utf-8").catch(err => null));
 	if (!monorepoBasePath && !raw) {
 		console.log(`No coverage report found at '${lcovFile}', exiting...`);
 		return;
@@ -6150,6 +6152,8 @@ async function main() {
 	if (!monorepoBasePath && baseFile && !baseRaw) {
 		console.log(`No coverage report found at '${baseFile}', ignoring...`);
 	}
+
+	console.log("monorepoBasePath", monorepoBasePath);
 
 	let lcovArray = monorepoBasePath ? getLcovFiles(monorepoBasePath) : [];
 	let lcovBaseArray = monorepoBasePath
@@ -6188,7 +6192,7 @@ async function main() {
 		base: context.payload.pull_request.base.ref,
 	};
 
-	const lcov = await parse$1(raw);
+	const lcov = !monorepoBasePath && (await parse$1(raw));
 	const baselcov = baseRaw && (await parse$1(baseRaw));
 
 	const client = github$1.getOctokit(token);

--- a/dist/main.js
+++ b/dist/main.js
@@ -6186,7 +6186,7 @@ async function main() {
 		client,
 		context,
 		prNumber: context.payload.pull_request.number,
-		body: lcovArrayForMonorepo.length
+		body: !lcovArrayForMonorepo.length
 			? diff(lcov, baselcov, options)
 			: diffForMonorepo(lcovArrayForMonorepo, lcovBaseArrayForMonorepo.options),
 	});

--- a/dist/main.js
+++ b/dist/main.js
@@ -22883,8 +22883,13 @@ function uncovered(file, options) {
 
 function comment(lcov, lcovArrayWithRaw, options) {
 	const HTML = lcovArrayWithRaw.map(lcovObj => {
-		return `${lcovObj.packageName} - ${table(
-			tbody(tr(th(percentage(lcovObj.lcov).toFixed(2), "%"))),
+		return `${table(
+			tbody(
+				tr(
+					th(lcovObj.packageName),
+					th(percentage(lcovObj.lcov).toFixed(2), "%"),
+				),
+			),
 		)} \n\n ${details(
 			summary("Coverage Report"),
 			tabulate(lcovObj.lcov, options),

--- a/dist/main.js
+++ b/dist/main.js
@@ -22882,12 +22882,21 @@ function uncovered(file, options) {
 }
 
 function comment(lcov, lcovArrayWithRaw, options) {
-	console.log("lcovArrayWithRaw", lcovArrayWithRaw);
+	const tableHTML = lcovArrayWithRaw.map(lcovObj => {
+		return `${lcovObj.packageName} - ${table(
+			tbody(tr(th(percentage(lcovObj.lcov).toFixed(2), "%"))),
+		)} \n\n`;
+	});
+
+	const detailsHTML = lcovArrayWithRaw.map(lcovObj => {
+		return details(summary("Coverage Report"), tabulate(lcovObj.lcov, options));
+	});
+
 	return fragment(
 		`Coverage after merging ${b(options.head)} into ${b(options.base)}`,
-		table(tbody(tr(th(percentage(lcov).toFixed(2), "%")))),
+		tableHTML.join(""),
 		"\n\n",
-		details(summary("Coverage Report"), tabulate(lcov, options)),
+		detailsHTML.join(""),
 	);
 }
 

--- a/package.json
+++ b/package.json
@@ -57,6 +57,8 @@
 	},
 	"prettier": {
 		"tabWidth": 4,
+		"useTabs": false,
+		"bracketSpacing": true,
 		"trailingComma": "all"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
 		]
 	},
 	"prettier": {
+		"tabWidth": 4,
 		"trailingComma": "all"
 	}
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -6,31 +6,31 @@ import { parse } from "./lcov";
 import { diff } from "./comment";
 
 async function main() {
-	const file = process.argv[2];
-	const beforeFile = process.argv[3];
-	const prefix = path.dirname(path.dirname(path.resolve(file))) + "/";
+    const file = process.argv[2];
+    const beforeFile = process.argv[3];
+    const prefix = path.dirname(path.dirname(path.resolve(file))) + "/";
 
-	const content = await fs.readFile(file, "utf-8");
-	const lcov = await parse(content);
+    const content = await fs.readFile(file, "utf-8");
+    const lcov = await parse(content);
 
-	let before;
-	if (beforeFile) {
-		const content = await fs.readFile(beforeFile, "utf-8");
-		before = await parse(content);
-	}
+    let before;
+    if (beforeFile) {
+        const content = await fs.readFile(beforeFile, "utf-8");
+        before = await parse(content);
+    }
 
-	const options = {
-		repository: "example/foo",
-		commit: "f9d42291812ed03bb197e48050ac38ac6befe4e5",
-		prefix,
-		head: "feat/test",
-		base: "master",
-	};
+    const options = {
+        repository: "example/foo",
+        commit: "f9d42291812ed03bb197e48050ac38ac6befe4e5",
+        prefix,
+        head: "feat/test",
+        base: "master",
+    };
 
-	console.log(diff(lcov, before, options));
+    console.log(diff(lcov, before, options));
 }
 
 main().catch(function(err) {
-	console.log(err);
-	process.exit(1);
+    console.log(err);
+    process.exit(1);
 });

--- a/src/comment.js
+++ b/src/comment.js
@@ -2,13 +2,28 @@ import { details, summary, b, fragment, table, tbody, tr, th } from "./html";
 import { percentage } from "./lcov";
 import { tabulate } from "./tabulate";
 
-export function commentForMonorepo(lcovArrayForMonorepo, options) {
+export function commentForMonorepo(
+	lcovArrayForMonorepo,
+	lcovBaseArrayForMonorepo,
+	options,
+) {
 	const html = lcovArrayForMonorepo.map(lcovObj => {
+		const pbefore = percentage(
+			lcovBaseArrayForMonorepo.find(
+				el => el.packageName === lcovObj.packageName,
+			).lcov,
+		);
+		const pafter = percentage(lcovObj.lcov);
+		const pdiff = pafter - pbefore;
+		const plus = pdiff > 0 ? "+" : "";
+		const arrow = pdiff === 0 ? "" : pdiff < 0 ? "▾" : "▴";
+
 		return `${table(
 			tbody(
 				tr(
 					th(lcovObj.packageName),
 					th(percentage(lcovObj.lcov).toFixed(2), "%"),
+					th(arrow, " ", plus, pdiff.toFixed(2), "%"),
 				),
 			),
 		)} \n\n ${details(
@@ -63,10 +78,11 @@ export function diffForMonorepo(
 	lcovBaseArrayForMonorepo,
 	options,
 ) {
-	if (!lcovBaseArrayForMonorepo.length) {
-		return commentForMonorepo(lcovArrayForMonorepo, options);
-	}
-
+	return commentForMonorepo(
+		lcovArrayForMonorepo,
+		lcovBaseArrayForMonorepo,
+		options,
+	);
 	// const pbefore = percentage(before);
 	// const pafter = percentage(lcov);
 	// const pdiff = pafter - pbefore;

--- a/src/comment.js
+++ b/src/comment.js
@@ -4,12 +4,21 @@ import { percentage } from "./lcov";
 import { tabulate } from "./tabulate";
 
 export function comment(lcov, lcovArrayWithRaw, options) {
-	console.log("lcovArrayWithRaw", lcovArrayWithRaw);
+	const tableHTML = lcovArrayWithRaw.map(lcovObj => {
+		return `${lcovObj.packageName} - ${table(
+			tbody(tr(th(percentage(lcovObj.lcov).toFixed(2), "%"))),
+		)} \n\n`;
+	});
+
+	const detailsHTML = lcovArrayWithRaw.map(lcovObj => {
+		return details(summary("Coverage Report"), tabulate(lcovObj.lcov, options));
+	});
+
 	return fragment(
 		`Coverage after merging ${b(options.head)} into ${b(options.base)}`,
-		table(tbody(tr(th(percentage(lcov).toFixed(2), "%")))),
+		tableHTML.join(""),
 		"\n\n",
-		details(summary("Coverage Report"), tabulate(lcov, options)),
+		detailsHTML.join(""),
 	);
 }
 

--- a/src/comment.js
+++ b/src/comment.js
@@ -17,12 +17,16 @@ export function commentForMonorepo(
 		const plus = pdiff > 0 ? "+" : "";
 		const arrow = pdiff === 0 ? "" : pdiff < 0 ? "▾" : "▴";
 
+		const pdiffHtml = baseLcov
+			? th(arrow, " ", plus, pdiff.toFixed(2), "%")
+			: "";
+
 		return `${table(
 			tbody(
 				tr(
 					th(lcovObj.packageName),
 					th(percentage(lcovObj.lcov).toFixed(2), "%"),
-					th(arrow, " ", plus, pdiff.toFixed(2), "%"),
+					pdiffHtml,
 				),
 			),
 		)} \n\n ${details(

--- a/src/comment.js
+++ b/src/comment.js
@@ -5,8 +5,13 @@ import { tabulate } from "./tabulate";
 
 export function comment(lcov, lcovArrayWithRaw, options) {
 	const HTML = lcovArrayWithRaw.map(lcovObj => {
-		return `${lcovObj.packageName} - ${table(
-			tbody(tr(th(percentage(lcovObj.lcov).toFixed(2), "%"))),
+		return `${table(
+			tbody(
+				tr(
+					th(lcovObj.packageName),
+					th(percentage(lcovObj.lcov).toFixed(2), "%"),
+				),
+			),
 		)} \n\n ${details(
 			summary("Coverage Report"),
 			tabulate(lcovObj.lcov, options),

--- a/src/comment.js
+++ b/src/comment.js
@@ -62,7 +62,9 @@ export function comment(lcov, before, options) {
 	const pdiffHtml = before ? th(arrow, " ", plus, pdiff.toFixed(2), "%") : "";
 
 	return fragment(
-		`Coverage after merging ${b(options.head)} into ${b(options.base)} <p></p>`,
+		`Coverage after merging ${b(options.head)} into ${b(
+			options.base,
+		)} <p></p>`,
 		table(tbody(tr(th(percentage(lcov).toFixed(2), "%"), pdiffHtml))),
 		"\n\n",
 		details(summary("Coverage Report"), tabulate(lcov, options)),

--- a/src/comment.js
+++ b/src/comment.js
@@ -8,12 +8,11 @@ export function commentForMonorepo(
 	options,
 ) {
 	const html = lcovArrayForMonorepo.map(lcovObj => {
-		const pbefore = percentage(
-			lcovBaseArrayForMonorepo.find(
-				el => el.packageName === lcovObj.packageName,
-			).lcov,
+		const baseLcov = lcovBaseArrayForMonorepo.find(
+			el => el.packageName === lcovObj.packageName,
 		);
-		const pafter = percentage(lcovObj.lcov);
+		const pbefore = baseLcov ? percentage(baseLcov) : 0;
+		const pafter = baseLcov ? percentage(lcovObj.lcov) : 0;
 		const pdiff = pafter - pbefore;
 		const plus = pdiff > 0 ? "+" : "";
 		const arrow = pdiff === 0 ? "" : pdiff < 0 ? "▾" : "▴";

--- a/src/comment.js
+++ b/src/comment.js
@@ -3,18 +3,24 @@ import { details, summary, b, fragment, table, tbody, tr, th } from "./html";
 import { percentage } from "./lcov";
 import { tabulate } from "./tabulate";
 
-export function comment(lcov, options) {
+export function comment(lcovArrayWithRaw, lcov, options) {
+	const tableHTML = lcovArrayWithRaw.map(lcovObj => {
+		return `${lcovObj.packageName} - ${table(
+			tbody(tr(th(percentage(lcovObj.lcov).toFixed(2), "%"))),
+		)} \n\n`;
+	});
+
 	return fragment(
 		`Coverage after merging ${b(options.head)} into ${b(options.base)}`,
-		table(tbody(tr(th(percentage(lcov).toFixed(2), "%")))),
+		tableHTML.join(""),
 		"\n\n",
 		details(summary("Coverage Report"), tabulate(lcov, options)),
 	);
 }
 
-export function diff(lcov, before, options) {
+export function diff(lcovArrayWithRaw, lcov, before, options) {
 	if (!before) {
-		return comment(lcov, options);
+		return comment(lcovArrayWithRaw, lcov, options);
 	}
 
 	const pbefore = percentage(before);

--- a/src/comment.js
+++ b/src/comment.js
@@ -63,7 +63,7 @@ export function diffForMonorepo(
 	lcovBaseArrayForMonorepo,
 	options,
 ) {
-	if (!lcovBaseArrayForMonorepo) {
+	if (!lcovBaseArrayForMonorepo.length) {
 		return commentForMonorepo(lcovArrayForMonorepo, options);
 	}
 

--- a/src/comment.js
+++ b/src/comment.js
@@ -19,7 +19,7 @@ export function comment(lcov, lcovArrayWithRaw, options) {
 	});
 
 	return fragment(
-		`Coverage after merging ${b(options.head)} into ${b(options.base)}`,
+		`Coverage after merging ${b(options.head)} into ${b(options.base)} <br/>`,
 		HTML.join(""),
 	);
 }

--- a/src/comment.js
+++ b/src/comment.js
@@ -14,7 +14,6 @@ export function comment(lcovArrayWithRaw, lcov, options) {
 		`Coverage after merging ${b(options.head)} into ${b(options.base)}`,
 		tableHTML.join(""),
 		"\n\n",
-		details(summary("Coverage Report"), tabulate(lcov, options)),
 	);
 }
 

--- a/src/comment.js
+++ b/src/comment.js
@@ -1,10 +1,9 @@
 import { details, summary, b, fragment, table, tbody, tr, th } from "./html";
-
 import { percentage } from "./lcov";
 import { tabulate } from "./tabulate";
 
 export function commentForMonorepo(lcovArrayForMonorepo, options) {
-	const HTML = lcovArrayForMonorepo.map(lcovObj => {
+	const html = lcovArrayForMonorepo.map(lcovObj => {
 		return `${table(
 			tbody(
 				tr(
@@ -19,8 +18,8 @@ export function commentForMonorepo(lcovArrayForMonorepo, options) {
 	});
 
 	return fragment(
-		`Coverage after merging ${b(options.head)} into ${b(options.base)} <p></p>`,
-		HTML.join(""),
+		`Coverage after merging into ${b(options.base)} <p></p>`,
+		html.join(""),
 	);
 }
 

--- a/src/comment.js
+++ b/src/comment.js
@@ -62,7 +62,7 @@ export function comment(lcov, before, options) {
 	const pdiffHtml = before ? th(arrow, " ", plus, pdiff.toFixed(2), "%") : "";
 
 	return fragment(
-		`Coverage after merging ${b(options.head)} into ${b(options.base)}`,
+		`Coverage after merging ${b(options.head)} into ${b(options.base)} <p></p>`,
 		table(tbody(tr(th(percentage(lcov).toFixed(2), "%"), pdiffHtml))),
 		"\n\n",
 		details(summary("Coverage Report"), tabulate(lcov, options)),

--- a/src/comment.js
+++ b/src/comment.js
@@ -9,42 +9,42 @@ import { tabulate } from "./tabulate";
  * @param {*} options
  */
 export function commentForMonorepo(
-	lcovArrayForMonorepo,
-	lcovBaseArrayForMonorepo,
-	options,
+    lcovArrayForMonorepo,
+    lcovBaseArrayForMonorepo,
+    options,
 ) {
-	const html = lcovArrayForMonorepo.map(lcovObj => {
-		const baseLcov = lcovBaseArrayForMonorepo.find(
-			el => el.packageName === lcovObj.packageName,
-		);
-		const pbefore = baseLcov ? percentage(baseLcov) : 0;
-		const pafter = baseLcov ? percentage(lcovObj.lcov) : 0;
-		const pdiff = pafter - pbefore;
-		const plus = pdiff > 0 ? "+" : "";
-		const arrow = pdiff === 0 ? "" : pdiff < 0 ? "▾" : "▴";
+    const html = lcovArrayForMonorepo.map(lcovObj => {
+        const baseLcov = lcovBaseArrayForMonorepo.find(
+            el => el.packageName === lcovObj.packageName,
+        );
+        const pbefore = baseLcov ? percentage(baseLcov) : 0;
+        const pafter = baseLcov ? percentage(lcovObj.lcov) : 0;
+        const pdiff = pafter - pbefore;
+        const plus = pdiff > 0 ? "+" : "";
+        const arrow = pdiff === 0 ? "" : pdiff < 0 ? "▾" : "▴";
 
-		const pdiffHtml = baseLcov
-			? th(arrow, " ", plus, pdiff.toFixed(2), "%")
-			: "";
+        const pdiffHtml = baseLcov
+            ? th(arrow, " ", plus, pdiff.toFixed(2), "%")
+            : "";
 
-		return `${table(
-			tbody(
-				tr(
-					th(lcovObj.packageName),
-					th(percentage(lcovObj.lcov).toFixed(2), "%"),
-					pdiffHtml,
-				),
-			),
-		)} \n\n ${details(
-			summary("Coverage Report"),
-			tabulate(lcovObj.lcov, options),
-		)} <br/>`;
-	});
+        return `${table(
+            tbody(
+                tr(
+                    th(lcovObj.packageName),
+                    th(percentage(lcovObj.lcov).toFixed(2), "%"),
+                    pdiffHtml,
+                ),
+            ),
+        )} \n\n ${details(
+            summary("Coverage Report"),
+            tabulate(lcovObj.lcov, options),
+        )} <br/>`;
+    });
 
-	return fragment(
-		`Coverage after merging into ${b(options.base)} <p></p>`,
-		html.join(""),
-	);
+    return fragment(
+        `Coverage after merging into ${b(options.base)} <p></p>`,
+        html.join(""),
+    );
 }
 
 /**
@@ -53,22 +53,22 @@ export function commentForMonorepo(
  * @param {*} options
  */
 export function comment(lcov, before, options) {
-	const pbefore = before ? percentage(before) : 0;
-	const pafter = before ? percentage(lcov) : 0;
-	const pdiff = pafter - pbefore;
-	const plus = pdiff > 0 ? "+" : "";
-	const arrow = pdiff === 0 ? "" : pdiff < 0 ? "▾" : "▴";
+    const pbefore = before ? percentage(before) : 0;
+    const pafter = before ? percentage(lcov) : 0;
+    const pdiff = pafter - pbefore;
+    const plus = pdiff > 0 ? "+" : "";
+    const arrow = pdiff === 0 ? "" : pdiff < 0 ? "▾" : "▴";
 
-	const pdiffHtml = before ? th(arrow, " ", plus, pdiff.toFixed(2), "%") : "";
+    const pdiffHtml = before ? th(arrow, " ", plus, pdiff.toFixed(2), "%") : "";
 
-	return fragment(
-		`Coverage after merging ${b(options.head)} into ${b(
-			options.base,
-		)} <p></p>`,
-		table(tbody(tr(th(percentage(lcov).toFixed(2), "%"), pdiffHtml))),
-		"\n\n",
-		details(summary("Coverage Report"), tabulate(lcov, options)),
-	);
+    return fragment(
+        `Coverage after merging ${b(options.head)} into ${b(
+            options.base,
+        )} <p></p>`,
+        table(tbody(tr(th(percentage(lcov).toFixed(2), "%"), pdiffHtml))),
+        "\n\n",
+        details(summary("Coverage Report"), tabulate(lcov, options)),
+    );
 }
 
 /**
@@ -78,7 +78,7 @@ export function comment(lcov, before, options) {
  * @param {*} options
  */
 export function diff(lcov, before, options) {
-	return comment(lcov, before, options);
+    return comment(lcov, before, options);
 }
 
 /**
@@ -88,13 +88,13 @@ export function diff(lcov, before, options) {
  * @param {*} options
  */
 export function diffForMonorepo(
-	lcovArrayForMonorepo,
-	lcovBaseArrayForMonorepo,
-	options,
+    lcovArrayForMonorepo,
+    lcovBaseArrayForMonorepo,
+    options,
 ) {
-	return commentForMonorepo(
-		lcovArrayForMonorepo,
-		lcovBaseArrayForMonorepo,
-		options,
-	);
+    return commentForMonorepo(
+        lcovArrayForMonorepo,
+        lcovBaseArrayForMonorepo,
+        options,
+    );
 }

--- a/src/comment.js
+++ b/src/comment.js
@@ -2,6 +2,12 @@ import { details, summary, b, fragment, table, tbody, tr, th } from "./html";
 import { percentage } from "./lcov";
 import { tabulate } from "./tabulate";
 
+/**
+ * Github comment for monorepo
+ * @param {Array<{packageName, lcovPath}>} lcovArrayForMonorepo
+ * @param {{Array<{packageName, lcovBasePath}>}} lcovBaseArrayForMonorepo
+ * @param {*} options
+ */
 export function commentForMonorepo(
 	lcovArrayForMonorepo,
 	lcovBaseArrayForMonorepo,
@@ -41,41 +47,44 @@ export function commentForMonorepo(
 	);
 }
 
-export function comment(lcov, options) {
-	return fragment(
-		`Coverage after merging ${b(options.head)} into ${b(options.base)}`,
-		table(tbody(tr(th(percentage(lcov).toFixed(2), "%")))),
-		"\n\n",
-		details(summary("Coverage Report"), tabulate(lcov, options)),
-	);
-}
-
-export function diff(lcov, before, options) {
-	if (!before) {
-		return comment(lcov, options);
-	}
-
-	const pbefore = percentage(before);
-	const pafter = percentage(lcov);
+/**
+ * Github comment for single repo
+ * @param {raw lcov} lcov
+ * @param {*} options
+ */
+export function comment(lcov, before, options) {
+	const pbefore = before ? percentage(before) : 0;
+	const pafter = before ? percentage(lcov) : 0;
 	const pdiff = pafter - pbefore;
 	const plus = pdiff > 0 ? "+" : "";
 	const arrow = pdiff === 0 ? "" : pdiff < 0 ? "▾" : "▴";
 
+	const pdiffHtml = before ? th(arrow, " ", plus, pdiff.toFixed(2), "%") : "";
+
 	return fragment(
 		`Coverage after merging ${b(options.head)} into ${b(options.base)}`,
-		table(
-			tbody(
-				tr(
-					th(pafter.toFixed(2), "%"),
-					th(arrow, " ", plus, pdiff.toFixed(2), "%"),
-				),
-			),
-		),
+		table(tbody(tr(th(percentage(lcov).toFixed(2), "%"), pdiffHtml))),
 		"\n\n",
 		details(summary("Coverage Report"), tabulate(lcov, options)),
 	);
 }
 
+/**
+ * Diff in coverage percentage for single repo
+ * @param {raw lcov} lcov
+ * @param {raw base lcov} before
+ * @param {*} options
+ */
+export function diff(lcov, before, options) {
+	return comment(lcov, before, options);
+}
+
+/**
+ * Diff in coverage percentage for monorepo
+ * @param {Array<{packageName, lcovPath}>} lcovArrayForMonorepo
+ * @param {{Array<{packageName, lcovBasePath}>}} lcovBaseArrayForMonorepo
+ * @param {*} options
+ */
 export function diffForMonorepo(
 	lcovArrayForMonorepo,
 	lcovBaseArrayForMonorepo,
@@ -86,23 +95,4 @@ export function diffForMonorepo(
 		lcovBaseArrayForMonorepo,
 		options,
 	);
-	// const pbefore = percentage(before);
-	// const pafter = percentage(lcov);
-	// const pdiff = pafter - pbefore;
-	// const plus = pdiff > 0 ? "+" : "";
-	// const arrow = pdiff === 0 ? "" : pdiff < 0 ? "▾" : "▴";
-
-	// return fragment(
-	// 	`Coverage after merging ${b(options.head)} into ${b(options.base)}`,
-	// 	table(
-	// 		tbody(
-	// 			tr(
-	// 				th(pafter.toFixed(2), "%"),
-	// 				th(arrow, " ", plus, pdiff.toFixed(2), "%"),
-	// 			),
-	// 		),
-	// 	),
-	// 	"\n\n",
-	// 	details(summary("Coverage Report"), tabulate(lcov, options)),
-	// );
 }

--- a/src/comment.js
+++ b/src/comment.js
@@ -19,7 +19,7 @@ export function comment(lcov, lcovArrayWithRaw, options) {
 	});
 
 	return fragment(
-		`Coverage after merging ${b(options.head)} into ${b(options.base)} <br/>`,
+		`Coverage after merging ${b(options.head)} into ${b(options.base)} <p></p>`,
 		HTML.join(""),
 	);
 }

--- a/src/comment.js
+++ b/src/comment.js
@@ -4,21 +4,18 @@ import { percentage } from "./lcov";
 import { tabulate } from "./tabulate";
 
 export function comment(lcov, lcovArrayWithRaw, options) {
-	const tableHTML = lcovArrayWithRaw.map(lcovObj => {
+	const HTML = lcovArrayWithRaw.map(lcovObj => {
 		return `${lcovObj.packageName} - ${table(
 			tbody(tr(th(percentage(lcovObj.lcov).toFixed(2), "%"))),
-		)} \n\n`;
-	});
-
-	const detailsHTML = lcovArrayWithRaw.map(lcovObj => {
-		return details(summary("Coverage Report"), tabulate(lcovObj.lcov, options));
+		)} \n\n ${details(
+			summary("Coverage Report"),
+			tabulate(lcovObj.lcov, options),
+		)}`;
 	});
 
 	return fragment(
 		`Coverage after merging ${b(options.head)} into ${b(options.base)}`,
-		tableHTML.join(""),
-		"\n\n",
-		detailsHTML.join(""),
+		HTML.join(""),
 	);
 }
 

--- a/src/comment.js
+++ b/src/comment.js
@@ -3,7 +3,8 @@ import { details, summary, b, fragment, table, tbody, tr, th } from "./html";
 import { percentage } from "./lcov";
 import { tabulate } from "./tabulate";
 
-export function comment(lcov, options) {
+export function comment(lcov, lcovArrayWithRaw, options) {
+	console.log("lcovArrayWithRaw", lcovArrayWithRaw);
 	return fragment(
 		`Coverage after merging ${b(options.head)} into ${b(options.base)}`,
 		table(tbody(tr(th(percentage(lcov).toFixed(2), "%")))),
@@ -12,9 +13,9 @@ export function comment(lcov, options) {
 	);
 }
 
-export function diff(lcov, before, options) {
+export function diff(lcov, lcovArrayWithRaw, before, options) {
 	if (!before) {
-		return comment(lcov, options);
+		return comment(lcov, lcovArrayWithRaw, options);
 	}
 
 	const pbefore = percentage(before);

--- a/src/comment.js
+++ b/src/comment.js
@@ -32,13 +32,9 @@ export function comment(lcov, options) {
 	);
 }
 
-export function diff(lcov, lcovArrayForMonorepo, before, options) {
+export function diff(lcov, before, options) {
 	if (!before) {
-		if (lcovArrayForMonorepo.length) {
-			return commentForMonorepo(lcovArrayForMonorepo, options);
-		} else {
-			return comment(lcov, lcovArrayForMonorepo, options);
-		}
+		return comment(lcov, options);
 	}
 
 	const pbefore = percentage(before);
@@ -60,4 +56,34 @@ export function diff(lcov, lcovArrayForMonorepo, before, options) {
 		"\n\n",
 		details(summary("Coverage Report"), tabulate(lcov, options)),
 	);
+}
+
+export function diffForMonorepo(
+	lcovArrayForMonorepo,
+	lcovBaseArrayForMonorepo,
+	options,
+) {
+	if (!lcovBaseArrayForMonorepo) {
+		return commentForMonorepo(lcovArrayForMonorepo, options);
+	}
+
+	// const pbefore = percentage(before);
+	// const pafter = percentage(lcov);
+	// const pdiff = pafter - pbefore;
+	// const plus = pdiff > 0 ? "+" : "";
+	// const arrow = pdiff === 0 ? "" : pdiff < 0 ? "▾" : "▴";
+
+	// return fragment(
+	// 	`Coverage after merging ${b(options.head)} into ${b(options.base)}`,
+	// 	table(
+	// 		tbody(
+	// 			tr(
+	// 				th(pafter.toFixed(2), "%"),
+	// 				th(arrow, " ", plus, pdiff.toFixed(2), "%"),
+	// 			),
+	// 		),
+	// 	),
+	// 	"\n\n",
+	// 	details(summary("Coverage Report"), tabulate(lcov, options)),
+	// );
 }

--- a/src/comment.js
+++ b/src/comment.js
@@ -3,8 +3,7 @@ import { details, summary, b, fragment, table, tbody, tr, th } from "./html";
 import { percentage } from "./lcov";
 import { tabulate } from "./tabulate";
 
-export function comment(lcov, lcovArrayWithRaw, options) {
-	console.log("lcovArrayWithRaw", lcovArrayWithRaw);
+export function comment(lcov, options) {
 	return fragment(
 		`Coverage after merging ${b(options.head)} into ${b(options.base)}`,
 		table(tbody(tr(th(percentage(lcov).toFixed(2), "%")))),
@@ -15,7 +14,8 @@ export function comment(lcov, lcovArrayWithRaw, options) {
 
 export function diff(lcov, lcovArrayWithRaw, before, options) {
 	if (!before) {
-		return comment(lcov, lcovArrayWithRaw, options);
+		console.log("lcovArrayWithRaw", lcovArrayWithRaw);
+		return comment(lcov, options);
 	}
 
 	const pbefore = percentage(before);

--- a/src/comment.js
+++ b/src/comment.js
@@ -3,7 +3,8 @@ import { details, summary, b, fragment, table, tbody, tr, th } from "./html";
 import { percentage } from "./lcov";
 import { tabulate } from "./tabulate";
 
-export function comment(lcov, options) {
+export function comment(lcov, lcovArrayWithRaw, options) {
+	console.log("lcovArrayWithRaw", lcovArrayWithRaw);
 	return fragment(
 		`Coverage after merging ${b(options.head)} into ${b(options.base)}`,
 		table(tbody(tr(th(percentage(lcov).toFixed(2), "%")))),
@@ -14,8 +15,7 @@ export function comment(lcov, options) {
 
 export function diff(lcov, lcovArrayWithRaw, before, options) {
 	if (!before) {
-		console.log("lcovArrayWithRaw", lcovArrayWithRaw);
-		return comment(lcov, options);
+		return comment(lcov, lcovArrayWithRaw, options);
 	}
 
 	const pbefore = percentage(before);

--- a/src/comment.js
+++ b/src/comment.js
@@ -3,8 +3,8 @@ import { details, summary, b, fragment, table, tbody, tr, th } from "./html";
 import { percentage } from "./lcov";
 import { tabulate } from "./tabulate";
 
-export function comment(lcov, lcovArrayWithRaw, options) {
-	const HTML = lcovArrayWithRaw.map(lcovObj => {
+export function commentForMonorepo(lcovArrayForMonorepo, options) {
+	const HTML = lcovArrayForMonorepo.map(lcovObj => {
 		return `${table(
 			tbody(
 				tr(
@@ -24,9 +24,22 @@ export function comment(lcov, lcovArrayWithRaw, options) {
 	);
 }
 
-export function diff(lcov, lcovArrayWithRaw, before, options) {
+export function comment(lcov, options) {
+	return fragment(
+		`Coverage after merging ${b(options.head)} into ${b(options.base)}`,
+		table(tbody(tr(th(percentage(lcov).toFixed(2), "%")))),
+		"\n\n",
+		details(summary("Coverage Report"), tabulate(lcov, options)),
+	);
+}
+
+export function diff(lcov, lcovArrayForMonorepo, before, options) {
 	if (!before) {
-		return comment(lcov, lcovArrayWithRaw, options);
+		if (lcovArrayForMonorepo.length) {
+			return commentForMonorepo(lcovArrayForMonorepo, options);
+		} else {
+			return comment(lcov, lcovArrayForMonorepo, options);
+		}
 	}
 
 	const pbefore = percentage(before);

--- a/src/comment.js
+++ b/src/comment.js
@@ -15,7 +15,7 @@ export function comment(lcov, lcovArrayWithRaw, options) {
 		)} \n\n ${details(
 			summary("Coverage Report"),
 			tabulate(lcovObj.lcov, options),
-		)}`;
+		)} <br/>`;
 	});
 
 	return fragment(

--- a/src/comment.js
+++ b/src/comment.js
@@ -3,23 +3,18 @@ import { details, summary, b, fragment, table, tbody, tr, th } from "./html";
 import { percentage } from "./lcov";
 import { tabulate } from "./tabulate";
 
-export function comment(lcovArrayWithRaw, lcov, options) {
-	const tableHTML = lcovArrayWithRaw.map(lcovObj => {
-		return `${lcovObj.packageName} - ${table(
-			tbody(tr(th(percentage(lcovObj.lcov).toFixed(2), "%"))),
-		)} \n\n`;
-	});
-
+export function comment(lcov, options) {
 	return fragment(
 		`Coverage after merging ${b(options.head)} into ${b(options.base)}`,
-		tableHTML.join(""),
+		table(tbody(tr(th(percentage(lcov).toFixed(2), "%")))),
 		"\n\n",
+		details(summary("Coverage Report"), tabulate(lcov, options)),
 	);
 }
 
-export function diff(lcovArrayWithRaw, lcov, before, options) {
+export function diff(lcov, before, options) {
 	if (!before) {
-		return comment(lcovArrayWithRaw, lcov, options);
+		return comment(lcov, options);
 	}
 
 	const pbefore = percentage(before);

--- a/src/github.js
+++ b/src/github.js
@@ -16,67 +16,67 @@ const hiddenHeader = `<!-- monorepo-jest-reporter-action -->`;
 const appendHiddenHeaderToComment = body => hiddenHeader + body;
 
 const listComments = async ({ client, context, prNumber, commentHeader }) => {
-	const { data: existingComments } = await client.issues.listComments({
-		...context.repo,
-		issue_number: prNumber,
-	});
+    const { data: existingComments } = await client.issues.listComments({
+        ...context.repo,
+        issue_number: prNumber,
+    });
 
-	return existingComments.filter(({ body }) => body.startsWith(hiddenHeader));
+    return existingComments.filter(({ body }) => body.startsWith(hiddenHeader));
 };
 
 const insertComment = async ({ client, context, prNumber, body }) =>
-	client.issues.createComment({
-		...context.repo,
-		issue_number: prNumber,
-		body: appendHiddenHeaderToComment(body),
-	});
+    client.issues.createComment({
+        ...context.repo,
+        issue_number: prNumber,
+        body: appendHiddenHeaderToComment(body),
+    });
 
 const updateComment = async ({ client, context, body, commentId }) =>
-	client.issues.updateComment({
-		...context.repo,
-		comment_id: commentId,
-		body: appendHiddenHeaderToComment(body),
-	});
+    client.issues.updateComment({
+        ...context.repo,
+        comment_id: commentId,
+        body: appendHiddenHeaderToComment(body),
+    });
 
 const deleteComments = async ({ client, context, comments }) =>
-	Promise.all(
-		comments.map(({ id }) =>
-			client.issues.deleteComment({
-				...context.repo,
-				comment_id: id,
-			}),
-		),
-	);
+    Promise.all(
+        comments.map(({ id }) =>
+            client.issues.deleteComment({
+                ...context.repo,
+                comment_id: id,
+            }),
+        ),
+    );
 
 const upsertComment = async ({ client, context, prNumber, body }) => {
-	const existingComments = await listComments({
-		client,
-		context,
-		prNumber,
-	});
-	const last = existingComments.pop();
+    const existingComments = await listComments({
+        client,
+        context,
+        prNumber,
+    });
+    const last = existingComments.pop();
 
-	await deleteComments({
-		client,
-		context,
-		comments: existingComments,
-	});
+    await deleteComments({
+        client,
+        context,
+        comments: existingComments,
+    });
 
-	return last
-		? updateComment({
-				client,
-				context,
-				body,
-				commentId: last.id,
-		  })
-		: insertComment({
-				client,
-				context,
-				prNumber,
-				body,
-		  });
+    return last
+        ? updateComment({
+              client,
+              context,
+              body,
+              commentId: last.id,
+          })
+        : insertComment({
+              client,
+              context,
+              prNumber,
+              body,
+          });
 };
 
 module.exports = {
-	upsertComment,
+    upsertComment,
 };

--- a/src/html.js
+++ b/src/html.js
@@ -1,17 +1,17 @@
 function tag(name) {
-	return function(...children) {
-		const props =
-			typeof children[0] === "object"
-				? Object.keys(children[0])
-						.map(key => ` ${key}='${children[0][key]}'`)
-						.join("")
-				: "";
+    return function(...children) {
+        const props =
+            typeof children[0] === "object"
+                ? Object.keys(children[0])
+                      .map(key => ` ${key}='${children[0][key]}'`)
+                      .join("")
+                : "";
 
-		const c =
-			typeof children[0] === "string" ? children : children.slice(1);
+        const c =
+            typeof children[0] === "string" ? children : children.slice(1);
 
-		return `<${name}${props}>${c.join("")}</${name}>`;
-	};
+        return `<${name}${props}>${c.join("")}</${name}>`;
+    };
 }
 
 export const details = tag("details");
@@ -26,5 +26,5 @@ export const a = tag("a");
 export const span = tag("span");
 
 export const fragment = function(...children) {
-	return children.join("");
+    return children.join("");
 };

--- a/src/html.js
+++ b/src/html.js
@@ -7,7 +7,8 @@ function tag(name) {
 						.join("")
 				: "";
 
-		const c = typeof children[0] === "string" ? children : children.slice(1);
+		const c =
+			typeof children[0] === "string" ? children : children.slice(1);
 
 		return `<${name}${props}>${c.join("")}</${name}>`;
 	};

--- a/src/html_test.js
+++ b/src/html_test.js
@@ -1,41 +1,41 @@
 import {
-	details,
-	summary,
-	tr,
-	td,
-	th,
-	b,
-	table,
-	tbody,
-	a,
-	span,
-	fragment,
+    details,
+    summary,
+    tr,
+    td,
+    th,
+    b,
+    table,
+    tbody,
+    a,
+    span,
+    fragment,
 } from "./html";
 
 test("html tags should return the correct html", function() {
-	expect(details("foo", "bar")).toBe("<details>foobar</details>");
-	expect(summary("foo", "bar")).toBe("<summary>foobar</summary>");
-	expect(tr("foo", "bar")).toBe("<tr>foobar</tr>");
-	expect(td("foo", "bar")).toBe("<td>foobar</td>");
-	expect(th("foo", "bar")).toBe("<th>foobar</th>");
-	expect(b("foo", "bar")).toBe("<b>foobar</b>");
-	expect(table("foo", "bar")).toBe("<table>foobar</table>");
-	expect(tbody("foo", "bar")).toBe("<tbody>foobar</tbody>");
-	expect(a("foo", "bar")).toBe("<a>foobar</a>");
-	expect(span("foo", "bar")).toBe("<span>foobar</span>");
+    expect(details("foo", "bar")).toBe("<details>foobar</details>");
+    expect(summary("foo", "bar")).toBe("<summary>foobar</summary>");
+    expect(tr("foo", "bar")).toBe("<tr>foobar</tr>");
+    expect(td("foo", "bar")).toBe("<td>foobar</td>");
+    expect(th("foo", "bar")).toBe("<th>foobar</th>");
+    expect(b("foo", "bar")).toBe("<b>foobar</b>");
+    expect(table("foo", "bar")).toBe("<table>foobar</table>");
+    expect(tbody("foo", "bar")).toBe("<tbody>foobar</tbody>");
+    expect(a("foo", "bar")).toBe("<a>foobar</a>");
+    expect(span("foo", "bar")).toBe("<span>foobar</span>");
 });
 
 test("html fragment should return the children", function() {
-	expect(fragment()).toBe("");
-	expect(fragment("foo")).toBe("foo");
-	expect(fragment("foo", "bar")).toBe("foobar");
+    expect(fragment()).toBe("");
+    expect(fragment("foo")).toBe("foo");
+    expect(fragment("foo", "bar")).toBe("foobar");
 });
 
 test("html tags should accept props", function() {
-	expect(a({ href: "http://www.example.com" }, "example")).toBe(
-		"<a href='http://www.example.com'>example</a>",
-	);
-	expect(
-		a({ href: "http://www.example.com", target: "_blank" }, "example"),
-	).toBe("<a href='http://www.example.com' target='_blank'>example</a>");
+    expect(a({ href: "http://www.example.com" }, "example")).toBe(
+        "<a href='http://www.example.com'>example</a>",
+    );
+    expect(
+        a({ href: "http://www.example.com", target: "_blank" }, "example"),
+    ).toBe("<a href='http://www.example.com' target='_blank'>example</a>");
 });

--- a/src/index.js
+++ b/src/index.js
@@ -54,8 +54,6 @@ async function main() {
 		}
 	}
 
-	console.log("lcovArrayWithRaw", lcovArrayWithRaw);
-
 	const options = {
 		repository: context.payload.repository.full_name,
 		commit: context.payload.pull_request.head.sha,
@@ -72,7 +70,7 @@ async function main() {
 		repo: context.repo.repo,
 		owner: context.repo.owner,
 		issue_number: context.payload.pull_request.number,
-		body: diff(lcov, baselcov, options),
+		body: diff(lcov, lcovArrayWithRaw, baselcov, options),
 	});
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -64,7 +64,6 @@ async function main() {
 
 	const lcov = await parse(raw);
 	const baselcov = baseRaw && (await parse(baseRaw));
-	const body = diff(lcov, baselcov, options);
 
 	await new GitHub(token).issues.createComment({
 		repo: context.repo.repo,

--- a/src/index.js
+++ b/src/index.js
@@ -73,8 +73,6 @@ async function main() {
 		console.log(`No coverage report found at '${baseFile}', ignoring...`);
 	}
 
-	console.log("monorepoBasePath", monorepoBasePath);
-
 	let lcovArray = monorepoBasePath ? getLcovFiles(monorepoBasePath) : [];
 	let lcovBaseArray = monorepoBasePath
 		? getLcovBaseFiles(monorepoBasePath)

--- a/src/index.js
+++ b/src/index.js
@@ -13,19 +13,19 @@ import { upsertComment } from "./github";
  * @return {string[{<package_name>: <path_to_lcov_file>}]} Array with lcove file names with package names as key.
  */
 const getLcovFiles = (dir, filelist = []) => {
-	fs.readdirSync(dir).forEach(file => {
-		filelist = fs.statSync(path.join(dir, file)).isDirectory()
-			? getLcovFiles(path.join(dir, file), filelist)
-			: filelist
-					.filter(file => {
-						return file.path.includes("lcov.info");
-					})
-					.concat({
-						name: dir.split("/")[1],
-						path: path.join(dir, file),
-					});
-	});
-	return filelist;
+    fs.readdirSync(dir).forEach(file => {
+        filelist = fs.statSync(path.join(dir, file)).isDirectory()
+            ? getLcovFiles(path.join(dir, file), filelist)
+            : filelist
+                  .filter(file => {
+                      return file.path.includes("lcov.info");
+                  })
+                  .concat({
+                      name: dir.split("/")[1],
+                      path: path.join(dir, file),
+                  });
+    });
+    return filelist;
 };
 
 /**
@@ -35,102 +35,102 @@ const getLcovFiles = (dir, filelist = []) => {
  * @return {string[{<package_name>: <path_to_lcov_file>}]} Array with lcove file names with package names as key.
  */
 const getLcovBaseFiles = (dir, filelist = []) => {
-	fs.readdirSync(dir).forEach(file => {
-		filelist = fs.statSync(path.join(dir, file)).isDirectory()
-			? getLcovBaseFiles(path.join(dir, file), filelist)
-			: filelist
-					.filter(file => {
-						return file.path.includes("lcov-base.info");
-					})
-					.concat({
-						name: dir.split("/")[1],
-						path: path.join(dir, file),
-					});
-	});
-	return filelist;
+    fs.readdirSync(dir).forEach(file => {
+        filelist = fs.statSync(path.join(dir, file)).isDirectory()
+            ? getLcovBaseFiles(path.join(dir, file), filelist)
+            : filelist
+                  .filter(file => {
+                      return file.path.includes("lcov-base.info");
+                  })
+                  .concat({
+                      name: dir.split("/")[1],
+                      path: path.join(dir, file),
+                  });
+    });
+    return filelist;
 };
 
 async function main() {
-	const { context = {} } = github || {};
+    const { context = {} } = github || {};
 
-	const token = core.getInput("github-token");
-	const lcovFile = core.getInput("lcov-file") || "./coverage/lcov.info";
-	const baseFile = core.getInput("lcov-base");
-	// Add base path for monorepo
-	const monorepoBasePath = core.getInput("monorepo-base-path");
+    const token = core.getInput("github-token");
+    const lcovFile = core.getInput("lcov-file") || "./coverage/lcov.info";
+    const baseFile = core.getInput("lcov-base");
+    // Add base path for monorepo
+    const monorepoBasePath = core.getInput("monorepo-base-path");
 
-	const raw =
-		!monorepoBasePath &&
-		(await promises.readFile(lcovFile, "utf-8").catch(err => null));
-	if (!monorepoBasePath && !raw) {
-		console.log(`No coverage report found at '${lcovFile}', exiting...`);
-		return;
-	}
+    const raw =
+        !monorepoBasePath &&
+        (await promises.readFile(lcovFile, "utf-8").catch(err => null));
+    if (!monorepoBasePath && !raw) {
+        console.log(`No coverage report found at '${lcovFile}', exiting...`);
+        return;
+    }
 
-	const baseRaw =
-		baseFile &&
-		(await promises.readFile(baseFile, "utf-8").catch(err => null));
-	if (!monorepoBasePath && baseFile && !baseRaw) {
-		console.log(`No coverage report found at '${baseFile}', ignoring...`);
-	}
+    const baseRaw =
+        baseFile &&
+        (await promises.readFile(baseFile, "utf-8").catch(err => null));
+    if (!monorepoBasePath && baseFile && !baseRaw) {
+        console.log(`No coverage report found at '${baseFile}', ignoring...`);
+    }
 
-	let lcovArray = monorepoBasePath ? getLcovFiles(monorepoBasePath) : [];
-	let lcovBaseArray = monorepoBasePath
-		? getLcovBaseFiles(monorepoBasePath)
-		: [];
+    let lcovArray = monorepoBasePath ? getLcovFiles(monorepoBasePath) : [];
+    let lcovBaseArray = monorepoBasePath
+        ? getLcovBaseFiles(monorepoBasePath)
+        : [];
 
-	const lcovArrayForMonorepo = [];
-	const lcovBaseArrayForMonorepo = [];
-	for (const file of lcovArray) {
-		if (file.path.includes(".info")) {
-			const raw = await promises.readFile(file.path, "utf8");
-			const data = await parse(raw);
-			lcovArrayForMonorepo.push({
-				packageName: file.name,
-				lcov: data,
-			});
-		}
-	}
+    const lcovArrayForMonorepo = [];
+    const lcovBaseArrayForMonorepo = [];
+    for (const file of lcovArray) {
+        if (file.path.includes(".info")) {
+            const raw = await promises.readFile(file.path, "utf8");
+            const data = await parse(raw);
+            lcovArrayForMonorepo.push({
+                packageName: file.name,
+                lcov: data,
+            });
+        }
+    }
 
-	for (const file of lcovBaseArray) {
-		if (file.path.includes(".info")) {
-			const raw = await promises.readFile(file.path, "utf8");
-			const data = await parse(raw);
-			lcovBaseArrayForMonorepo.push({
-				packageName: file.name,
-				lcov: data,
-			});
-		}
-	}
+    for (const file of lcovBaseArray) {
+        if (file.path.includes(".info")) {
+            const raw = await promises.readFile(file.path, "utf8");
+            const data = await parse(raw);
+            lcovBaseArrayForMonorepo.push({
+                packageName: file.name,
+                lcov: data,
+            });
+        }
+    }
 
-	const options = {
-		repository: context.payload.repository.full_name,
-		commit: context.payload.pull_request.head.sha,
-		prefix: `${process.env.GITHUB_WORKSPACE}/`,
-		head: context.payload.pull_request.head.ref,
-		base: context.payload.pull_request.base.ref,
-	};
+    const options = {
+        repository: context.payload.repository.full_name,
+        commit: context.payload.pull_request.head.sha,
+        prefix: `${process.env.GITHUB_WORKSPACE}/`,
+        head: context.payload.pull_request.head.ref,
+        base: context.payload.pull_request.base.ref,
+    };
 
-	const lcov = !monorepoBasePath && (await parse(raw));
-	const baselcov = baseRaw && (await parse(baseRaw));
+    const lcov = !monorepoBasePath && (await parse(raw));
+    const baselcov = baseRaw && (await parse(baseRaw));
 
-	const client = github.getOctokit(token);
+    const client = github.getOctokit(token);
 
-	await upsertComment({
-		client,
-		context,
-		prNumber: context.payload.pull_request.number,
-		body: !lcovArrayForMonorepo.length
-			? diff(lcov, baselcov, options)
-			: diffForMonorepo(
-					lcovArrayForMonorepo,
-					lcovBaseArrayForMonorepo,
-					options,
-			  ),
-	});
+    await upsertComment({
+        client,
+        context,
+        prNumber: context.payload.pull_request.number,
+        body: !lcovArrayForMonorepo.length
+            ? diff(lcov, baselcov, options)
+            : diffForMonorepo(
+                  lcovArrayForMonorepo,
+                  lcovBaseArrayForMonorepo,
+                  options,
+              ),
+    });
 }
 
 main().catch(function(err) {
-	console.log(err);
-	core.setFailed(err.message);
+    console.log(err);
+    core.setFailed(err.message);
 });

--- a/src/index.js
+++ b/src/index.js
@@ -115,7 +115,7 @@ async function main() {
 		client,
 		context,
 		prNumber: context.payload.pull_request.number,
-		body: lcovArrayForMonorepo.length
+		body: !lcovArrayForMonorepo.length
 			? diff(lcov, baselcov, options)
 			: diffForMonorepo(lcovArrayForMonorepo, lcovBaseArrayForMonorepo.options),
 	});

--- a/src/index.js
+++ b/src/index.js
@@ -11,36 +11,15 @@ import { upsertComment } from "./github";
  * @function getLcovFiles
  * @param  {string} dir Dir path string.
  * @return {string[{<package_name>: <path_to_lcov_file>}]} Array with lcove file names with package names as key.
+ * @param {string} lcovFileName  path string  for lcov file for PR or base lcov file.
  */
-const getLcovFiles = (dir, filelist = []) => {
+const getLcovFiles = (dir, filelist = [], lcovFileName = "lcov.info") => {
     fs.readdirSync(dir).forEach(file => {
         filelist = fs.statSync(path.join(dir, file)).isDirectory()
             ? getLcovFiles(path.join(dir, file), filelist)
             : filelist
                   .filter(file => {
-                      return file.path.includes("lcov.info");
-                  })
-                  .concat({
-                      name: dir.split("/")[1],
-                      path: path.join(dir, file),
-                  });
-    });
-    return filelist;
-};
-
-/**
- * Find all files inside a dir, recursively for base branch.
- * @function getLcovBaseFiles
- * @param  {string} dir Dir path string.
- * @return {string[{<package_name>: <path_to_lcov_file>}]} Array with lcove file names with package names as key.
- */
-const getLcovBaseFiles = (dir, filelist = []) => {
-    fs.readdirSync(dir).forEach(file => {
-        filelist = fs.statSync(path.join(dir, file)).isDirectory()
-            ? getLcovBaseFiles(path.join(dir, file), filelist)
-            : filelist
-                  .filter(file => {
-                      return file.path.includes("lcov-base.info");
+                      return file.path.includes(lcovFileName);
                   })
                   .concat({
                       name: dir.split("/")[1],
@@ -76,7 +55,7 @@ async function main() {
 
     let lcovArray = monorepoBasePath ? getLcovFiles(monorepoBasePath) : [];
     let lcovBaseArray = monorepoBasePath
-        ? getLcovBaseFiles(monorepoBasePath)
+        ? getLcovFiles(monorepoBasePath, "lcov-base.info")
         : [];
 
     const lcovArrayForMonorepo = [];

--- a/src/index.js
+++ b/src/index.js
@@ -59,7 +59,9 @@ async function main() {
 	// Add base path for monorepo
 	const monorepoBasePath = core.getInput("monorepo-base-path");
 
-	const raw = await promises.readFile(lcovFile, "utf-8").catch(err => null);
+	const raw =
+		!monorepoBasePath &&
+		(await promises.readFile(lcovFile, "utf-8").catch(err => null));
 	if (!monorepoBasePath && !raw) {
 		console.log(`No coverage report found at '${lcovFile}', exiting...`);
 		return;
@@ -70,6 +72,8 @@ async function main() {
 	if (!monorepoBasePath && baseFile && !baseRaw) {
 		console.log(`No coverage report found at '${baseFile}', ignoring...`);
 	}
+
+	console.log("monorepoBasePath", monorepoBasePath);
 
 	let lcovArray = monorepoBasePath ? getLcovFiles(monorepoBasePath) : [];
 	let lcovBaseArray = monorepoBasePath
@@ -108,7 +112,7 @@ async function main() {
 		base: context.payload.pull_request.base.ref,
 	};
 
-	const lcov = await parse(raw);
+	const lcov = !monorepoBasePath && (await parse(raw));
 	const baselcov = baseRaw && (await parse(baseRaw));
 
 	const client = github.getOctokit(token);

--- a/src/index.js
+++ b/src/index.js
@@ -68,7 +68,8 @@ async function main() {
 	}
 
 	const baseRaw =
-		baseFile && (await promises.readFile(baseFile, "utf-8").catch(err => null));
+		baseFile &&
+		(await promises.readFile(baseFile, "utf-8").catch(err => null));
 	if (!monorepoBasePath && baseFile && !baseRaw) {
 		console.log(`No coverage report found at '${baseFile}', ignoring...`);
 	}

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,14 @@ async function main() {
 	const lcovFile = core.getInput("lcov-file") || "./coverage/lcov.info"
 	const baseFile = core.getInput("lcov-base")
 
+	// Add base path for monorepo
+	const monorepoBasePath = core.getInput("monorepo-base-path") || "./packages";
+
+	for await (const dirent of monorepoBasePath) {
+    console.log(dirent.name);
+  }
+
+
 	const raw = await fs.readFile(lcovFile, "utf-8").catch(err => null)
 	if (!raw) {
 		console.log(`No coverage report found at '${lcovFile}', exiting...`)

--- a/src/index.js
+++ b/src/index.js
@@ -60,14 +60,14 @@ async function main() {
 	const monorepoBasePath = core.getInput("monorepo-base-path");
 
 	const raw = await promises.readFile(lcovFile, "utf-8").catch(err => null);
-	if (!raw) {
+	if (!monorepoBasePath && !raw) {
 		console.log(`No coverage report found at '${lcovFile}', exiting...`);
 		return;
 	}
 
 	const baseRaw =
 		baseFile && (await promises.readFile(baseFile, "utf-8").catch(err => null));
-	if (baseFile && !baseRaw) {
+	if (!monorepoBasePath && baseFile && !baseRaw) {
 		console.log(`No coverage report found at '${baseFile}', ignoring...`);
 	}
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,27 @@
-import { promises as fs } from "fs";
+import fs, { promises } from "fs";
+import path from "path";
 import core from "@actions/core";
 import { GitHub, context } from "@actions/github";
 
 import { parse } from "./lcov";
 import { diff } from "./comment";
+
+const getAllFiles = function(dirPath, arrayOfFiles) {
+  let files = fs.readdirSync(dirPath)
+  arrayOfFiles = arrayOfFiles || []
+
+  files.forEach(function(file) {
+    if (fs.statSync(dirPath + "/" + file).isDirectory()) {
+      arrayOfFiles = getAllFiles(dirPath + "/" + file, arrayOfFiles)
+    } else {
+      if( file.includes('.info')){
+        arrayOfFiles.push(path.join(path.resolve(), dirPath, "/", file))
+      }
+    }
+  })
+
+  return arrayOfFiles
+}
 
 async function main() {
 	const token = core.getInput("github-token");
@@ -13,22 +31,22 @@ async function main() {
 	// Add base path for monorepo
 	const monorepoBasePath = core.getInput("monorepo-base-path") || "./packages";
 
-	let dirCont = await fs.readdir(monorepoBasePath);
-	let files = dirCont.filter( function( elm ) {return elm.match(/.*\.(info)/ig);});
-  for (const file of files) {
-    console.log(file);
-  }
+	const lcovArray = getAllFiles(monorepoBasePath);
+
+	let raw = "";
+	lcovArray.forEach(function(lcovFile) {
+		raw += fs.readFileSync(lcovFile, "utf-8")
+	});
 
 
-
-	const raw = await fs.readFile(lcovFile, "utf-8").catch(err => null)
+	//const raw = await promises.readFile(lcovFile, "utf-8").catch(err => null)
 	if (!raw) {
 		console.log(`No coverage report found at '${lcovFile}', exiting...`);
 		return;
 	}
 
 	const baseRaw =
-		baseFile && (await fs.readFile(baseFile, "utf-8").catch(err => null));
+		baseFile && (await promises.readFile(baseFile, "utf-8").catch(err => null));
 	if (baseFile && !baseRaw) {
 		console.log(`No coverage report found at '${baseFile}', ignoring...`);
 	}

--- a/src/index.js
+++ b/src/index.js
@@ -117,7 +117,11 @@ async function main() {
 		prNumber: context.payload.pull_request.number,
 		body: !lcovArrayForMonorepo.length
 			? diff(lcov, baselcov, options)
-			: diffForMonorepo(lcovArrayForMonorepo, lcovBaseArrayForMonorepo.options),
+			: diffForMonorepo(
+					lcovArrayForMonorepo,
+					lcovBaseArrayForMonorepo,
+					options,
+			  ),
 	});
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,7 @@ async function main() {
 	const lcovFile = core.getInput("lcov-file") || "./coverage/lcov.info";
 	const baseFile = core.getInput("lcov-base");
 	// Add base path for monorepo
-	const monorepoBasePath = core.getInput("monorepo-base-path") || "./packages";
+	const monorepoBasePath = core.getInput("monorepo-base-path");
 
 	const raw = await promises.readFile(lcovFile, "utf-8").catch(err => null);
 	if (!raw) {

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,8 @@ async function main() {
 	// Add base path for monorepo
 	const monorepoBasePath = core.getInput("monorepo-base-path") || "./packages";
 
-	for await (const dirent of monorepoBasePath) {
+	const dir = await fs.promises.opendir(monorepoBasePath);
+	for await (const dirent of dir) {
     console.log(dirent.name);
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ async function main() {
 	// Add base path for monorepo
 	const monorepoBasePath = core.getInput("monorepo-base-path") || "./packages";
 
-	const dir = await fs.promises.opendir(monorepoBasePath);
+	const dir = await fs.opendir(monorepoBasePath);
 	for await (const dirent of dir) {
     console.log(dirent.name);
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import fs, { promises } from "fs";
 import core from "@actions/core";
+import path from "path";
 import { GitHub, context } from "@actions/github";
 import { parse } from "./lcov";
 import { diff } from "./comment";

--- a/src/index.js
+++ b/src/index.js
@@ -71,8 +71,10 @@ async function main() {
 		console.log(`No coverage report found at '${baseFile}', ignoring...`);
 	}
 
-	let lcovArray = getLcovFiles(monorepoBasePath);
-	let lcovBaseArray = getLcovBaseFiles(monorepoBasePath);
+	let lcovArray = monorepoBasePath ? getLcovFiles(monorepoBasePath) : [];
+	let lcovBaseArray = monorepoBasePath
+		? getLcovBaseFiles(monorepoBasePath)
+		: [];
 
 	const lcovArrayForMonorepo = [];
 	const lcovBaseArrayForMonorepo = [];

--- a/src/index.js
+++ b/src/index.js
@@ -13,10 +13,12 @@ async function main() {
 	// Add base path for monorepo
 	const monorepoBasePath = core.getInput("monorepo-base-path") || "./packages";
 
-	const dir = await fs.opendir(monorepoBasePath);
-	for await (const dirent of dir) {
-    console.log(dirent.name);
+	let dirCont = await fs.readdir(monorepoBasePath);
+	let files = dirCont.filter( function( elm ) {return elm.match(/.*\.(info)/ig);});
+  for (const file of files) {
+    console.log(file);
   }
+
 
 
 	const raw = await fs.readFile(lcovFile, "utf-8").catch(err => null)

--- a/src/index.js
+++ b/src/index.js
@@ -74,7 +74,7 @@ async function main() {
 		client,
 		context,
 		prNumber: context.payload.pull_request.number,
-		body: diff(lcov, baselcov, options),
+		body: diff(lcov, lcovArrayWithRaw, baselcov, options),
 	});
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,7 @@ async function main() {
 
     let lcovArray = monorepoBasePath ? getLcovFiles(monorepoBasePath) : [];
     let lcovBaseArray = monorepoBasePath
-        ? getLcovFiles(monorepoBasePath, "lcov-base.info")
+        ? getLcovFiles(monorepoBasePath, [], "lcov-base.info")
         : [];
 
     const lcovArrayForMonorepo = [];

--- a/src/lcov.js
+++ b/src/lcov.js
@@ -2,25 +2,25 @@ import lcov from "lcov-parse";
 
 // Parse lcov string into lcov data
 export function parse(data) {
-	return new Promise(function(resolve, reject) {
-		lcov(data, function(err, res) {
-			if (err) {
-				reject(err);
-				return;
-			}
-			resolve(res);
-		});
-	});
+    return new Promise(function(resolve, reject) {
+        lcov(data, function(err, res) {
+            if (err) {
+                reject(err);
+                return;
+            }
+            resolve(res);
+        });
+    });
 }
 
 // Get the total coverage percentage from the lcov data.
 export function percentage(lcov) {
-	let hit = 0;
-	let found = 0;
-	for (const entry of lcov) {
-		hit += entry.lines.hit;
-		found += entry.lines.found;
-	}
+    let hit = 0;
+    let found = 0;
+    for (const entry of lcov) {
+        hit += entry.lines.hit;
+        found += entry.lines.found;
+    }
 
-	return (hit / found) * 100;
+    return (hit / found) * 100;
 }

--- a/src/lcov_test.js
+++ b/src/lcov_test.js
@@ -1,7 +1,7 @@
 import { parse, percentage } from "./lcov";
 
 test("parse should parse lcov strings correctly", async function() {
-	const data = `
+    const data = `
 TN:
 SF:/files/project/foo.js
 FN:19,foo
@@ -24,96 +24,96 @@ BRH:4
 end_of_record
 `;
 
-	const lcov = await parse(data);
-	expect(lcov).toEqual([
-		{
-			title: "",
-			file: "/files/project/foo.js",
-			lines: {
-				found: 23,
-				hit: 21,
-				details: [
-					{
-						line: 20,
-						hit: 3,
-					},
-					{
-						line: 21,
-						hit: 3,
-					},
-					{
-						line: 22,
-						hit: 3,
-					},
-				],
-			},
-			functions: {
-				hit: 2,
-				found: 3,
-				details: [
-					{
-						name: "foo",
-						line: 19,
-					},
-					{
-						name: "bar",
-						line: 33,
-					},
-					{
-						name: "baz",
-						line: 54,
-					},
-				],
-			},
-			branches: {
-				hit: 4,
-				found: 5,
-				details: [
-					{
-						line: 21,
-						block: 0,
-						branch: 0,
-						taken: 1,
-					},
-					{
-						line: 21,
-						block: 0,
-						branch: 1,
-						taken: 2,
-					},
-					{
-						line: 22,
-						block: 1,
-						branch: 0,
-						taken: 1,
-					},
-					{
-						line: 22,
-						block: 1,
-						branch: 1,
-						taken: 2,
-					},
-					{
-						line: 37,
-						block: 2,
-						branch: 0,
-						taken: 0,
-					},
-				],
-			},
-		},
-	]);
+    const lcov = await parse(data);
+    expect(lcov).toEqual([
+        {
+            title: "",
+            file: "/files/project/foo.js",
+            lines: {
+                found: 23,
+                hit: 21,
+                details: [
+                    {
+                        line: 20,
+                        hit: 3,
+                    },
+                    {
+                        line: 21,
+                        hit: 3,
+                    },
+                    {
+                        line: 22,
+                        hit: 3,
+                    },
+                ],
+            },
+            functions: {
+                hit: 2,
+                found: 3,
+                details: [
+                    {
+                        name: "foo",
+                        line: 19,
+                    },
+                    {
+                        name: "bar",
+                        line: 33,
+                    },
+                    {
+                        name: "baz",
+                        line: 54,
+                    },
+                ],
+            },
+            branches: {
+                hit: 4,
+                found: 5,
+                details: [
+                    {
+                        line: 21,
+                        block: 0,
+                        branch: 0,
+                        taken: 1,
+                    },
+                    {
+                        line: 21,
+                        block: 0,
+                        branch: 1,
+                        taken: 2,
+                    },
+                    {
+                        line: 22,
+                        block: 1,
+                        branch: 0,
+                        taken: 1,
+                    },
+                    {
+                        line: 22,
+                        block: 1,
+                        branch: 1,
+                        taken: 2,
+                    },
+                    {
+                        line: 37,
+                        block: 2,
+                        branch: 0,
+                        taken: 0,
+                    },
+                ],
+            },
+        },
+    ]);
 });
 
 test("parse should fail on invalid lcov", async function() {
-	await expect(parse("invalid")).rejects.toBe("Failed to parse string");
+    await expect(parse("invalid")).rejects.toBe("Failed to parse string");
 });
 
 test("percentage should calculate the correct percentage", function() {
-	expect(
-		percentage([
-			{ lines: { hit: 20, found: 25 } },
-			{ lines: { hit: 10, found: 15 } },
-		]),
-	).toBe(75);
+    expect(
+        percentage([
+            { lines: { hit: 20, found: 25 } },
+            { lines: { hit: 10, found: 15 } },
+        ]),
+    ).toBe(75);
 });

--- a/src/tabulate.js
+++ b/src/tabulate.js
@@ -2,92 +2,92 @@ import { th, tr, td, table, tbody, a, b, span, fragment } from "./html";
 
 // Tabulate the lcov data in a HTML table.
 export function tabulate(lcov, options) {
-	const head = tr(
-		th("File"),
-		th("Branches"),
-		th("Funcs"),
-		th("Lines"),
-		th("Uncovered Lines"),
-	);
+    const head = tr(
+        th("File"),
+        th("Branches"),
+        th("Funcs"),
+        th("Lines"),
+        th("Uncovered Lines"),
+    );
 
-	const folders = {};
-	for (const file of lcov) {
-		const parts = file.file.replace(options.prefix, "").split("/");
-		const folder = parts.slice(0, -1).join("/");
-		folders[folder] = folders[folder] || [];
-		folders[folder].push(file);
-	}
+    const folders = {};
+    for (const file of lcov) {
+        const parts = file.file.replace(options.prefix, "").split("/");
+        const folder = parts.slice(0, -1).join("/");
+        folders[folder] = folders[folder] || [];
+        folders[folder].push(file);
+    }
 
-	const rows = Object.keys(folders)
-		.sort()
-		.reduce(
-			(acc, key) => [
-				...acc,
-				toFolder(key, options),
-				...folders[key].map(file => toRow(file, key !== "", options)),
-			],
-			[],
-		);
+    const rows = Object.keys(folders)
+        .sort()
+        .reduce(
+            (acc, key) => [
+                ...acc,
+                toFolder(key, options),
+                ...folders[key].map(file => toRow(file, key !== "", options)),
+            ],
+            [],
+        );
 
-	return table(tbody(head, ...rows));
+    return table(tbody(head, ...rows));
 }
 
 function toFolder(path) {
-	if (path === "") {
-		return "";
-	}
+    if (path === "") {
+        return "";
+    }
 
-	return tr(td({ colspan: 5 }, b(path)));
+    return tr(td({ colspan: 5 }, b(path)));
 }
 
 function toRow(file, indent, options) {
-	return tr(
-		td(filename(file, indent, options)),
-		td(percentage(file.branches, options)),
-		td(percentage(file.functions, options)),
-		td(percentage(file.lines, options)),
-		td(uncovered(file, options)),
-	);
+    return tr(
+        td(filename(file, indent, options)),
+        td(percentage(file.branches, options)),
+        td(percentage(file.functions, options)),
+        td(percentage(file.lines, options)),
+        td(uncovered(file, options)),
+    );
 }
 
 function filename(file, indent, options) {
-	const relative = file.file.replace(options.prefix, "");
-	const href = `https://github.com/${options.repository}/blob/${options.commit}/${relative}`;
-	const parts = relative.split("/");
-	const last = parts[parts.length - 1];
-	const space = indent ? "&nbsp; &nbsp;" : "";
-	return fragment(space, a({ href }, last));
+    const relative = file.file.replace(options.prefix, "");
+    const href = `https://github.com/${options.repository}/blob/${options.commit}/${relative}`;
+    const parts = relative.split("/");
+    const last = parts[parts.length - 1];
+    const space = indent ? "&nbsp; &nbsp;" : "";
+    return fragment(space, a({ href }, last));
 }
 
 function percentage(item) {
-	if (!item) {
-		return "N/A";
-	}
+    if (!item) {
+        return "N/A";
+    }
 
-	const value = item.found === 0 ? 100 : (item.hit / item.found) * 100;
-	const rounded = value.toFixed(2).replace(/\.0*$/, "");
+    const value = item.found === 0 ? 100 : (item.hit / item.found) * 100;
+    const rounded = value.toFixed(2).replace(/\.0*$/, "");
 
-	const tag = value === 100 ? fragment : b;
+    const tag = value === 100 ? fragment : b;
 
-	return tag(`${rounded}%`);
+    return tag(`${rounded}%`);
 }
 
 function uncovered(file, options) {
-	const branches = (file.branches ? file.branches.details : [])
-		.filter(branch => branch.taken === 0)
-		.map(branch => branch.line);
+    const branches = (file.branches ? file.branches.details : [])
+        .filter(branch => branch.taken === 0)
+        .map(branch => branch.line);
 
-	const lines = (file.lines ? file.lines.details : [])
-		.filter(line => line.hit === 0)
-		.map(line => line.line);
+    const lines = (file.lines ? file.lines.details : [])
+        .filter(line => line.hit === 0)
+        .map(line => line.line);
 
-	const all = [...branches, ...lines].sort();
+    const all = [...branches, ...lines].sort();
 
-	return all
-		.map(function(line) {
-			const relative = file.file.replace(options.prefix, "");
-			const href = `https://github.com/${options.repository}/blob/${options.commit}/${relative}#L${line}`;
-			return a({ href }, line);
-		})
-		.join(", ");
+    return all
+        .map(function(line) {
+            const relative = file.file.replace(options.prefix, "");
+            const href = `https://github.com/${options.repository}/blob/${options.commit}/${relative}#L${line}`;
+            return a({ href }, line);
+        })
+        .join(", ");
 }

--- a/src/tabulate_test.js
+++ b/src/tabulate_test.js
@@ -2,202 +2,202 @@ import { tabulate } from "./tabulate";
 import { th, tr, td, table, tbody, a, b, span, fragment } from "./html";
 
 test("tabulate should generate a correct table", function() {
-	const data = [
-		{
-			file: "/files/project/index.js",
-			functions: {
-				found: 0,
-				hit: 0,
-				details: [],
-			},
-		},
-		{
-			file: "/files/project/src/foo.js",
-			lines: {
-				found: 23,
-				hit: 21,
-				details: [
-					{
-						line: 20,
-						hit: 3,
-					},
-					{
-						line: 21,
-						hit: 3,
-					},
-					{
-						line: 22,
-						hit: 3,
-					},
-				],
-			},
-			functions: {
-				hit: 2,
-				found: 3,
-				details: [
-					{
-						name: "foo",
-						line: 19,
-					},
-					{
-						name: "bar",
-						line: 33,
-					},
-					{
-						name: "baz",
-						line: 54,
-					},
-				],
-			},
-			branches: {
-				hit: 3,
-				found: 3,
-				details: [
-					{
-						line: 21,
-						block: 0,
-						branch: 0,
-						taken: 1,
-					},
-					{
-						line: 21,
-						block: 0,
-						branch: 1,
-						taken: 2,
-					},
-					{
-						line: 37,
-						block: 1,
-						branch: 0,
-						taken: 0,
-					},
-				],
-			},
-		},
-		{
-			file: "/files/project/src/bar/baz.js",
-			lines: {
-				found: 10,
-				hit: 5,
-				details: [
-					{
-						line: 20,
-						hit: 0,
-					},
-					{
-						line: 21,
-						hit: 0,
-					},
-					{
-						line: 22,
-						hit: 3,
-					},
-				],
-			},
-			functions: {
-				hit: 2,
-				found: 3,
-				details: [
-					{
-						name: "foo",
-						line: 19,
-					},
-					{
-						name: "bar",
-						line: 33,
-					},
-					{
-						name: "baz",
-						line: 54,
-					},
-				],
-			},
-		},
-	];
+    const data = [
+        {
+            file: "/files/project/index.js",
+            functions: {
+                found: 0,
+                hit: 0,
+                details: [],
+            },
+        },
+        {
+            file: "/files/project/src/foo.js",
+            lines: {
+                found: 23,
+                hit: 21,
+                details: [
+                    {
+                        line: 20,
+                        hit: 3,
+                    },
+                    {
+                        line: 21,
+                        hit: 3,
+                    },
+                    {
+                        line: 22,
+                        hit: 3,
+                    },
+                ],
+            },
+            functions: {
+                hit: 2,
+                found: 3,
+                details: [
+                    {
+                        name: "foo",
+                        line: 19,
+                    },
+                    {
+                        name: "bar",
+                        line: 33,
+                    },
+                    {
+                        name: "baz",
+                        line: 54,
+                    },
+                ],
+            },
+            branches: {
+                hit: 3,
+                found: 3,
+                details: [
+                    {
+                        line: 21,
+                        block: 0,
+                        branch: 0,
+                        taken: 1,
+                    },
+                    {
+                        line: 21,
+                        block: 0,
+                        branch: 1,
+                        taken: 2,
+                    },
+                    {
+                        line: 37,
+                        block: 1,
+                        branch: 0,
+                        taken: 0,
+                    },
+                ],
+            },
+        },
+        {
+            file: "/files/project/src/bar/baz.js",
+            lines: {
+                found: 10,
+                hit: 5,
+                details: [
+                    {
+                        line: 20,
+                        hit: 0,
+                    },
+                    {
+                        line: 21,
+                        hit: 0,
+                    },
+                    {
+                        line: 22,
+                        hit: 3,
+                    },
+                ],
+            },
+            functions: {
+                hit: 2,
+                found: 3,
+                details: [
+                    {
+                        name: "foo",
+                        line: 19,
+                    },
+                    {
+                        name: "bar",
+                        line: 33,
+                    },
+                    {
+                        name: "baz",
+                        line: 54,
+                    },
+                ],
+            },
+        },
+    ];
 
-	const options = {
-		repository: "example/foo",
-		commit: "2e15bee6fe0df5003389aa5ec894ec0fea2d874a",
-		prefix: "/files/project/",
-	};
+    const options = {
+        repository: "example/foo",
+        commit: "2e15bee6fe0df5003389aa5ec894ec0fea2d874a",
+        prefix: "/files/project/",
+    };
 
-	const html = table(
-		tbody(
-			tr(
-				th("File"),
-				th("Branches"),
-				th("Funcs"),
-				th("Lines"),
-				th("Uncovered Lines"),
-			),
-			tr(
-				td(
-					a(
-						{
-							href: `https://github.com/${options.repository}/blob/${options.commit}/index.js`,
-						},
-						"index.js",
-					),
-				),
-				td("N/A"),
-				td("100%"),
-				td("N/A"),
-				td(),
-			),
-			tr(td({ colspan: 5 }, b("src"))),
-			tr(
-				td(
-					"&nbsp; &nbsp;",
-					a(
-						{
-							href: `https://github.com/${options.repository}/blob/${options.commit}/src/foo.js`,
-						},
-						"foo.js",
-					),
-				),
-				td("100%"),
-				td(b("66.67%")),
-				td(b("91.30%")),
-				td(
-					a(
-						{
-							href: `https://github.com/${options.repository}/blob/${options.commit}/src/foo.js#L37`,
-						},
-						37,
-					),
-				),
-			),
-			tr(td({ colspan: 5 }, b("src/bar"))),
-			tr(
-				td(
-					"&nbsp; &nbsp;",
-					a(
-						{
-							href: `https://github.com/${options.repository}/blob/${options.commit}/src/bar/baz.js`,
-						},
-						"baz.js",
-					),
-				),
-				td("N/A"),
-				td(b("66.67%")),
-				td(b("50%")),
-				td(
-					a(
-						{
-							href: `https://github.com/${options.repository}/blob/${options.commit}/src/bar/baz.js#L20`,
-						},
-						20,
-					),
-					", ",
-					a(
-						{
-							href: `https://github.com/${options.repository}/blob/${options.commit}/src/bar/baz.js#L21`,
-						},
-						21,
-					),
-				),
-			),
-		),
-	);
-	expect(tabulate(data, options)).toBe(html);
+    const html = table(
+        tbody(
+            tr(
+                th("File"),
+                th("Branches"),
+                th("Funcs"),
+                th("Lines"),
+                th("Uncovered Lines"),
+            ),
+            tr(
+                td(
+                    a(
+                        {
+                            href: `https://github.com/${options.repository}/blob/${options.commit}/index.js`,
+                        },
+                        "index.js",
+                    ),
+                ),
+                td("N/A"),
+                td("100%"),
+                td("N/A"),
+                td(),
+            ),
+            tr(td({ colspan: 5 }, b("src"))),
+            tr(
+                td(
+                    "&nbsp; &nbsp;",
+                    a(
+                        {
+                            href: `https://github.com/${options.repository}/blob/${options.commit}/src/foo.js`,
+                        },
+                        "foo.js",
+                    ),
+                ),
+                td("100%"),
+                td(b("66.67%")),
+                td(b("91.30%")),
+                td(
+                    a(
+                        {
+                            href: `https://github.com/${options.repository}/blob/${options.commit}/src/foo.js#L37`,
+                        },
+                        37,
+                    ),
+                ),
+            ),
+            tr(td({ colspan: 5 }, b("src/bar"))),
+            tr(
+                td(
+                    "&nbsp; &nbsp;",
+                    a(
+                        {
+                            href: `https://github.com/${options.repository}/blob/${options.commit}/src/bar/baz.js`,
+                        },
+                        "baz.js",
+                    ),
+                ),
+                td("N/A"),
+                td(b("66.67%")),
+                td(b("50%")),
+                td(
+                    a(
+                        {
+                            href: `https://github.com/${options.repository}/blob/${options.commit}/src/bar/baz.js#L20`,
+                        },
+                        20,
+                    ),
+                    ", ",
+                    a(
+                        {
+                            href: `https://github.com/${options.repository}/blob/${options.commit}/src/bar/baz.js#L21`,
+                        },
+                        21,
+                    ),
+                ),
+            ),
+        ),
+    );
+    expect(tabulate(data, options)).toBe(html);
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -68,7 +68,7 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/core@^7.11.6":
+"@babel/core@^7.8.6":
   version "7.12.10"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.12.10.tgz#b79a2e1b9f70ed3d84bbfb6d8c4ef825f606bccd"
   integrity sha512-eTAlQKq65zHfkHZV0sIVODCPGVgoo1HdBlbSLi9CqOzuZanMv2ihzY+4paiKr1mH+XmYESMAmJ/dpZ68eN6d8w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,6 +22,13 @@
   dependencies:
     "@babel/highlight" "^7.8.3"
 
+"@babel/code-frame@^7.10.4":
+  version "7.12.11"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.11.tgz#f4ad435aa263db935b8f10f2c552d23fb716a63f"
+  integrity sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==
+  dependencies:
+    "@babel/highlight" "^7.10.4"
+
 "@babel/compat-data@^7.8.6":
   version "7.8.6"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.8.6.tgz#7eeaa0dfa17e50c7d9c0832515eee09b56f04e35"
@@ -31,7 +38,7 @@
     invariant "^2.2.4"
     semver "^5.5.0"
 
-"@babel/core@^7.1.0", "@babel/core@^7.7.5", "@babel/core@^7.8.6":
+"@babel/core@^7.1.0", "@babel/core@^7.7.5":
   version "7.8.6"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.8.6.tgz#27d7df9258a45c2e686b6f18b6c659e563aa4636"
   integrity sha512-Sheg7yEJD51YHAvLEV/7Uvw95AeWqYPL3Vk3zGujJKIhJ+8oLw2ALaf3hbucILhKsgSoADOvtKRJuNVdcJkOrg==
@@ -50,6 +57,36 @@
     lodash "^4.17.13"
     resolve "^1.3.2"
     semver "^5.4.1"
+    source-map "^0.5.0"
+
+"@babel/core@^7.11.6":
+  version "7.12.10"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.12.10.tgz#b79a2e1b9f70ed3d84bbfb6d8c4ef825f606bccd"
+  integrity sha512-eTAlQKq65zHfkHZV0sIVODCPGVgoo1HdBlbSLi9CqOzuZanMv2ihzY+4paiKr1mH+XmYESMAmJ/dpZ68eN6d8w==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/generator" "^7.12.10"
+    "@babel/helper-module-transforms" "^7.12.1"
+    "@babel/helpers" "^7.12.5"
+    "@babel/parser" "^7.12.10"
+    "@babel/template" "^7.12.7"
+    "@babel/traverse" "^7.12.10"
+    "@babel/types" "^7.12.10"
+    convert-source-map "^1.7.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.1"
+    json5 "^2.1.2"
+    lodash "^4.17.19"
+    semver "^5.4.1"
+    source-map "^0.5.0"
+
+"@babel/generator@^7.12.10":
+  version "7.12.11"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.12.11.tgz#98a7df7b8c358c9a37ab07a24056853016aba3af"
+  integrity sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==
+  dependencies:
+    "@babel/types" "^7.12.11"
+    jsesc "^2.5.1"
     source-map "^0.5.0"
 
 "@babel/generator@^7.8.6":
@@ -123,6 +160,15 @@
     "@babel/traverse" "^7.8.3"
     "@babel/types" "^7.8.3"
 
+"@babel/helper-function-name@^7.10.4":
+  version "7.12.11"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.12.11.tgz#1fd7738aee5dcf53c3ecff24f1da9c511ec47b42"
+  integrity sha512-AtQKjtYNolKNi6nNNVLQ27CP6D9oFR6bq/HPYSizlzbp7uC1M59XJe8L+0uXjbIaZaUJF99ruHqVGiKXU/7ybA==
+  dependencies:
+    "@babel/helper-get-function-arity" "^7.12.10"
+    "@babel/template" "^7.12.7"
+    "@babel/types" "^7.12.11"
+
 "@babel/helper-function-name@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz#eeeb665a01b1f11068e9fb86ad56a1cb1a824cca"
@@ -131,6 +177,13 @@
     "@babel/helper-get-function-arity" "^7.8.3"
     "@babel/template" "^7.8.3"
     "@babel/types" "^7.8.3"
+
+"@babel/helper-get-function-arity@^7.12.10":
+  version "7.12.10"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.10.tgz#b158817a3165b5faa2047825dfa61970ddcc16cf"
+  integrity sha512-mm0n5BPjR06wh9mPQaDdXWDoll/j5UpCAPl1x8fS71GHm7HA6Ua2V4ylG1Ju8lvcTOietbPNNPaSilKj+pj+Ag==
+  dependencies:
+    "@babel/types" "^7.12.10"
 
 "@babel/helper-get-function-arity@^7.8.3":
   version "7.8.3"
@@ -146,6 +199,13 @@
   dependencies:
     "@babel/types" "^7.8.3"
 
+"@babel/helper-member-expression-to-functions@^7.12.7":
+  version "7.12.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.7.tgz#aa77bd0396ec8114e5e30787efa78599d874a855"
+  integrity sha512-DCsuPyeWxeHgh1Dus7APn7iza42i/qXqiFPWyBDdOFtvS581JQePsc1F/nD+fHrcswhLlRc2UpYS1NwERxZhHw==
+  dependencies:
+    "@babel/types" "^7.12.7"
+
 "@babel/helper-member-expression-to-functions@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.8.3.tgz#659b710498ea6c1d9907e0c73f206eee7dadc24c"
@@ -153,12 +213,34 @@
   dependencies:
     "@babel/types" "^7.8.3"
 
+"@babel/helper-module-imports@^7.12.1":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz#1bfc0229f794988f76ed0a4d4e90860850b54dfb"
+  integrity sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==
+  dependencies:
+    "@babel/types" "^7.12.5"
+
 "@babel/helper-module-imports@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz#7fe39589b39c016331b6b8c3f441e8f0b1419498"
   integrity sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==
   dependencies:
     "@babel/types" "^7.8.3"
+
+"@babel/helper-module-transforms@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.12.1.tgz#7954fec71f5b32c48e4b303b437c34453fd7247c"
+  integrity sha512-QQzehgFAZ2bbISiCpmVGfiGux8YVFXQ0abBic2Envhej22DVXV9nCFaS5hIQbkyo1AdGb+gNME2TSh3hYJVV/w==
+  dependencies:
+    "@babel/helper-module-imports" "^7.12.1"
+    "@babel/helper-replace-supers" "^7.12.1"
+    "@babel/helper-simple-access" "^7.12.1"
+    "@babel/helper-split-export-declaration" "^7.11.0"
+    "@babel/helper-validator-identifier" "^7.10.4"
+    "@babel/template" "^7.10.4"
+    "@babel/traverse" "^7.12.1"
+    "@babel/types" "^7.12.1"
+    lodash "^4.17.19"
 
 "@babel/helper-module-transforms@^7.8.3":
   version "7.8.6"
@@ -172,6 +254,13 @@
     "@babel/template" "^7.8.6"
     "@babel/types" "^7.8.6"
     lodash "^4.17.13"
+
+"@babel/helper-optimise-call-expression@^7.12.10":
+  version "7.12.10"
+  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.10.tgz#94ca4e306ee11a7dd6e9f42823e2ac6b49881e2d"
+  integrity sha512-4tpbU0SrSTjjt65UMWSrUOPZTsgvPgGG4S8QSTNHacKzpS51IVWGDj0yCwyeZND/i+LSN2g/O63jEXEWm49sYQ==
+  dependencies:
+    "@babel/types" "^7.12.10"
 
 "@babel/helper-optimise-call-expression@^7.8.3":
   version "7.8.3"
@@ -203,6 +292,16 @@
     "@babel/traverse" "^7.8.3"
     "@babel/types" "^7.8.3"
 
+"@babel/helper-replace-supers@^7.12.1":
+  version "7.12.11"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.12.11.tgz#ea511658fc66c7908f923106dd88e08d1997d60d"
+  integrity sha512-q+w1cqmhL7R0FNzth/PLLp2N+scXEK/L2AHbXUyydxp828F4FEa5WcVoqui9vFRiHDQErj9Zof8azP32uGVTRA==
+  dependencies:
+    "@babel/helper-member-expression-to-functions" "^7.12.7"
+    "@babel/helper-optimise-call-expression" "^7.12.10"
+    "@babel/traverse" "^7.12.10"
+    "@babel/types" "^7.12.11"
+
 "@babel/helper-replace-supers@^7.8.3", "@babel/helper-replace-supers@^7.8.6":
   version "7.8.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.8.6.tgz#5ada744fd5ad73203bf1d67459a27dcba67effc8"
@@ -213,6 +312,13 @@
     "@babel/traverse" "^7.8.6"
     "@babel/types" "^7.8.6"
 
+"@babel/helper-simple-access@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.12.1.tgz#32427e5aa61547d38eb1e6eaf5fd1426fdad9136"
+  integrity sha512-OxBp7pMrjVewSSC8fXDFrHrBcJATOOFssZwv16F3/6Xtc138GHybBfPbm9kfiqQHKhYQrlamWILwlDCeyMFEaA==
+  dependencies:
+    "@babel/types" "^7.12.1"
+
 "@babel/helper-simple-access@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.8.3.tgz#7f8109928b4dab4654076986af575231deb639ae"
@@ -221,12 +327,24 @@
     "@babel/template" "^7.8.3"
     "@babel/types" "^7.8.3"
 
+"@babel/helper-split-export-declaration@^7.11.0":
+  version "7.12.11"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.11.tgz#1b4cc424458643c47d37022223da33d76ea4603a"
+  integrity sha512-LsIVN8j48gHgwzfocYUSkO/hjYAOJqlpJEc7tGXcIm4cubjVUf8LGW6eWRyxEu7gA25q02p0rQUWoCI33HNS5g==
+  dependencies:
+    "@babel/types" "^7.12.11"
+
 "@babel/helper-split-export-declaration@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz#31a9f30070f91368a7182cf05f831781065fc7a9"
   integrity sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==
   dependencies:
     "@babel/types" "^7.8.3"
+
+"@babel/helper-validator-identifier@^7.10.4", "@babel/helper-validator-identifier@^7.12.11":
+  version "7.12.11"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz#c9a1f021917dcb5ccf0d4e453e399022981fc9ed"
+  integrity sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==
 
 "@babel/helper-wrap-function@^7.8.3":
   version "7.8.3"
@@ -238,6 +356,15 @@
     "@babel/traverse" "^7.8.3"
     "@babel/types" "^7.8.3"
 
+"@babel/helpers@^7.12.5":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.12.5.tgz#1a1ba4a768d9b58310eda516c449913fe647116e"
+  integrity sha512-lgKGMQlKqA8meJqKsW6rUnc4MdUk35Ln0ATDqdM1a/UpARODdI4j5Y5lVfUScnSNkJcdCRAaWkspykNoFg9sJA==
+  dependencies:
+    "@babel/template" "^7.10.4"
+    "@babel/traverse" "^7.12.5"
+    "@babel/types" "^7.12.5"
+
 "@babel/helpers@^7.8.4":
   version "7.8.4"
   resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.8.4.tgz#754eb3ee727c165e0a240d6c207de7c455f36f73"
@@ -246,6 +373,15 @@
     "@babel/template" "^7.8.3"
     "@babel/traverse" "^7.8.4"
     "@babel/types" "^7.8.3"
+
+"@babel/highlight@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.10.4.tgz#7d1bdfd65753538fabe6c38596cdb76d9ac60143"
+  integrity sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.10.4"
+    chalk "^2.0.0"
+    js-tokens "^4.0.0"
 
 "@babel/highlight@^7.8.3":
   version "7.8.3"
@@ -274,6 +410,11 @@
   version "7.8.6"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.8.6.tgz#ba5c9910cddb77685a008e3c587af8d27b67962c"
   integrity sha512-trGNYSfwq5s0SgM1BMEB8hX3NDmO7EP2wsDGDexiaKMB92BaRpS+qZfpkMqUBhcsOTBwNy9B/jieo4ad/t/z2g==
+
+"@babel/parser@^7.12.10", "@babel/parser@^7.12.7":
+  version "7.12.11"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.11.tgz#9ce3595bcd74bc5c466905e86c535b8b25011e79"
+  integrity sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg==
 
 "@babel/plugin-proposal-async-generator-functions@^7.8.3":
   version "7.8.3"
@@ -722,6 +863,15 @@
     pirates "^4.0.0"
     source-map-support "^0.5.16"
 
+"@babel/template@^7.10.4", "@babel/template@^7.12.7":
+  version "7.12.7"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.12.7.tgz#c817233696018e39fbb6c491d2fb684e05ed43bc"
+  integrity sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/parser" "^7.12.7"
+    "@babel/types" "^7.12.7"
+
 "@babel/template@^7.7.4", "@babel/template@^7.8.3", "@babel/template@^7.8.6":
   version "7.8.6"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.8.6.tgz#86b22af15f828dfb086474f964dcc3e39c43ce2b"
@@ -746,6 +896,21 @@
     globals "^11.1.0"
     lodash "^4.17.13"
 
+"@babel/traverse@^7.12.1", "@babel/traverse@^7.12.10", "@babel/traverse@^7.12.5":
+  version "7.12.10"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.12.10.tgz#2d1f4041e8bf42ea099e5b2dc48d6a594c00017a"
+  integrity sha512-6aEtf0IeRgbYWzta29lePeYSk+YAFIC3kyqESeft8o5CkFlYIMX+EQDDWEiAQ9LHOA3d0oHdgrSsID/CKqXJlg==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/generator" "^7.12.10"
+    "@babel/helper-function-name" "^7.10.4"
+    "@babel/helper-split-export-declaration" "^7.11.0"
+    "@babel/parser" "^7.12.10"
+    "@babel/types" "^7.12.10"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.19"
+
 "@babel/types@^7.0.0", "@babel/types@^7.3.0", "@babel/types@^7.8.3", "@babel/types@^7.8.6":
   version "7.8.6"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.8.6.tgz#629ecc33c2557fcde7126e58053127afdb3e6d01"
@@ -753,6 +918,15 @@
   dependencies:
     esutils "^2.0.2"
     lodash "^4.17.13"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.12.1", "@babel/types@^7.12.10", "@babel/types@^7.12.11", "@babel/types@^7.12.5", "@babel/types@^7.12.7":
+  version "7.12.11"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.12.11.tgz#a86e4d71e30a9b6ee102590446c98662589283ce"
+  integrity sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.12.11"
+    lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 
 "@bcoe/v8-coverage@^0.2.3":
@@ -2968,6 +3142,13 @@ json5@^2.1.0:
   dependencies:
     minimist "^1.2.0"
 
+json5@^2.1.2:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.3.tgz#c9b0f7fa9233bfe5807fe66fcf3a5617ed597d43"
+  integrity sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==
+  dependencies:
+    minimist "^1.2.5"
+
 jsprim@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
@@ -3071,6 +3252,11 @@ lodash@^4.17.13, lodash@^4.17.15:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
+lodash@^4.17.19:
+  version "4.17.20"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
+  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
 lolex@^5.0.0:
   version "5.1.2"
@@ -3197,6 +3383,11 @@ minimist@^1.1.1, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
   integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
+
+minimist@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
+  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
 mixin-deep@^1.2.0:
   version "1.3.2"


### PR DESCRIPTION
### Description & Changelog

[Demo PR](https://github.com/ScaCap/precious-web/pull/169)

- Added new `monorepo-base-path` for monorepos
- Updated `prettier` to align with other scalable products
- New comment design for monorepos
- This will still work for single repos. If we pass `monorepo-base-path`, then we do not need to send `lcov-path` and `lcov-base`. For single repos it will be other way round

- This will out of the box for showing `diff`. It iterates over monrepo and look for `lcov-base.info` and show percentage diff.

Monorepo

```yml
- name: Add coverage comment
              continue-on-error: true
              uses: ScaCap/monorepo-jest-reporter-action@change_input
              with:
                  github-token: ${{ secrets.GITHUB_TOKEN }}
                  monorepo-base-path: './packages'
```

Output 
<img width="862" alt="Screenshot 2020-12-17 at 00 17 36" src="https://user-images.githubusercontent.com/16473868/102441493-abc7dd00-4022-11eb-841a-346c5749bd02.png">


Single repo

```yml
- name: Add onboarding coverage comment
              continue-on-error: true
              uses: ScaCap/monorepo-jest-reporter-action@change_input
              with:
                  github-token: ${{ secrets.GITHUB_TOKEN }}
                  lcov-file: ./packages/onboarding/coverage/lcov.info
```

Output

![Screenshot 2020-12-17 at 03 14 17](https://user-images.githubusercontent.com/16473868/102441556-d4e86d80-4022-11eb-8039-cc5e516020b9.png)



