### PR TITLE
Fix missing monorepo path for file href

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -7,7 +7,7 @@ import { diff } from "./comment";
 const main = async () => {
     const file = process.argv[2];
     const beforeFile = process.argv[3];
-    const prefix = `${path.dirname(path.dirname(path.resolve(file)))}/`;
+    const workspace = `${path.dirname(path.dirname(path.resolve(file)))}/`;
 
     const content = await fs.readFile(file, "utf-8");
     const lcov = await parse(content);
@@ -21,7 +21,8 @@ const main = async () => {
     const options = {
         repository: "example/foo",
         commit: "f9d42291812ed03bb197e48050ac38ac6befe4e5",
-        prefix,
+        workspace,
+        basePath: "",
         head: "feat/test",
         base: "master",
     };

--- a/src/comment.js
+++ b/src/comment.js
@@ -1,3 +1,4 @@
+import path from "path";
 import { details, summary, b, fragment, table, tbody, tr, th } from "./html";
 import { percentage } from "./lcov";
 import { tabulate } from "./tabulate";
@@ -41,6 +42,10 @@ const commentForMonorepo = (
         const baseLcov = lcovBaseArrayForMonorepo.find(
             el => el.packageName === lcovObj.packageName,
         );
+        const pkgOptions = {
+            ...options,
+            basePath: path.join(options.basePath, lcovObj.packageName),
+        };
 
         const pbefore = baseLcov ? percentage(baseLcov.lcov) : 0;
         const pafter = baseLcov ? percentage(lcovObj.lcov) : 0;
@@ -83,7 +88,7 @@ const commentForMonorepo = (
             ),
         )} \n\n ${details(
             summary("Coverage Report"),
-            tabulate(report, options),
+            tabulate(report, pkgOptions),
         )} <br/>`;
     });
 

--- a/src/index.js
+++ b/src/index.js
@@ -50,6 +50,22 @@ const getLcovBaseFiles = (dir, filelist) => {
     return fileArray;
 };
 
+// eslint-disable-next-line require-await
+const toLcovForMonorepo = async lcovFiles =>
+    Promise.all(
+        lcovFiles
+            .filter(file => file.path.includes(".info"))
+            .map(async file => {
+                const rLcove = await promises.readFile(file.path, "utf8");
+                const data = await parse(rLcove);
+
+                return {
+                    packageName: file.name,
+                    lcov: data,
+                };
+            }),
+    );
+
 const main = async () => {
     const { context = {} } = github || {};
 
@@ -80,39 +96,18 @@ const main = async () => {
         console.log(`No coverage report found at '${baseFile}', ignoring...`);
     }
 
-    const lcovArray = monorepoBasePath ? getLcovFiles(monorepoBasePath) : [];
-    const lcovBaseArray = monorepoBasePath
-        ? getLcovBaseFiles(monorepoBasePath)
+    const lcovArrayForMonorepo = monorepoBasePath
+        ? await toLcovForMonorepo(getLcovFiles(monorepoBasePath))
         : [];
-
-    const lcovArrayForMonorepo = [];
-    const lcovBaseArrayForMonorepo = [];
-    for (const file of lcovArray) {
-        if (file.path.includes(".info")) {
-            const rLcove = await promises.readFile(file.path, "utf8");
-            const data = await parse(rLcove);
-            lcovArrayForMonorepo.push({
-                packageName: file.name,
-                lcov: data,
-            });
-        }
-    }
-
-    for (const file of lcovBaseArray) {
-        if (file.path.includes(".info")) {
-            const rLcovBase = await promises.readFile(file.path, "utf8");
-            const data = await parse(rLcovBase);
-            lcovBaseArrayForMonorepo.push({
-                packageName: file.name,
-                lcov: data,
-            });
-        }
-    }
+    const lcovBaseArrayForMonorepo = monorepoBasePath
+        ? await toLcovForMonorepo(getLcovBaseFiles(monorepoBasePath))
+        : [];
 
     const options = {
         repository: context.payload.repository.full_name,
         commit: context.payload.pull_request.head.sha,
-        prefix: `${process.env.GITHUB_WORKSPACE}/`,
+        workspace: `${process.env.GITHUB_WORKSPACE}/`,
+        basePath: monorepoBasePath || "",
         head: context.payload.pull_request.head.ref,
         base: context.payload.pull_request.base.ref,
         appName,

--- a/src/tabulate.js
+++ b/src/tabulate.js
@@ -1,8 +1,13 @@
+import Path from "path";
 import { th, tr, td, table, tbody, a, b, fragment } from "./html";
 
 const filename = (file, indent, options) => {
-    const relative = file.file.replace(options.prefix, "");
-    const href = `https://github.com/${options.repository}/blob/${options.commit}/${relative}`;
+    const relative = Path.join(
+        options.commit,
+        file.file.includes(options.basePath) ? "" : options.basePath,
+        file.file.replace(options.workspace, ""),
+    );
+    const href = `https://github.com/${options.repository}/blob/${relative}`;
     const parts = relative.split("/");
     const last = parts[parts.length - 1];
     const space = indent ? "&nbsp; &nbsp;" : "";
@@ -36,8 +41,12 @@ const uncovered = (file, options) => {
 
     return all
         .map(line => {
-            const relative = file.file.replace(options.prefix, "");
-            const href = `https://github.com/${options.repository}/blob/${options.commit}/${relative}#L${line}`;
+            const relative = Path.join(
+                options.commit,
+                file.file.includes(options.basePath) ? "" : options.basePath,
+                file.file.replace(options.workspace, ""),
+            );
+            const href = `https://github.com/${options.repository}/blob/${relative}#L${line}`;
 
             return a({ href }, line);
         })
@@ -73,7 +82,7 @@ export const tabulate = (lcov, options) => {
 
     const folders = {};
     for (const file of lcov) {
-        const parts = file.file.replace(options.prefix, "").split("/");
+        const parts = file.file.replace(options.workspace, "").split("/");
         const folder = parts.slice(0, -1).join("/");
         folders[folder] = folders[folder] || [];
         folders[folder].push(file);

--- a/src/tabulate.test.js
+++ b/src/tabulate.test.js
@@ -118,7 +118,8 @@ test("tabulate should generate a correct table", () => {
     const options = {
         repository: "example/foo",
         commit: "2e15bee6fe0df5003389aa5ec894ec0fea2d874a",
-        prefix: "/files/project/",
+        workspace: "/files/project/",
+        basePath: "",
     };
 
     const html = table(
@@ -200,4 +201,108 @@ test("tabulate should generate a correct table", () => {
         ),
     );
     expect(tabulate(data, options)).toBe(html);
+});
+
+test("tabulate should generate file href for monorepo package", () => {
+    const data = [
+        {
+            file: "/files/project/src/foo.js",
+            lines: {
+                found: 23,
+                hit: 21,
+                details: [
+                    {
+                        line: 20,
+                        hit: 1,
+                    },
+                ],
+            },
+            functions: {
+                hit: 2,
+                found: 3,
+                details: [
+                    {
+                        name: "foo",
+                        line: 19,
+                    },
+                    {
+                        name: "bar",
+                        line: 33,
+                    },
+                    {
+                        name: "baz",
+                        line: 54,
+                    },
+                ],
+            },
+            branches: {
+                hit: 3,
+                found: 3,
+                details: [
+                    {
+                        line: 21,
+                        block: 0,
+                        branch: 0,
+                        taken: 1,
+                    },
+                    {
+                        line: 21,
+                        block: 0,
+                        branch: 1,
+                        taken: 2,
+                    },
+                    {
+                        line: 37,
+                        block: 1,
+                        branch: 0,
+                        taken: 0,
+                    },
+                ],
+            },
+        },
+    ];
+
+    const options = {
+        repository: "example/foo",
+        commit: "2e15bee6fe0df5003389aa5ec894ec0fea2d874a",
+        workspace: "/files/project/",
+        basePath: "packages",
+    };
+    const pkg1Path = `packages/pkg-1`;
+
+    const html = table(
+        tbody(
+            tr(
+                th("File"),
+                th("Branches"),
+                th("Funcs"),
+                th("Lines"),
+                th("Uncovered Lines"),
+            ),
+            tr(td({ colspan: 5 }, b("src"))),
+            tr(
+                td(
+                    "&nbsp; &nbsp;",
+                    a(
+                        {
+                            href: `https://github.com/${options.repository}/blob/${options.commit}/${pkg1Path}/src/foo.js`,
+                        },
+                        "foo.js",
+                    ),
+                ),
+                td("100%"),
+                td(b("66.67%")),
+                td(b("91.30%")),
+                td(
+                    a(
+                        {
+                            href: `https://github.com/${options.repository}/blob/${options.commit}/${pkg1Path}/src/foo.js#L37`,
+                        },
+                        37,
+                    ),
+                ),
+            ),
+        ),
+    );
+    expect(tabulate(data, { ...options, basePath: pkg1Path })).toBe(html);
 });


### PR DESCRIPTION
The file `hrefs` in tabulate.js are missing the monorepo parent "packages/" and child package folders since the function `getLcovFiles(dir, ` is relative to the child package.

Once the branch `fix_eslint` is merged I can switch this PR to point to `master`.