### PR TITLE
Fix monorepo file href

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -7,7 +7,7 @@ import { diff } from "./comment";
 const main = async () => {
     const file = process.argv[2];
     const beforeFile = process.argv[3];
-    const prefix = `${path.dirname(path.dirname(path.resolve(file)))}/`;
+    const workspace = `${path.dirname(path.dirname(path.resolve(file)))}/`;
 
     const content = await fs.readFile(file, "utf-8");
     const lcov = await parse(content);
@@ -21,7 +21,8 @@ const main = async () => {
     const options = {
         repository: "example/foo",
         commit: "f9d42291812ed03bb197e48050ac38ac6befe4e5",
-        prefix,
+        workspace,
+        basePath: "",
         head: "feat/test",
         base: "master",
     };

--- a/src/tabulate.js
+++ b/src/tabulate.js
@@ -1,11 +1,20 @@
+import Path from "path";
 import { th, tr, td, table, tbody, a, b, fragment } from "./html";
 
 const filename = (file, indent, options) => {
-    const relative = file.file.replace(options.prefix, "");
-    const href = `https://github.com/${options.repository}/blob/${options.commit}/${relative}`;
+    const relative = Path.join(
+        options.commit.substring(0, 7),
+        file.file.includes(options.basePath) ? "" : options.basePath,
+        file.file.replace(options.workspace, ""),
+    );
+    const href = `/${options.repository}/blob/${relative}`;
     const parts = relative.split("/");
     const last = parts[parts.length - 1];
     const space = indent ? "&nbsp; &nbsp;" : "";
+
+    if (options.condense) {
+        return last;
+    }
 
     return fragment(space, a({ href }, last));
 };
@@ -24,6 +33,10 @@ const percentage = item => {
 };
 
 const uncovered = (file, options) => {
+    if (options.condense) {
+        return "*";
+    }
+
     const branches = (file.branches ? file.branches.details : [])
         .filter(branch => branch.taken === 0)
         .map(branch => branch.line);
@@ -36,8 +49,12 @@ const uncovered = (file, options) => {
 
     return all
         .map(line => {
-            const relative = file.file.replace(options.prefix, "");
-            const href = `https://github.com/${options.repository}/blob/${options.commit}/${relative}#L${line}`;
+            const relative = Path.join(
+                options.commit.substring(0, 7),
+                file.file.includes(options.basePath) ? "" : options.basePath,
+                file.file.replace(options.workspace, ""),
+            );
+            const href = `/${options.repository}/blob/${relative}#L${line}`;
 
             return a({ href }, line);
         })
@@ -73,7 +90,7 @@ export const tabulate = (lcov, options) => {
 
     const folders = {};
     for (const file of lcov) {
-        const parts = file.file.replace(options.prefix, "").split("/");
+        const parts = file.file.replace(options.workspace, "").split("/");
         const folder = parts.slice(0, -1).join("/");
         folders[folder] = folders[folder] || [];
         folders[folder].push(file);

--- a/src/tabulate.test.js
+++ b/src/tabulate.test.js
@@ -118,8 +118,10 @@ test("tabulate should generate a correct table", () => {
     const options = {
         repository: "example/foo",
         commit: "2e15bee6fe0df5003389aa5ec894ec0fea2d874a",
-        prefix: "/files/project/",
+        workspace: "/files/project/",
+        basePath: "",
     };
+    const sha = options.commit.substring(0, 7);
 
     const html = table(
         tbody(
@@ -134,7 +136,7 @@ test("tabulate should generate a correct table", () => {
                 td(
                     a(
                         {
-                            href: `https://github.com/${options.repository}/blob/${options.commit}/index.js`,
+                            href: `/${options.repository}/blob/${sha}/index.js`,
                         },
                         "index.js",
                     ),
@@ -150,7 +152,7 @@ test("tabulate should generate a correct table", () => {
                     "&nbsp; &nbsp;",
                     a(
                         {
-                            href: `https://github.com/${options.repository}/blob/${options.commit}/src/foo.js`,
+                            href: `/${options.repository}/blob/${sha}/src/foo.js`,
                         },
                         "foo.js",
                     ),
@@ -161,7 +163,7 @@ test("tabulate should generate a correct table", () => {
                 td(
                     a(
                         {
-                            href: `https://github.com/${options.repository}/blob/${options.commit}/src/foo.js#L37`,
+                            href: `/${options.repository}/blob/${sha}/src/foo.js#L37`,
                         },
                         37,
                     ),
@@ -173,7 +175,7 @@ test("tabulate should generate a correct table", () => {
                     "&nbsp; &nbsp;",
                     a(
                         {
-                            href: `https://github.com/${options.repository}/blob/${options.commit}/src/bar/baz.js`,
+                            href: `/${options.repository}/blob/${sha}/src/bar/baz.js`,
                         },
                         "baz.js",
                     ),
@@ -184,14 +186,14 @@ test("tabulate should generate a correct table", () => {
                 td(
                     a(
                         {
-                            href: `https://github.com/${options.repository}/blob/${options.commit}/src/bar/baz.js#L20`,
+                            href: `/${options.repository}/blob/${sha}/src/bar/baz.js#L20`,
                         },
                         20,
                     ),
                     ", ",
                     a(
                         {
-                            href: `https://github.com/${options.repository}/blob/${options.commit}/src/bar/baz.js#L21`,
+                            href: `/${options.repository}/blob/${sha}/src/bar/baz.js#L21`,
                         },
                         21,
                     ),
@@ -200,4 +202,109 @@ test("tabulate should generate a correct table", () => {
         ),
     );
     expect(tabulate(data, options)).toBe(html);
+});
+
+test("tabulate should generate file href for monorepo package", () => {
+    const data = [
+        {
+            file: "/files/project/src/foo.js",
+            lines: {
+                found: 23,
+                hit: 21,
+                details: [
+                    {
+                        line: 20,
+                        hit: 1,
+                    },
+                ],
+            },
+            functions: {
+                hit: 2,
+                found: 3,
+                details: [
+                    {
+                        name: "foo",
+                        line: 19,
+                    },
+                    {
+                        name: "bar",
+                        line: 33,
+                    },
+                    {
+                        name: "baz",
+                        line: 54,
+                    },
+                ],
+            },
+            branches: {
+                hit: 3,
+                found: 3,
+                details: [
+                    {
+                        line: 21,
+                        block: 0,
+                        branch: 0,
+                        taken: 1,
+                    },
+                    {
+                        line: 21,
+                        block: 0,
+                        branch: 1,
+                        taken: 2,
+                    },
+                    {
+                        line: 37,
+                        block: 1,
+                        branch: 0,
+                        taken: 0,
+                    },
+                ],
+            },
+        },
+    ];
+
+    const options = {
+        repository: "example/foo",
+        commit: "2e15bee6fe0df5003389aa5ec894ec0fea2d874a",
+        workspace: "/files/project/",
+        basePath: "packages",
+    };
+    const pkg1Path = `packages/pkg-1`;
+    const sha = options.commit.substring(0, 7);
+
+    const html = table(
+        tbody(
+            tr(
+                th("File"),
+                th("Branches"),
+                th("Funcs"),
+                th("Lines"),
+                th("Uncovered Lines"),
+            ),
+            tr(td({ colspan: 5 }, b("src"))),
+            tr(
+                td(
+                    "&nbsp; &nbsp;",
+                    a(
+                        {
+                            href: `/${options.repository}/blob/${sha}/${pkg1Path}/src/foo.js`,
+                        },
+                        "foo.js",
+                    ),
+                ),
+                td("100%"),
+                td(b("66.67%")),
+                td(b("91.30%")),
+                td(
+                    a(
+                        {
+                            href: `/${options.repository}/blob/${sha}/${pkg1Path}/src/foo.js#L37`,
+                        },
+                        37,
+                    ),
+                ),
+            ),
+        ),
+    );
+    expect(tabulate(data, { ...options, basePath: pkg1Path })).toBe(html);
 });


### PR DESCRIPTION
This PR does a couple things. Let me know if I should break it into two.

1. Fixes the GitHub file links by prepending the package path (eg adding `packages/my-library` to `{repo}/blob/{sha}/my-file.js`)
2. Reduces the PR comment size to get under the GitHub max of 65536; first by doing relative link URLs and second by removing the links and uncovered lines all-together if there are more than 600 uncovered lines.